### PR TITLE
Add 3rd test and translation switch

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -32,12 +32,6 @@ codecheck)
       exit 1 # CodeCheck warnings.
    fi
    ;;
-compiler)
-   # Just run this to test whether there are any error during compiling.
-   # If this job fails we don't need to run on the compile stage.
-   cmake .. -DCMAKE_BUILD_TYPE:STRING="Release" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_BUILD_WEBSITE_TOOLS="ON" -DOPTION_ASAN="OFF"
-   make -k -j3
-   ;;
 documentation)
    # Any warning is an error.
    pushd ../doc/sphinx

--- a/.travis.sh
+++ b/.travis.sh
@@ -6,13 +6,7 @@ cd build
 
 case "$1" in
 build)
-   if [ "$BUILD_TYPE" == "Debug" ]; then
-      # We skip translations and codecheck to speed things up
-      cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="OFF" -DOPTION_ASAN="OFF" -DOPTION_BUILD_WEBSITE_TOOLS=$BUILD_WEBSITE_TOOLS -DOPTION_BUILD_CODECHECK="OFF"
-   else
-      # We test translations only on release builds, in order to help with job timeouts
-      cmake .. -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_ASAN="OFF" -DOPTION_BUILD_WEBSITE_TOOLS=$BUILD_WEBSITE_TOOLS
-   fi
+   cmake .. -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DOPTION_BUILD_TRANSLATIONS=$BUILD_TRANSLATIONS -DOPTION_BUILD_WEBSITE_TOOLS=$BUILD_WEBSITE_TOOLS -DOPTION_ASAN="OFF" -DOPTION_BUILD_CODECHECK="OFF"
    # Do the actual build.
    make -k -j3
 
@@ -37,6 +31,12 @@ codecheck)
       echo "You have codecheck warnings (see above) Please fix."
       exit 1 # CodeCheck warnings.
    fi
+   ;;
+compiler)
+   # Just run this to test whether there are any error during compiling.
+   # If this job fails we don't need to run on the compile stage.
+   cmake .. -DCMAKE_BUILD_TYPE:STRING="Release" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_BUILD_WEBSITE_TOOLS="ON" -DOPTION_ASAN="OFF"
+   make -k -j3
    ;;
 documentation)
    # Any warning is an error.

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ jobs:
       name: "Codecheck Suite"
       script: ./.travis.sh codecheck
       cache: false
+    - name: "Compiler Errors"
+      script: ./.travis.sh compiler
     - name: "Documentation Test"
       language: python
       cache: pip
@@ -64,86 +66,86 @@ jobs:
       name: "DEBUG: macOS 10.14 with Xcode 10.3"
       os: osx
       osx_image: xcode10.3
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="ON"
     - name: "RELEASE: macOS 10.14 with Xcode 10.3"
       os: osx
       osx_image: xcode10.3
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
     - name: "DEBUG: macOS 10.13 with Xcode 9.4"
       os: osx
       osx_image: xcode9.4
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="ON"
     - name: "RELEASE: macOS 10.13 with Xcode 9.4"
       os: osx
       osx_image: xcode9.4
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
     - name: "DEBUG: macOS 10.12 with XCode 8.3"
       os: osx
       osx_image: xcode8.3
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="ON"
     - name: "RELEASE: macOS 10.12 with XCode 8.3"
       os: osx
       osx_image: xcode8.3
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
 
     ### Linux BUILDs
     - name: "DEBUG: Ubuntu 18.04 with clang 7"
       os: linux
       dist: bionic
       compiler: clang
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="ON"
       services: xvfb
       cache: false
     - name: "RELEASE: Ubuntu 18.04 with clang 7"
       os: linux
       dist: bionic
       compiler: clang
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
       services: xvfb
       cache: false
     - name: "DEBUG: Ubuntu 18.04 with gcc 7.4"
       os: linux
       dist: bionic
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="OFF"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="OFF"
       services: xvfb
       cache: false
     - name: "RELEASE: Ubuntu 18.04 with gcc 7.4"
       os: linux
       dist: bionic
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
       services: xvfb
     - name: "DEBUG: Ubuntu 16.04 with gcc 5.4"
       os: linux
       dist: xenial
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="OFF"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="OFF"
       services: xvfb
       cache: false
     - name: "RELEASE: Ubuntu 16.04 with gcc 5.4"
       os: linux
       dist: xenial
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
       services: xvfb
     - name: "DEBUG: Ubuntu 14.04 with clang 3.4"
       os: linux
       dist: trusty
       compiler: clang
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="ON"
       cache: false
     - name: "RELEASE: Ubuntu 14.04 with clang 3.4"
       os: linux
       dist: trusty
       compiler: clang
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
       cache: false
     - name: "DEBUG: Ubuntu 14.04 with gcc 4.8"
       os: linux
       dist: trusty
-      env: BUILD_TYPE="Debug" BUILD_WEBSITE_TOOLS="OFF"
+      env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="OFF"
       cache: false
     - name: "RELEASE: Ubuntu 14.04 with gcc 4.8"
       os: linux
       dist: trusty
-      env: BUILD_TYPE="Release" BUILD_WEBSITE_TOOLS="ON"
+      env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,16 +53,15 @@ jobs:
       name: "Codecheck Suite"
       script: ./.travis.sh codecheck
       cache: false
-    - name: "Compiler Errors"
-      script: ./.travis.sh compiler
     - name: "Documentation Test"
       language: python
       cache: pip
       install: pip install sphinx
       script: ./.travis.sh documentation
 
-    - stage: compile
-      ### macOS BUILDS
+    - stage: compiler
+      # Run this stage to test whether there are any error during compiling.
+      # We use the macOS builds since they run the fastest.
       name: "DEBUG: macOS 10.14 with Xcode 10.3"
       os: osx
       osx_image: xcode10.3
@@ -71,7 +70,10 @@ jobs:
       os: osx
       osx_image: xcode10.3
       env: BUILD_TYPE="Release" BUILD_TRANSLATIONS="ON" BUILD_WEBSITE_TOOLS="ON"
-    - name: "DEBUG: macOS 10.13 with Xcode 9.4"
+
+    - stage: build
+      ### macOS BUILDS
+      name: "DEBUG: macOS 10.13 with Xcode 9.4"
       os: osx
       osx_image: xcode9.4
       env: BUILD_TYPE="Debug" BUILD_TRANSLATIONS="OFF" BUILD_WEBSITE_TOOLS="ON"
@@ -153,4 +155,5 @@ script: ./.travis.sh build
 
 stages:
   - tests
-  - compile
+  - compiler
+  - build


### PR DESCRIPTION
The the Compiler Errors test should avoid situations were the code would not compile with any compiler like it was in this case [were verything failed.](https://travis-ci.org/widelands/widelands/builds/585738263)

Also a translation switch has been added so translations can be en-/disabled on a per job basis.