### PR TITLE
revamp Travis-CI builds

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,50 +1,56 @@
 set -ex
 
-export START_TIME=$(date +%s)
-
 # Create build folder.
 mkdir build
 cd build
 
-if [ "$BUILD_TYPE" == "Debug" ]; then
-   # We test translations only on release builds, in order to help with job timeouts
-   cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="OFF" -DOPTION_ASAN="OFF"
+case "$1" in
+build)
+   export START_TIME=$(date +%s)
+   
+   if [ "$BUILD_TYPE" == "Debug" ]; then
+      cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="OFF" -DOPTION_ASAN="OFF"
+   else
+      # We test translations only on release builds, in order to help with job timeouts
+      cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_ASAN="OFF"
+   fi
+   # Do the actual build.
+   make -k -j3
+   
+   export STOP_TIME=$(date +%s)
+
+   # Run the regression suite only if compiling didn't take too long (to avoid timeouts).
+   # On macOS it always fails with a broken GL installation message, so we ommit it.
+   if [ "$TRAVIS_OS_NAME" = linux ]; then
+      if [ "$TRAVIS_COMPILER" = g++ ] && (( STOP_TIME - START_TIME >= 1980 )); then
+         echo "Not enough time left, to run the regression suit."
+      else
+         cd ..
+         ./regression_test.py -b build/src/widelands
+      fi
+   fi
+   ;;
+codecheck)
+   cmake .. -DCMAKE_BUILD_TYPE:STRING="Debug"
    # Run the codecheck test suite.
    pushd ../cmake/codecheck
    ./run_tests.py
    popd
-
-   # Any codecheck warning is an error in Debug builds. Keep the codebase clean!!
+   
+   # Any codecheck warning is an error. Keep the codebase clean!!
    # Suppress color output.
    TERM=dumb make -j1 codecheck 2>&1 | tee codecheck.out
    if grep '^[/_.a-zA-Z]\+:[0-9]\+:' codecheck.out; then
       echo "You have codecheck warnings (see above) Please fix."
       exit 1 # CodeCheck warnings.
    fi
-else
-   cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_ASAN="OFF"
-
-   # We test the documentation on release builds to make timeouts for debug builds less likely.
+   ;;
+documentation)
    # Any warning is an error.
    pushd ../doc/sphinx
    mkdir source/_static
    ./extract_rst.py
    sphinx-build -W -b json -d build/doctrees source build/json
    popd
-fi
-
-# Do the actual build.
-make -k -j3
-
-export STOP_TIME=$(date +%s)
-
-# Run the regression suite only if compiling didn't take too long (to avoid timeouts).
-# On macOS it always fails with a broken GL installation message, so we ommit it.
-if [ "$TRAVIS_OS_NAME" = linux ]; then
-   if [ "$TRAVIS_COMPILER" = g++ ] && (( STOP_TIME - START_TIME >= 1980 )); then
-      echo "Not enough time left, to run the regression suit."
-   else
-      cd ..
-      ./regression_test.py -b build/src/widelands
-   fi
-fi
+   ;;
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,78 +63,86 @@ language: cpp
 matrix:
   include:
     ### macOS BUILDS
-      # macOS 10.14 with Xcode 10.3
-    - os: osx
+    - name: "macOS 10.14 with Xcode 10.3"
+      os: osx
       osx_image: xcode10.3
       env: BUILD_TYPE="Debug"
-    - os: osx
+    - name: "macOS 10.14 with Xcode 10.3"
+      os: osx
       osx_image: xcode10.3
       env: BUILD_TYPE="Release"
-      # macOS 10.13 with Xcode 9.4
-    - os: osx
+    - name: "macOS 10.13 with Xcode 9.4"
+      os: osx
       osx_image: xcode9.4
       env: BUILD_TYPE="Debug"
-    - os: osx
+    - name: "macOS 10.13 with Xcode 9.4"
+      os: osx
       osx_image: xcode9.4
       env: BUILD_TYPE="Release"
-      # macOS 10.12 with XCode 8.3
-    - os: osx
+    - name: "macOS 10.12 with XCode 8.3"
+      os: osx
       osx_image: xcode8.3
       env: BUILD_TYPE="Debug"
-    - os: osx
+    - name: "macOS 10.12 with XCode 8.3"
+      os: osx
       osx_image: xcode8.3
       env: BUILD_TYPE="Release"
     ### Linux BUILDs
-      # Ubuntu 18.04 with clang 7
-    - os: linux
+    - name: "Ubuntu 18.04 with clang 7"
+      os: linux
       dist: bionic
       compiler: clang
       env: BUILD_TYPE="Debug"
       services: xvfb
       cache: false
-    - os: linux
+    - name: "Ubuntu 18.04 with clang 7"
+      os: linux
       dist: bionic
       compiler: clang
       env: BUILD_TYPE="Release"
       services: xvfb
       cache: false
-      # Ubuntu 18.04 with gcc 7.4
-    - os: linux
+    - name: "Ubuntu 18.04 with gcc 7.4"
+      os: linux
       dist: bionic
       env: BUILD_TYPE="Debug"
       services: xvfb
       cache: false
-    - os: linux
+    - name: "Ubuntu 18.04 with gcc 7.4"
+      os: linux
       dist: bionic
       env: BUILD_TYPE="Release"
       services: xvfb
-      # Ubuntu 16.04 with gcc 5.4
-    - os: linux
+    - name: "Ubuntu 16.04 with gcc 5.4"
+      os: linux
       dist: xenial
       env: BUILD_TYPE="Debug"
       services: xvfb
       cache: false
-    - os: linux
+    - name: "Ubuntu 16.04 with gcc 5.4"
+      os: linux
       dist: xenial
       env: BUILD_TYPE="Release"
       services: xvfb
-      # Ubuntu 14.04 with clang 3.4
-    - os: linux
+    - name: "Ubuntu 14.04 with clang 3.4"
+      os: linux
       dist: trusty
       compiler: clang
       env: BUILD_TYPE="Debug"
       cache: false
-    - os: linux
+    - name: "Ubuntu 14.04 with clang 3.4"
+      os: linux
       dist: trusty
       compiler: clang
       env: BUILD_TYPE="Release"
       cache: false
-      # Ubuntu 14.04 with gcc 4.8
-    - os: linux
+    - name: "Ubuntu 14.04 with gcc 4.8"
+      os: linux
       dist: trusty
       env: BUILD_TYPE="Debug"
       cache: false
-    - os: linux
+    - name: "Ubuntu 14.04 with gcc 4.8"
+      os: linux
       dist: trusty
       env: BUILD_TYPE="Release"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,13 @@ addons:
 
 before_script:
   - >
-    if [ "$BUILD_TYPE" == "Release" ]; then \
-      if [ "$TRAVIS_OS_NAME" = osx ]; then \
-        export PATH="$HOME/Library/Python/2.7/bin:$PATH"; \
-      else \
-        export PATH=$HOME/.local/bin:$PATH; \
-      fi && \
-      # install sphinx without sudo
-      pip2 install sphinx --user `whoami`;\
+    if [ "$TRAVIS_OS_NAME" = osx ]; then \
+      # brew doesn't add a link by default
+      brew link --force gettext && \
+      # icu4c cannot be forced
+      export ICU_ROOT="$(brew --prefix icu4c)" && \
+      # add ccache to the PATH variable
+      export PATH="/usr/local/opt/ccache/libexec:$PATH"; \
     fi
   - >
     if [ "$TRAVIS_DIST" == "trusty" ]; then \
@@ -43,27 +42,27 @@ before_script:
     fi
 
 branches:
-  only: master
+  only:
+    - master
+    - travis-with-caches
 
 cache: ccache
 
-install:
-  - >
-    if [ "$TRAVIS_OS_NAME" = osx ]; then \
-      # brew doesn't add a link by default
-      brew link --force gettext && \
-      # icu4c cannot be forced
-      export ICU_ROOT="$(brew --prefix icu4c)" && \
-      # add ccache to the PATH variable
-      export PATH="/usr/local/opt/ccache/libexec:$PATH"; \
-    fi
-
-language: cpp
-
-matrix:
+jobs:
   include:
-    ### macOS BUILDS
-    - name: "DEBUG: macOS 10.14 with Xcode 10.3"
+    - stage: tests
+      name: "Codecheck Suite"
+      script: ./.travis.sh codecheck
+      cache: false
+    - name: "Documentation Test"
+      language: python
+      cache: pip
+      install: pip install sphinx
+      script: ./.travis.sh documentation
+
+    - stage: compile
+      ### macOS BUILDS
+      name: "DEBUG: macOS 10.14 with Xcode 10.3"
       os: osx
       osx_image: xcode10.3
       env: BUILD_TYPE="Debug"
@@ -87,6 +86,7 @@ matrix:
       os: osx
       osx_image: xcode8.3
       env: BUILD_TYPE="Release"
+
     ### Linux BUILDs
     - name: "DEBUG: Ubuntu 18.04 with clang 7"
       os: linux
@@ -146,4 +146,10 @@ matrix:
       dist: trusty
       env: BUILD_TYPE="Release"
 
-script: ./.travis.sh
+language: cpp
+
+script: ./.travis.sh build
+
+stages:
+  - tests
+  - compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,6 @@
-language: cpp
-script: bash -e .travis.sh
-sudo: required
-dist: trusty
-
-before_script:
-  - export DISPLAY=:99.0
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi
-  - sleep 3 # give xvfb some time to start
-
-# Only build the master branch
-branches:
-  only:
-    - master
-
-# Let travis add additional repos and install packages for us (https://docs.travis-ci.com/user/migrating-from-legacy/#Adding-APT-Sources)
 addons:
   apt:
-    # The aliases used are based on a whitelist, see https://github.com/travis-ci/apt-source-whitelist for details.
-    # Clang 3.4 and 3.5 are too old (presumably) to have gotten official aliases
-    sources:
-      - ubuntu-toolchain-r-test
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.4 main"
-        key_url: "http://apt.llvm.org/llvm-snapshot.gpg.key"
-      - sourceline: "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.5 main"
-        key_url: "http://apt.llvm.org/llvm-snapshot.gpg.key"
-      - llvm-toolchain-trusty-7
-      - llvm-toolchain-trusty-8
     packages:
-      - cmake
       - libboost-dev
       - libboost-regex-dev
       - libboost-system-dev
@@ -42,61 +14,128 @@ addons:
       - libsdl2-ttf-dev
       - python-pip
       - zlib1g-dev
+  homebrew:
+    packages:
+      - ccache
+      - glew
+      - sdl2
+      - sdl2_image
+      - sdl2_mixer
+      - sdl2_ttf
+    update: true
+
+before_script:
+  - >
+    if [ "$BUILD_TYPE" == "Release" ]; then \
+      if [ "$TRAVIS_OS_NAME" = osx ]; then \
+        export PATH="$HOME/Library/Python/2.7/bin:$PATH"; \
+      else \
+        export PATH=$HOME/.local/bin:$PATH; \
+      fi && \
+      # install sphinx without sudo
+      pip2 install sphinx --user `whoami`;\
+    fi
+  - >
+    if [ "$TRAVIS_DIST" == "trusty" ]; then \
+      export DISPLAY=:99.0 && \
+      sh -e /etc/init.d/xvfb start && \
+      sleep 3; \
+    fi
+
+branches:
+  only: master
+
+cache: ccache
+
+install:
+  - >
+    if [ "$TRAVIS_OS_NAME" = osx ]; then \
+      # brew doesn't add a link by default
+      brew link --force gettext && \
+      # icu4c cannot be forced
+      export ICU_ROOT="$(brew --prefix icu4c)" && \
+      # add ccache to the PATH variable
+      export PATH="/usr/local/opt/ccache/libexec:$PATH"; \
+    fi
+
+language: cpp
 
 matrix:
   include:
-    ### MAC OSX BUILDS
+    ### macOS BUILDS
+      # macOS 10.14 with Xcode 10.3
     - os: osx
+      osx_image: xcode10.3
       env: BUILD_TYPE="Debug"
     - os: osx
+      osx_image: xcode10.3
       env: BUILD_TYPE="Release"
-    ### LINUX + CLANG BUILDS
+      # macOS 10.13 with Xcode 9.4
+    - os: osx
+      osx_image: xcode9.4
+      env: BUILD_TYPE="Debug"
+    - os: osx
+      osx_image: xcode9.4
+      env: BUILD_TYPE="Release"
+      # macOS 10.12 with XCode 8.3
+    - os: osx
+      osx_image: xcode8.3
+      env: BUILD_TYPE="Debug"
+    - os: osx
+      osx_image: xcode8.3
+      env: BUILD_TYPE="Release"
+    ### Linux BUILDs
+      # Ubuntu 18.04 with clang 7
     - os: linux
+      dist: bionic
       compiler: clang
-      env: CLANG_VERSION="3.4" BUILD_TYPE="Debug"
+      env: BUILD_TYPE="Debug"
+      services: xvfb
+      cache: false
     - os: linux
+      dist: bionic
       compiler: clang
-      env: CLANG_VERSION="3.5" BUILD_TYPE="Debug"
+      env: BUILD_TYPE="Release"
+      services: xvfb
+      cache: false
+      # Ubuntu 18.04 with gcc 7.4
     - os: linux
+      dist: bionic
+      env: BUILD_TYPE="Debug"
+      services: xvfb
+      cache: false
+    - os: linux
+      dist: bionic
+      env: BUILD_TYPE="Release"
+      services: xvfb
+      # Ubuntu 16.04 with gcc 5.4
+    - os: linux
+      dist: xenial
+      env: BUILD_TYPE="Debug"
+      services: xvfb
+      cache: false
+    - os: linux
+      dist: xenial
+      env: BUILD_TYPE="Release"
+      services: xvfb
+      # Ubuntu 14.04 with clang 3.4
+    - os: linux
+      dist: trusty
       compiler: clang
-      env: CLANG_VERSION="7" BUILD_TYPE="Debug"
+      env: BUILD_TYPE="Debug"
+      cache: false
     - os: linux
+      dist: trusty
       compiler: clang
-      env: CLANG_VERSION="8" BUILD_TYPE="Debug"
+      env: BUILD_TYPE="Release"
+      cache: false
+      # Ubuntu 14.04 with gcc 4.8
     - os: linux
-      compiler: clang
-      env: CLANG_VERSION="3.4" BUILD_TYPE="Release"
+      dist: trusty
+      env: BUILD_TYPE="Debug"
+      cache: false
     - os: linux
-      compiler: clang
-      env: CLANG_VERSION="3.5" BUILD_TYPE="Release"
-    - os: linux
-      compiler: clang
-      env: CLANG_VERSION="7" BUILD_TYPE="Release"
-    - os: linux
-      compiler: clang
-      env: CLANG_VERSION="8" BUILD_TYPE="Release"
-    ### LINUX + GCC BUILDS
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="4.8" BUILD_TYPE="Debug"
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="4.9" BUILD_TYPE="Debug"
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="7" BUILD_TYPE="Debug"
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="8" BUILD_TYPE="Debug"
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="4.8" BUILD_TYPE="Release"
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="4.9" BUILD_TYPE="Release"
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="7" BUILD_TYPE="Release"
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION="8" BUILD_TYPE="Release"
+      dist: trusty
+      env: BUILD_TYPE="Release"
+
+script: ./.travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,85 +63,85 @@ language: cpp
 matrix:
   include:
     ### macOS BUILDS
-    - name: "macOS 10.14 with Xcode 10.3"
+    - name: "DEBUG: macOS 10.14 with Xcode 10.3"
       os: osx
       osx_image: xcode10.3
       env: BUILD_TYPE="Debug"
-    - name: "macOS 10.14 with Xcode 10.3"
+    - name: "RELEASE: macOS 10.14 with Xcode 10.3"
       os: osx
       osx_image: xcode10.3
       env: BUILD_TYPE="Release"
-    - name: "macOS 10.13 with Xcode 9.4"
+    - name: "DEBUG: macOS 10.13 with Xcode 9.4"
       os: osx
       osx_image: xcode9.4
       env: BUILD_TYPE="Debug"
-    - name: "macOS 10.13 with Xcode 9.4"
+    - name: "RELEASE: macOS 10.13 with Xcode 9.4"
       os: osx
       osx_image: xcode9.4
       env: BUILD_TYPE="Release"
-    - name: "macOS 10.12 with XCode 8.3"
+    - name: "DEBUG: macOS 10.12 with XCode 8.3"
       os: osx
       osx_image: xcode8.3
       env: BUILD_TYPE="Debug"
-    - name: "macOS 10.12 with XCode 8.3"
+    - name: "RELEASE: macOS 10.12 with XCode 8.3"
       os: osx
       osx_image: xcode8.3
       env: BUILD_TYPE="Release"
     ### Linux BUILDs
-    - name: "Ubuntu 18.04 with clang 7"
+    - name: "DEBUG: Ubuntu 18.04 with clang 7"
       os: linux
       dist: bionic
       compiler: clang
       env: BUILD_TYPE="Debug"
       services: xvfb
       cache: false
-    - name: "Ubuntu 18.04 with clang 7"
+    - name: "RELEASE: Ubuntu 18.04 with clang 7"
       os: linux
       dist: bionic
       compiler: clang
       env: BUILD_TYPE="Release"
       services: xvfb
       cache: false
-    - name: "Ubuntu 18.04 with gcc 7.4"
+    - name: "DEBUG: Ubuntu 18.04 with gcc 7.4"
       os: linux
       dist: bionic
       env: BUILD_TYPE="Debug"
       services: xvfb
       cache: false
-    - name: "Ubuntu 18.04 with gcc 7.4"
+    - name: "RELEASE: Ubuntu 18.04 with gcc 7.4"
       os: linux
       dist: bionic
       env: BUILD_TYPE="Release"
       services: xvfb
-    - name: "Ubuntu 16.04 with gcc 5.4"
+    - name: "DEBUG: Ubuntu 16.04 with gcc 5.4"
       os: linux
       dist: xenial
       env: BUILD_TYPE="Debug"
       services: xvfb
       cache: false
-    - name: "Ubuntu 16.04 with gcc 5.4"
+    - name: "RELEASE: Ubuntu 16.04 with gcc 5.4"
       os: linux
       dist: xenial
       env: BUILD_TYPE="Release"
       services: xvfb
-    - name: "Ubuntu 14.04 with clang 3.4"
+    - name: "DEBUG: Ubuntu 14.04 with clang 3.4"
       os: linux
       dist: trusty
       compiler: clang
       env: BUILD_TYPE="Debug"
       cache: false
-    - name: "Ubuntu 14.04 with clang 3.4"
+    - name: "RELEASE: Ubuntu 14.04 with clang 3.4"
       os: linux
       dist: trusty
       compiler: clang
       env: BUILD_TYPE="Release"
       cache: false
-    - name: "Ubuntu 14.04 with gcc 4.8"
+    - name: "DEBUG: Ubuntu 14.04 with gcc 4.8"
       os: linux
       dist: trusty
       env: BUILD_TYPE="Debug"
       cache: false
-    - name: "Ubuntu 14.04 with gcc 4.8"
+    - name: "RELEASE: Ubuntu 14.04 with gcc 4.8"
       os: linux
       dist: trusty
       env: BUILD_TYPE="Release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ before_script:
 branches:
   only:
     - master
-    - travis-with-caches
 
 cache: ccache
 


### PR DESCRIPTION
Travis-CI builds are completely rewritten and don't require sudo anymore.

macOS: We build on 10.14(clang 7), 10.13(clang 5) & 10.12(clang3.9)
Linux: We build on 18.04 (clang 7 & gcc 7.4), 16.04 (gcc 5.4) & 14.04 (clang 3.4 & gcc 4.8)

On macOS all builds use ccache on Linux only the gcc Release builds. Since clang compiles
faster it is not as big of a problem and jobs are within the travis time-limit.

Regression suite is run on Linux jobs only if the compile-time didn't exceed 33 mins, to
avoid hitting the time-limit of 50 mins while executing the tests. This mainly affects
gcc debug builds.

For xvfb we utilize the new service stanza - only available on 18.04 and 16.04, though.
For 14.04 we use the old fashion way.

Only pushes to master and PR trigger builds.