### PR TITLE
Fix detect_revision.py to work with a wide variety of python versions

### DIFF
--- a/utils/detect_revision.py
+++ b/utils/detect_revision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Tries to find out the repository revision of the current working directory

--- a/utils/detect_revision.py
+++ b/utils/detect_revision.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Tries to find out the repository revision of the current working directory
@@ -22,6 +22,13 @@ except ImportError:
 
 base_path = p.abspath(p.join(p.dirname(__file__), p.pardir))
 
+def _communicate_utf8(cmd, **kwargs):
+    """Runs the 'cmd' with 'kwargs' and returns its output which is assumed to be utf-8."""
+    if sys.version_info >= (3, 0):
+        output = subprocess.check_output(cmd, **kwargs)
+        return output.decode("utf-8")
+    return subprocess.check_output(cmd, **kwargs)
+
 
 def detect_debian_version():
     """Parse bzr revision and branch information from debian/changelog."""
@@ -43,26 +50,11 @@ def detect_debian_version():
 
 def detect_git_revision():
     try:
-        cmd = subprocess.Popen(
-            ['git', 'rev-list', '--count', 'HEAD'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, cwd=base_path, text=True
-        )
-        stdout, stderr = cmd.communicate()
+        stdout = _communicate_utf8(['git', 'rev-list', '--count', 'HEAD'], cwd=base_path)
         git_count = stdout.rstrip()
-        cmd = subprocess.Popen(
-            ['git', 'rev-parse', '--short=7', 'HEAD'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, cwd=base_path, text=True
-        )
-        stdout, stderr = cmd.communicate()
+        stdout = _communicate_utf8(['git', 'rev-parse', '--short=7', 'HEAD'], cwd=base_path)
         git_revnum = stdout.rstrip()
-        cmd = subprocess.Popen(
-            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, cwd=base_path, text=True
-        )
-        stdout, stderr = cmd.communicate()
+        stdout = _communicate_utf8(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=base_path)
         git_abbrev = stdout.rstrip()
         if git_count and git_revnum and git_abbrev:
             return 'r%s[%s@%s]' % (git_count, git_revnum, git_abbrev)
@@ -94,9 +86,8 @@ def detect_bzr_revision():
         # Windows stand alone installer do not come with bzrlib. We try to
         # parse the output of bzr then directly
         try:
-            def run_bzr(subcmd): return subprocess.Popen(
-                ['bzr', subcmd], stdout=subprocess.PIPE, cwd=base_path
-            ).stdout.read().strip().decode('utf-8')
+            def run_bzr(subcmd):
+                return _communicate_utf8(['bzr', subcmd], cwd=base_path).strip()
             revno = run_bzr('revno')
             nick = run_bzr('nick')
             return 'bzr%s[%s]' % (revno, nick)

--- a/utils/detect_revision.py
+++ b/utils/detect_revision.py
@@ -22,11 +22,13 @@ except ImportError:
 
 base_path = p.abspath(p.join(p.dirname(__file__), p.pardir))
 
+
 def _communicate_utf8(cmd, **kwargs):
-    """Runs the 'cmd' with 'kwargs' and returns its output which is assumed to be utf-8."""
+    """Runs the 'cmd' with 'kwargs' and returns its output which is assumed to
+    be utf-8."""
     if sys.version_info >= (3, 0):
         output = subprocess.check_output(cmd, **kwargs)
-        return output.decode("utf-8")
+        return output.decode('utf-8')
     return subprocess.check_output(cmd, **kwargs)
 
 
@@ -50,11 +52,14 @@ def detect_debian_version():
 
 def detect_git_revision():
     try:
-        stdout = _communicate_utf8(['git', 'rev-list', '--count', 'HEAD'], cwd=base_path)
+        stdout = _communicate_utf8(
+            ['git', 'rev-list', '--count', 'HEAD'], cwd=base_path)
         git_count = stdout.rstrip()
-        stdout = _communicate_utf8(['git', 'rev-parse', '--short=7', 'HEAD'], cwd=base_path)
+        stdout = _communicate_utf8(
+            ['git', 'rev-parse', '--short=7', 'HEAD'], cwd=base_path)
         git_revnum = stdout.rstrip()
-        stdout = _communicate_utf8(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=base_path)
+        stdout = _communicate_utf8(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=base_path)
         git_abbrev = stdout.rstrip()
         if git_count and git_revnum and git_abbrev:
             return 'r%s[%s@%s]' % (git_count, git_revnum, git_abbrev)


### PR DESCRIPTION
#3551 changed the detect_revision.py script to use features which were added in python 3.7. This broke the nightly Mac OS builds, since the newest python3 for Mac OS 10.7 is 3.2. This PR changes the script to do the right thing for all py2 and py3 versions.

Fixes #3553.