### PR TITLE
Change OS X builds to produce identifiable nightlies.

### DIFF
--- a/utils/macos/build_app.sh
+++ b/utils/macos/build_app.sh
@@ -77,13 +77,15 @@ if [ ! -d "$SDK_DIRECTORY" ]; then
    fi
 fi
 
-REVISION=`bzr revno $SOURCE_DIR`
+pushd $SOURCE_DIR
+REVISION="r$(git rev-list --count HEAD)_$(git rev-parse --short HEAD)"
+popd
 DESTINATION="WidelandsRelease"
 
 if [[ -f $SOURCE_DIR/WL_RELEASE ]]; then
    WLVERSION="$(cat $SOURCE_DIR/WL_RELEASE)"
 else
-   WLVERSION="r$REVISION"
+   WLVERSION="$REVISION"
 fi
 
 echo ""


### PR DESCRIPTION
With bzr, we produced nightly names of the form `widelands_10.9_r9197.dmg`, this change now produces nigthlies of the form `widelands_10.9_r24228_9549eef25b.dmg`, with the revision being the number of commits in the branch (the same number that GitHub displays) as well as the SHA of the commit that is actually being build.

Related to #3469.