### PR TITLE
Fix time display in General Statistics

### DIFF
--- a/src/wui/plot_area.cc
+++ b/src/wui/plot_area.cc
@@ -231,6 +231,11 @@ void draw_diagram(uint32_t time_ms,
 	// Make sure we haven't more ticks than we have space for -> avoid overlap
 	how_many_ticks = std::min(how_many_ticks, calc_plot_x_max_ticks(inner_w));
 
+	// Make sure how_many_ticks is a divisor of max_x
+	while (max_x % how_many_ticks != 0) {
+		how_many_ticks--;
+	}
+
 	// Draw coordinate system
 	// X Axis
 	dst.draw_line_strip({Vector2f(kSpacing, inner_h - kSpaceBottom),


### PR DESCRIPTION
Fixes #3457
This fixes the problem that the time on the X axis in the General Statistics window is shown incorrectly if the slider is set to "game" and the game length is between 32 and 34 hours, or between 36 and 38 hours.
The fix decreases how_many_ticks until it is a divisor of max_x, because the label drawing code assumes it is the case and doesn't work properly if it isn't.