### PR TITLE
minimap overhaul

### DIFF
--- a/src/graphic/minimap_renderer.cc
+++ b/src/graphic/minimap_renderer.cc
@@ -266,7 +266,11 @@ int scale_map(const Widelands::Map& map) {
 	const uint16_t map_h = map.get_height();
 	if (!(map_w > 300)) {
 		int longest_axis = (map_w >= map_h ? map_w : map_h);
-		return (300 - (300 % longest_axis)) / longest_axis;
+		if (longest_axis <= 150) {
+			return (300 - (300 % longest_axis)) / longest_axis;
+		} else {
+			return (600 - (600 % longest_axis)) / longest_axis;
+		}
 	}
 	return 1;
 }

--- a/src/graphic/minimap_renderer.cc
+++ b/src/graphic/minimap_renderer.cc
@@ -273,7 +273,7 @@ int scale_map(const Widelands::Map& map, const bool zoom) {
 			return (600 - (600 % longest_axis)) / longest_axis;
 		} else if (longest_axis > 150) {
 			return (400 - (400 % longest_axis)) / longest_axis;
-		} else if (longest_axis < 300) {
+		} else {
 			return (300 - (300 % longest_axis)) / longest_axis;
 		}
 	}

--- a/src/graphic/minimap_renderer.cc
+++ b/src/graphic/minimap_renderer.cc
@@ -90,7 +90,7 @@ void draw_view_window(const Map& map,
                       const MiniMapType minimap_type,
                       const bool zoom,
                       Texture* texture) {
-	const float divider = zoom ? scale_map(map, false) : scale_map(map, true);
+	const float divider = scale_map(map, !zoom);
 	const int half_width =
 	   round_up_to_nearest_even(std::ceil(view_area.w / kTriangleWidth / divider));
 	const int half_height =
@@ -105,16 +105,14 @@ void draw_view_window(const Map& map,
 	case MiniMapType::kStaticMap: {
 		Vector2f origin = view_area.center();
 		MapviewPixelFunctions::normalize_pix(map, &origin);
-		center_pixel = Vector2i(origin.x / kTriangleWidth, origin.y / kTriangleHeight) *
-		               (zoom ? scale_map(map, true) : scale_map(map, false));
+		center_pixel =
+		   Vector2i(origin.x / kTriangleWidth, origin.y / kTriangleHeight) * scale_map(map, zoom);
 		break;
 	}
 	}
 
-	const int width =
-	   zoom ? map.get_width() * scale_map(map, true) : map.get_width() * scale_map(map, false);
-	const int height =
-	   zoom ? map.get_height() * scale_map(map, true) : map.get_height() * scale_map(map, false);
+	const int width = map.get_width() * scale_map(map, zoom);
+	const int height = map.get_height() * scale_map(map, zoom);
 	const auto make_red = [width, height, &texture](int x, int y) {
 		if (x < 0) {
 			x += width;
@@ -218,7 +216,7 @@ Vector2f minimap_pixel_to_mappixel(const Widelands::Map& map,
 		break;
 	}
 
-	const float multiplier = zoom ? scale_map(map, true) : scale_map(map, false);
+	const float multiplier = scale_map(map, zoom);
 	Vector2f map_pixel = top_left + Vector2f(minimap_pixel.x / multiplier * kTriangleWidth,
 	                                         minimap_pixel.y / multiplier * kTriangleHeight);
 	MapviewPixelFunctions::normalize_pix(map, &map_pixel);
@@ -263,8 +261,8 @@ std::unique_ptr<Texture> draw_minimap(const EditorGameBase& egbase,
 }
 
 int scale_map(const Widelands::Map& map, const bool zoom) {
-	// If a map is wider than 300px we don't scale. Otherwise we fit as much as possible into a 300px
-	// or 400px MiniMap window when zoom is disabled. Zoom fits the map into a 600px MiniMap.
+	// The MiniMap can have a maximum size of 600px. If a map is wider than 300px we don't scale.
+	// Otherwise we fit as much as possible into a 300px/400px MiniMap window when zoom is disabled.
 	const uint16_t map_w = map.get_width();
 	if (!(map_w > 300)) {
 		if (zoom) {

--- a/src/graphic/minimap_renderer.cc
+++ b/src/graphic/minimap_renderer.cc
@@ -266,15 +266,13 @@ int scale_map(const Widelands::Map& map, const bool zoom) {
 	// If a map is wider than 300px we don't scale. Otherwise we fit as much as possible into a 300px
 	// or 400px MiniMap window when zoom is disabled. Zoom fits the map into a 600px MiniMap.
 	const uint16_t map_w = map.get_width();
-	const uint16_t map_h = map.get_height();
 	if (!(map_w > 300)) {
-		int longest_axis = (map_w >= map_h ? map_w : map_h);
 		if (zoom) {
-			return (600 - (600 % longest_axis)) / longest_axis;
-		} else if (longest_axis > 150) {
-			return (400 - (400 % longest_axis)) / longest_axis;
+			return (600 - (600 % map_w)) / map_w;
+		} else if (map_w > 150) {
+			return (400 - (400 % map_w)) / map_w;
 		} else {
-			return (300 - (300 % longest_axis)) / longest_axis;
+			return (300 - (300 % map_w)) / map_w;
 		}
 	}
 	return 1;

--- a/src/graphic/minimap_renderer.cc
+++ b/src/graphic/minimap_renderer.cc
@@ -90,11 +90,11 @@ void draw_view_window(const Map& map,
                       const MiniMapType minimap_type,
                       const bool zoom,
                       Texture* texture) {
-	const float divider = scale_map(map, !zoom);
+	const float multiplier = scale_map(map, zoom);
 	const int half_width =
-	   round_up_to_nearest_even(std::ceil(view_area.w / kTriangleWidth / divider));
+	   round_up_to_nearest_even(std::ceil(view_area.w / kTriangleWidth * multiplier / 2.f));
 	const int half_height =
-	   round_up_to_nearest_even(std::ceil(view_area.h / kTriangleHeight / divider));
+	   round_up_to_nearest_even(std::ceil(view_area.h / kTriangleHeight * multiplier / 2.f));
 
 	Vector2i center_pixel = Vector2i::zero();
 	switch (minimap_type) {
@@ -260,7 +260,7 @@ std::unique_ptr<Texture> draw_minimap(const EditorGameBase& egbase,
 	return texture;
 }
 
-int scale_map(const Widelands::Map& map, const bool zoom) {
+int scale_map(const Widelands::Map& map, bool zoom) {
 	// The MiniMap can have a maximum size of 600px. If a map is wider than 300px we don't scale.
 	// Otherwise we fit as much as possible into a 300px/400px MiniMap window when zoom is disabled.
 	const uint16_t map_w = map.get_width();

--- a/src/graphic/minimap_renderer.h
+++ b/src/graphic/minimap_renderer.h
@@ -79,6 +79,6 @@ std::unique_ptr<Texture> draw_minimap(const Widelands::EditorGameBase& egbase,
                                       MiniMapLayer layers);
 
 // Find an even multiplier to fit the map into 300px
-int scale_map(const Widelands::Map& map);
+int scale_map(const Widelands::Map& map, const bool zoom);
 
 #endif  // end of include guard: WL_GRAPHIC_MINIMAP_RENDERER_H

--- a/src/graphic/minimap_renderer.h
+++ b/src/graphic/minimap_renderer.h
@@ -79,6 +79,6 @@ std::unique_ptr<Texture> draw_minimap(const Widelands::EditorGameBase& egbase,
                                       MiniMapLayer layers);
 
 // Find an even multiplier to fit the map into 300px
-int scale_map(const Widelands::Map& map, const bool zoom);
+int scale_map(const Widelands::Map& map, bool zoom);
 
 #endif  // end of include guard: WL_GRAPHIC_MINIMAP_RENDERER_H

--- a/src/graphic/minimap_renderer.h
+++ b/src/graphic/minimap_renderer.h
@@ -78,4 +78,7 @@ std::unique_ptr<Texture> draw_minimap(const Widelands::EditorGameBase& egbase,
                                       const MiniMapType& map_draw_type,
                                       MiniMapLayer layers);
 
+// Find an even multiplier to fit the map into 300px
+int scale_map(const Widelands::Map& map);
+
 #endif  // end of include guard: WL_GRAPHIC_MINIMAP_RENDERER_H

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -227,6 +227,7 @@ InteractiveBase::InteractiveBase(EditorGameBase& the_egbase, Section& global_s)
 		   map_view_.set_size(message.width, message.height);
 		   resize_chat_overlay();
 		   finalize_toolbar();
+		   mainview_move();
 	   });
 	sound_subscriber_ = Notifications::subscribe<NoteSound>(
 	   [this](const NoteSound& note) { play_sound_effect(note); });

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -219,7 +219,7 @@ void MiniMap::resize() {
 	button_bldns.set_size(but_w(), but_h());
 	button_zoom.set_pos(Vector2i(but_w() * 5, view_.get_h()));
 	button_zoom.set_size(but_w(), but_h());
-	if ((view_.get_w() > 300 || view_.get_h() > 300) &&
+	if ((view_.get_w() > 300 || view_.get_h() > 300 || (get_h() <= 620 && view_.get_h() >= 290)) &&
 	    !(*view_.minimap_layers_ & MiniMapLayer::Zoom2)) {
 		button_zoom.set_enabled(false);
 	}

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -205,6 +205,8 @@ MiniMap::MiniMap(InteractiveBase& ibase, Registry* const registry)
 
 	graphic_resolution_changed_subscriber_ = Notifications::subscribe<GraphicResolutionChanged>(
 	   [this](const GraphicResolutionChanged&) { check_boundaries(); });
+
+	update_button_permpressed();
 }
 
 void MiniMap::toggle(MiniMapLayer const button) {

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -198,9 +198,7 @@ MiniMap::MiniMap(InteractiveBase& ibase, Registry* const registry)
 	button_zoom.sigclicked.connect(
 	   boost::bind(&MiniMap::toggle, boost::ref(*this), MiniMapLayer::Zoom2));
 
-	resize();
-
-	update_button_permpressed();
+	check_boundaries();
 
 	if (get_usedefaultpos())
 		center_to_parent();

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -230,7 +230,6 @@ void MiniMap::resize() {
 		button_zoom.set_enabled(false);
 	}
 	move_inside_parent();
-	center_to_parent();
 }
 
 void MiniMap::update_button_permpressed() {

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -70,9 +70,9 @@ bool MiniMap::View::handle_mousepress(const uint8_t btn, int32_t x, int32_t y) {
 	return true;
 }
 
-void MiniMap::View::set_zoom(int32_t z) {
+void MiniMap::View::set_zoom(const bool zoom) {
 	const Widelands::Map& map = ibase_.egbase().map();
-	set_size(map.get_width() * z * scale_map(map), map.get_height() * z * scale_map(map));
+	set_size(map.get_width() * scale_map(map, zoom), map.get_height() * scale_map(map, zoom));
 }
 
 /*
@@ -205,7 +205,7 @@ void MiniMap::toggle(MiniMapLayer const button) {
 }
 
 void MiniMap::resize() {
-	view_.set_zoom((*view_.minimap_layers_ & MiniMapLayer::Zoom2) ? 2 : 1);
+	view_.set_zoom((*view_.minimap_layers_ & MiniMapLayer::Zoom2) ? true : false);
 	set_inner_size(view_.get_w(), view_.get_h() + number_of_button_rows() * but_h());
 	button_terrn.set_pos(Vector2i(but_w() * 0, view_.get_h()));
 	button_terrn.set_size(but_w(), but_h());

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -75,6 +75,13 @@ void MiniMap::View::set_zoom(const bool zoom) {
 	set_size(map.get_width() * scale_map(map, zoom), map.get_height() * scale_map(map, zoom));
 }
 
+bool MiniMap::View::can_zoom() {
+	const Widelands::Map& map = ibase_.egbase().map();
+	if (scale_map(map, true) == 1 || map.get_height() * scale_map(map, true) > ibase_.get_h() - 40) {
+		return false;
+	}
+	return true;
+}
 /*
 ==============================================================================
 
@@ -219,8 +226,7 @@ void MiniMap::resize() {
 	button_bldns.set_size(but_w(), but_h());
 	button_zoom.set_pos(Vector2i(but_w() * 5, view_.get_h()));
 	button_zoom.set_size(but_w(), but_h());
-	if ((view_.get_w() > 300 || view_.get_h() > 300 || (get_h() <= 620 && view_.get_h() >= 290)) &&
-	    !(*view_.minimap_layers_ & MiniMapLayer::Zoom2)) {
+	if (!view_.can_zoom() && !(*view_.minimap_layers_ & MiniMapLayer::Zoom2)) {
 		button_zoom.set_enabled(false);
 	}
 	move_inside_parent();

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -72,7 +72,7 @@ bool MiniMap::View::handle_mousepress(const uint8_t btn, int32_t x, int32_t y) {
 
 void MiniMap::View::set_zoom(int32_t z) {
 	const Widelands::Map& map = ibase_.egbase().map();
-	set_size((map.get_width() * z), (map.get_height()) * z);
+	set_size(map.get_width() * z * scale_map(map), map.get_height() * z * scale_map(map));
 }
 
 /*
@@ -95,10 +95,10 @@ destructor
 ===============
 */
 inline uint32_t MiniMap::number_of_buttons_per_row() const {
-	return 3;
+	return 6;
 }
 inline uint32_t MiniMap::number_of_button_rows() const {
-	return 2;
+	return 1;
 }
 inline uint32_t MiniMap::but_w() const {
 	return view_.get_w() / number_of_buttons_per_row();
@@ -207,19 +207,24 @@ void MiniMap::toggle(MiniMapLayer const button) {
 void MiniMap::resize() {
 	view_.set_zoom((*view_.minimap_layers_ & MiniMapLayer::Zoom2) ? 2 : 1);
 	set_inner_size(view_.get_w(), view_.get_h() + number_of_button_rows() * but_h());
-	button_terrn.set_pos(Vector2i(but_w() * 0, view_.get_h() + but_h() * 0));
+	button_terrn.set_pos(Vector2i(but_w() * 0, view_.get_h()));
 	button_terrn.set_size(but_w(), but_h());
-	button_owner.set_pos(Vector2i(but_w() * 1, view_.get_h() + but_h() * 0));
+	button_owner.set_pos(Vector2i(but_w() * 1, view_.get_h()));
 	button_owner.set_size(but_w(), but_h());
-	button_flags.set_pos(Vector2i(but_w() * 2, view_.get_h() + but_h() * 0));
+	button_flags.set_pos(Vector2i(but_w() * 2, view_.get_h()));
 	button_flags.set_size(but_w(), but_h());
-	button_roads.set_pos(Vector2i(but_w() * 0, view_.get_h() + but_h() * 1));
+	button_roads.set_pos(Vector2i(but_w() * 3, view_.get_h()));
 	button_roads.set_size(but_w(), but_h());
-	button_bldns.set_pos(Vector2i(but_w() * 1, view_.get_h() + but_h() * 1));
+	button_bldns.set_pos(Vector2i(but_w() * 4, view_.get_h()));
 	button_bldns.set_size(but_w(), but_h());
-	button_zoom.set_pos(Vector2i(but_w() * 2, view_.get_h() + but_h() * 1));
+	button_zoom.set_pos(Vector2i(but_w() * 5, view_.get_h()));
 	button_zoom.set_size(but_w(), but_h());
+	if ((view_.get_w() > 300 || view_.get_h() > 300) &&
+	    !(*view_.minimap_layers_ & MiniMapLayer::Zoom2)) {
+		button_zoom.set_enabled(false);
+	}
 	move_inside_parent();
+	center_to_parent();
 }
 
 void MiniMap::update_button_permpressed() {

--- a/src/wui/minimap.cc
+++ b/src/wui/minimap.cc
@@ -212,7 +212,7 @@ void MiniMap::toggle(MiniMapLayer const button) {
 }
 
 void MiniMap::resize() {
-	view_.set_zoom((*view_.minimap_layers_ & MiniMapLayer::Zoom2) ? true : false);
+	view_.set_zoom(*view_.minimap_layers_ & MiniMapLayer::Zoom2);
 	set_inner_size(view_.get_w(), view_.get_h() + number_of_button_rows() * but_h());
 	button_terrn.set_pos(Vector2i(but_w() * 0, view_.get_h()));
 	button_terrn.set_size(but_w(), but_h());

--- a/src/wui/minimap.h
+++ b/src/wui/minimap.h
@@ -77,7 +77,7 @@ private:
 
 		bool handle_mousepress(uint8_t btn, int32_t x, int32_t y) override;
 
-		void set_zoom(const bool zoom);
+		void set_zoom(bool zoom);
 
 		bool can_zoom();
 

--- a/src/wui/minimap.h
+++ b/src/wui/minimap.h
@@ -52,9 +52,13 @@ public:
 	}
 
 private:
+	std::unique_ptr<Notifications::Subscriber<GraphicResolutionChanged>>
+	   graphic_resolution_changed_subscriber_;
+
 	void toggle(MiniMapLayer);
 	void update_button_permpressed();
 	void resize();
+	void check_boundaries();
 
 	/**
 	 * MiniMap::View is the panel that represents the pure representation of the

--- a/src/wui/minimap.h
+++ b/src/wui/minimap.h
@@ -77,7 +77,7 @@ private:
 
 		bool handle_mousepress(uint8_t btn, int32_t x, int32_t y) override;
 
-		void set_zoom(int32_t z);
+		void set_zoom(const bool zoom);
 
 	private:
 		InteractiveBase& ibase_;

--- a/src/wui/minimap.h
+++ b/src/wui/minimap.h
@@ -79,6 +79,8 @@ private:
 
 		void set_zoom(const bool zoom);
 
+		bool can_zoom();
+
 	private:
 		InteractiveBase& ibase_;
 		Rectf view_area_;


### PR DESCRIPTION
* buttons for the minimap are in one row
* minimap zoom2 limited to 600px
* minimap tries to scale up to 300px/400px in normal mode
* when map has a width of more than 300, zoom is disabled
* disable zoom if the minimap height gets greater than the game's
* check size when switching into window mode

fixes #528