### PR TITLE
Handle error while reading the shading language

### DIFF
--- a/src/graphic/gl/initialize.cc
+++ b/src/graphic/gl/initialize.cc
@@ -207,6 +207,29 @@ SDL_GLContext initialize(
 		exit(1);
 	};
 
+	// Exit because we couldn't detect the shading language version, so there must be a problem
+	// communicating with the graphics adapter.
+	auto handle_unreadable_opengl_shading_language = [show_opengl_error_and_exit]() {
+		show_opengl_error_and_exit(
+		   "Widelands won't work because we were unable to detect the shading language version.\n"
+		   "There is an unknown problem with reading the information from the graphics driver.",
+		   (boost::format("%s\n%s") %
+		    /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
+		       support is limited here, so do not use advanced typography **/
+		    _("Widelands won't work because we were unable to detect the shading language "
+		      "version.") %
+		    /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
+		       support is limited here, so do not use advanced typography **/
+		    _("There is an unknown problem with reading the information from the graphics "
+		      "driver."))
+		      .str());
+	};
+
+	// glGetString returned an error for the shading language
+	if (glGetString(GL_SHADING_LANGUAGE_VERSION) == 0) {
+		handle_unreadable_opengl_shading_language();
+	}
+
 	std::vector<std::string> shading_language_version_vector;
 	boost::split(
 	   shading_language_version_vector, shading_language_version_string, boost::is_any_of("."));
@@ -251,21 +274,8 @@ SDL_GLContext initialize(
 				      .str());
 			}
 		} else {
-			// Exit because we couldn't detect the shading language version, so there must be a problem
-			// communicating with the graphics adapter.
-			show_opengl_error_and_exit(
-			   "Widelands won't work because we were unable to detect the shading language version.\n"
-			   "There is an unknown problem with reading the information from the graphics driver.",
-			   (boost::format("%s\n%s") %
-			    /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
-			       support is limited here, so do not use advanced typography **/
-			    _("Widelands won't work because we were unable to detect the shading language "
-			      "version.") %
-			    /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
-			       support is limited here, so do not use advanced typography **/
-			    _("There is an unknown problem with reading the information from the graphics "
-			      "driver."))
-			      .str());
+			// We don't know how to interpret the shading language info
+			handle_unreadable_opengl_shading_language();
 		}
 	}
 


### PR DESCRIPTION
Show error message box rather than crashing when reading the shading language version returns an error.

My Windows VM doesn't have a decent graphics driver, so it crashed with no shading language detectable.

This is the output produced by this branch:

![no-shading-language-error-message](https://user-images.githubusercontent.com/4095570/65820382-fdb6f400-e21f-11e9-8984-59651a886462.png)
