### PR TITLE
Make use of stages

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,50 +1,57 @@
+#!/bin/sh
 set -ex
-
-export START_TIME=$(date +%s)
 
 # Create build folder.
 mkdir build
 cd build
 
-if [ "$BUILD_TYPE" == "Debug" ]; then
-   # We test translations only on release builds, in order to help with job timeouts
-   cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="OFF" -DOPTION_ASAN="OFF"
+case "$1" in
+build)
+   export START_TIME=$(date +%s)
+   
+   if [ "$BUILD_TYPE" == "Debug" ]; then
+      cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="OFF" -DOPTION_ASAN="OFF"
+   else
+      # We test translations only on release builds, in order to help with job timeouts
+      cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_ASAN="OFF"
+   fi
+   # Do the actual build.
+   make -k -j3
+   
+   export STOP_TIME=$(date +%s)
+
+   # Run the regression suite only if compiling didn't take too long (to avoid timeouts).
+   # On macOS it always fails with a broken GL installation message, so we ommit it.
+   if [ "$TRAVIS_OS_NAME" = linux ]; then
+      if [ "$TRAVIS_COMPILER" = g++ ] && (( STOP_TIME - START_TIME >= 1980 )); then
+         echo "Not enough time left, to run the regression suit."
+      else
+         cd ..
+         ./regression_test.py -b build/src/widelands
+      fi
+   fi
+   ;;
+codecheck)
+   cmake .. -DCMAKE_BUILD_TYPE:STRING="Debug"
    # Run the codecheck test suite.
    pushd ../cmake/codecheck
    ./run_tests.py
    popd
-
-   # Any codecheck warning is an error in Debug builds. Keep the codebase clean!!
+   
+   # Any codecheck warning is an error. Keep the codebase clean!!
    # Suppress color output.
    TERM=dumb make -j1 codecheck 2>&1 | tee codecheck.out
    if grep '^[/_.a-zA-Z]\+:[0-9]\+:' codecheck.out; then
       echo "You have codecheck warnings (see above) Please fix."
       exit 1 # CodeCheck warnings.
    fi
-else
-   cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_ASAN="OFF"
-
-   # We test the documentation on release builds to make timeouts for debug builds less likely.
+   ;;
+documentation)
    # Any warning is an error.
    pushd ../doc/sphinx
    mkdir source/_static
    ./extract_rst.py
    sphinx-build -W -b json -d build/doctrees source build/json
    popd
-fi
-
-# Do the actual build.
-make -k -j3
-
-export STOP_TIME=$(date +%s)
-
-# Run the regression suite only if compiling didn't take too long (to avoid timeouts).
-# On macOS it always fails with a broken GL installation message, so we ommit it.
-if [ "$TRAVIS_OS_NAME" = linux ]; then
-   if [ "$TRAVIS_COMPILER" = g++ ] && (( STOP_TIME - START_TIME >= 1980 )); then
-      echo "Not enough time left, to run the regression suit."
-   else
-      cd ..
-      ./regression_test.py -b build/src/widelands
-   fi
-fi
+   ;;
+esac

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 set -ex
 
 # Create build folder.

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ branches:
     - master
     - travis-with-caches
 
+cache: ccache
+
 install:
   - >
     if [ "$TRAVIS_OS_NAME" = osx ]; then \
@@ -51,18 +53,45 @@ install:
 jobs:
   include:
     - stage: tests
-      name: "Codecheck Suite"
+    - name: "Codecheck Suite"
       script: ./.travis.sh codecheck
-      language: cpp
-    - script: ./.travis.sh documentation
-      name: "Documentation Test"
+      cache: false
+    - name: "Documentation Test"
       language: python
       cache: pip
       install: pip install sphinx
-#    - stage: compile
+      script: ./.travis.sh documentation
+    - stage: compile
+      ### macOS BUILDS
+    - name: "DEBUG: macOS 10.14 with Xcode 10.3"
+      os: osx
+      osx_image: xcode10.3
+      env: BUILD_TYPE="Debug"
+    - name: "RELEASE: macOS 10.14 with Xcode 10.3"
+      os: osx
+      osx_image: xcode10.3
+      env: BUILD_TYPE="Release"
+    - name: "DEBUG: macOS 10.13 with Xcode 9.4"
+      os: osx
+      osx_image: xcode9.4
+      env: BUILD_TYPE="Debug"
+    - name: "RELEASE: macOS 10.13 with Xcode 9.4"
+      os: osx
+      osx_image: xcode9.4
+      env: BUILD_TYPE="Release"
+    - name: "DEBUG: macOS 10.12 with XCode 8.3"
+      os: osx
+      osx_image: xcode8.3
+      env: BUILD_TYPE="Debug"
+    - name: "RELEASE: macOS 10.12 with XCode 8.3"
+      os: osx
+      osx_image: xcode8.3
+      env: BUILD_TYPE="Release"
+
+language: cpp
 
 script: ./.travis.sh build
 
 stages:
   - tests
-#  - compile
+  - compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,15 @@ addons:
 
 before_script:
   - >
+    if [ "$TRAVIS_OS_NAME" = osx ]; then \
+      # brew doesn't add a link by default
+      brew link --force gettext && \
+      # icu4c cannot be forced
+      export ICU_ROOT="$(brew --prefix icu4c)" && \
+      # add ccache to the PATH variable
+      export PATH="/usr/local/opt/ccache/libexec:$PATH"; \
+    fi
+  - >
     if [ "$TRAVIS_DIST" == "trusty" ]; then \
       export DISPLAY=:99.0 && \
       sh -e /etc/init.d/xvfb start && \
@@ -39,21 +48,10 @@ branches:
 
 cache: ccache
 
-install:
-  - >
-    if [ "$TRAVIS_OS_NAME" = osx ]; then \
-      # brew doesn't add a link by default
-      brew link --force gettext && \
-      # icu4c cannot be forced
-      export ICU_ROOT="$(brew --prefix icu4c)" && \
-      # add ccache to the PATH variable
-      export PATH="/usr/local/opt/ccache/libexec:$PATH"; \
-    fi
-
 jobs:
   include:
     - stage: tests
-    - name: "Codecheck Suite"
+      name: "Codecheck Suite"
       script: ./.travis.sh codecheck
       cache: false
     - name: "Documentation Test"
@@ -61,9 +59,10 @@ jobs:
       cache: pip
       install: pip install sphinx
       script: ./.travis.sh documentation
+
     - stage: compile
       ### macOS BUILDS
-    - name: "DEBUG: macOS 10.14 with Xcode 10.3"
+      name: "DEBUG: macOS 10.14 with Xcode 10.3"
       os: osx
       osx_image: xcode10.3
       env: BUILD_TYPE="Debug"
@@ -86,6 +85,65 @@ jobs:
     - name: "RELEASE: macOS 10.12 with XCode 8.3"
       os: osx
       osx_image: xcode8.3
+      env: BUILD_TYPE="Release"
+
+    ### Linux BUILDs
+    - name: "DEBUG: Ubuntu 18.04 with clang 7"
+      os: linux
+      dist: bionic
+      compiler: clang
+      env: BUILD_TYPE="Debug"
+      services: xvfb
+      cache: false
+    - name: "RELEASE: Ubuntu 18.04 with clang 7"
+      os: linux
+      dist: bionic
+      compiler: clang
+      env: BUILD_TYPE="Release"
+      services: xvfb
+      cache: false
+    - name: "DEBUG: Ubuntu 18.04 with gcc 7.4"
+      os: linux
+      dist: bionic
+      env: BUILD_TYPE="Debug"
+      services: xvfb
+      cache: false
+    - name: "RELEASE: Ubuntu 18.04 with gcc 7.4"
+      os: linux
+      dist: bionic
+      env: BUILD_TYPE="Release"
+      services: xvfb
+    - name: "DEBUG: Ubuntu 16.04 with gcc 5.4"
+      os: linux
+      dist: xenial
+      env: BUILD_TYPE="Debug"
+      services: xvfb
+      cache: false
+    - name: "RELEASE: Ubuntu 16.04 with gcc 5.4"
+      os: linux
+      dist: xenial
+      env: BUILD_TYPE="Release"
+      services: xvfb
+    - name: "DEBUG: Ubuntu 14.04 with clang 3.4"
+      os: linux
+      dist: trusty
+      compiler: clang
+      env: BUILD_TYPE="Debug"
+      cache: false
+    - name: "RELEASE: Ubuntu 14.04 with clang 3.4"
+      os: linux
+      dist: trusty
+      compiler: clang
+      env: BUILD_TYPE="Release"
+      cache: false
+    - name: "DEBUG: Ubuntu 14.04 with gcc 4.8"
+      os: linux
+      dist: trusty
+      env: BUILD_TYPE="Debug"
+      cache: false
+    - name: "RELEASE: Ubuntu 14.04 with gcc 4.8"
+      os: linux
+      dist: trusty
       env: BUILD_TYPE="Release"
 
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,6 @@ addons:
 
 before_script:
   - >
-    if [ "$BUILD_TYPE" == "Release" ]; then \
-      if [ "$TRAVIS_OS_NAME" = osx ]; then \
-        export PATH="$HOME/Library/Python/2.7/bin:$PATH"; \
-      else \
-        export PATH=$HOME/.local/bin:$PATH; \
-      fi && \
-      # install sphinx without sudo
-      pip2 install sphinx --user `whoami`;\
-    fi
-  - >
     if [ "$TRAVIS_DIST" == "trusty" ]; then \
       export DISPLAY=:99.0 && \
       sh -e /etc/init.d/xvfb start && \
@@ -43,9 +33,9 @@ before_script:
     fi
 
 branches:
-  only: master
-
-cache: ccache
+  only:
+    - master
+    - travis-with-caches
 
 install:
   - >
@@ -58,92 +48,17 @@ install:
       export PATH="/usr/local/opt/ccache/libexec:$PATH"; \
     fi
 
-language: cpp
-
-matrix:
+jobs:
   include:
-    ### macOS BUILDS
-    - name: "DEBUG: macOS 10.14 with Xcode 10.3"
-      os: osx
-      osx_image: xcode10.3
-      env: BUILD_TYPE="Debug"
-    - name: "RELEASE: macOS 10.14 with Xcode 10.3"
-      os: osx
-      osx_image: xcode10.3
-      env: BUILD_TYPE="Release"
-    - name: "DEBUG: macOS 10.13 with Xcode 9.4"
-      os: osx
-      osx_image: xcode9.4
-      env: BUILD_TYPE="Debug"
-    - name: "RELEASE: macOS 10.13 with Xcode 9.4"
-      os: osx
-      osx_image: xcode9.4
-      env: BUILD_TYPE="Release"
-    - name: "DEBUG: macOS 10.12 with XCode 8.3"
-      os: osx
-      osx_image: xcode8.3
-      env: BUILD_TYPE="Debug"
-    - name: "RELEASE: macOS 10.12 with XCode 8.3"
-      os: osx
-      osx_image: xcode8.3
-      env: BUILD_TYPE="Release"
-    ### Linux BUILDs
-    - name: "DEBUG: Ubuntu 18.04 with clang 7"
-      os: linux
-      dist: bionic
-      compiler: clang
-      env: BUILD_TYPE="Debug"
-      services: xvfb
-      cache: false
-    - name: "RELEASE: Ubuntu 18.04 with clang 7"
-      os: linux
-      dist: bionic
-      compiler: clang
-      env: BUILD_TYPE="Release"
-      services: xvfb
-      cache: false
-    - name: "DEBUG: Ubuntu 18.04 with gcc 7.4"
-      os: linux
-      dist: bionic
-      env: BUILD_TYPE="Debug"
-      services: xvfb
-      cache: false
-    - name: "RELEASE: Ubuntu 18.04 with gcc 7.4"
-      os: linux
-      dist: bionic
-      env: BUILD_TYPE="Release"
-      services: xvfb
-    - name: "DEBUG: Ubuntu 16.04 with gcc 5.4"
-      os: linux
-      dist: xenial
-      env: BUILD_TYPE="Debug"
-      services: xvfb
-      cache: false
-    - name: "RELEASE: Ubuntu 16.04 with gcc 5.4"
-      os: linux
-      dist: xenial
-      env: BUILD_TYPE="Release"
-      services: xvfb
-    - name: "DEBUG: Ubuntu 14.04 with clang 3.4"
-      os: linux
-      dist: trusty
-      compiler: clang
-      env: BUILD_TYPE="Debug"
-      cache: false
-    - name: "RELEASE: Ubuntu 14.04 with clang 3.4"
-      os: linux
-      dist: trusty
-      compiler: clang
-      env: BUILD_TYPE="Release"
-      cache: false
-    - name: "DEBUG: Ubuntu 14.04 with gcc 4.8"
-      os: linux
-      dist: trusty
-      env: BUILD_TYPE="Debug"
-      cache: false
-    - name: "RELEASE: Ubuntu 14.04 with gcc 4.8"
-      os: linux
-      dist: trusty
-      env: BUILD_TYPE="Release"
+    - stage: tests
+      name: "Codecheck Suite"
+      script: ./.travis.sh codecheck
+    - script: ./.travis.sh documentation
+      name: "Documentation Test"
+      language: python
+      install: pip install sphinx
+      
 
-script: ./.travis.sh
+#stages:
+#  - tests
+#  - compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,10 @@ jobs:
       language: python
       cache: pip
       install: pip install sphinx
+#    - stage: compile
 
-#stages:
-#  - tests
+script: ./.travis.sh build
+
+stages:
+  - tests
 #  - compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,12 @@ jobs:
     - stage: tests
       name: "Codecheck Suite"
       script: ./.travis.sh codecheck
+      language: cpp
     - script: ./.travis.sh documentation
       name: "Documentation Test"
       language: python
+      cache: pip
       install: pip install sphinx
-      
 
 #stages:
 #  - tests


### PR DESCRIPTION
We use builds stages now. First we run a code check and test the documentation. If nothing fails we the can go on and start compiling. This saves roughly 2 minutes on the debug builds which should help us with timeouts. Furthermore, we don't waste time when the code isn't clean.