### PR TITLE
Explicitely set text mode for Popen 

### DIFF
--- a/utils/detect_revision.py
+++ b/utils/detect_revision.py
@@ -46,21 +46,21 @@ def detect_git_revision():
         cmd = subprocess.Popen(
             ['git', 'rev-list', '--count', 'HEAD'],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, cwd=base_path
+            stderr=subprocess.PIPE, cwd=base_path, text=True
         )
         stdout, stderr = cmd.communicate()
         git_count = stdout.rstrip()
         cmd = subprocess.Popen(
             ['git', 'rev-parse', '--short=7', 'HEAD'],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, cwd=base_path
+            stderr=subprocess.PIPE, cwd=base_path, text=True
         )
         stdout, stderr = cmd.communicate()
         git_revnum = stdout.rstrip()
         cmd = subprocess.Popen(
             ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, cwd=base_path
+            stderr=subprocess.PIPE, cwd=base_path, text=True
         )
         stdout, stderr = cmd.communicate()
         git_abbrev = stdout.rstrip()


### PR DESCRIPTION
to avoid ugly binary strings on windows, e.g. rb'24260'[b'f1fa8f3'@b'master'](Release)