### PR TITLE
Separate Armor Smithy from Weapon Smithy

### DIFF
--- a/po/tribes/nn.po
+++ b/po/tribes/nn.po
@@ -525,7 +525,7 @@ msgstr "Demonter stad"
 #: ../../data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua:94
 msgctxt "atlanteans_building"
 msgid "Armor Smithy"
-msgstr "Våpensmie"
+msgstr "Rustningsmie"
 
 #. TRANSLATORS: Completed/Skipped/Did not start working because ...
 #: ../../data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua:143


### PR DESCRIPTION
Armor Smithy was wrongly translated as Våpensmie. Våpensmie means Weapon Smithy. This made the two buildings hard to distinguish.