### PR TITLE
Reduce default target quantity of planks for empire from 40 to 20.

### DIFF
--- a/data/tribes/wares/planks/init.lua
+++ b/data/tribes/wares/planks/init.lua
@@ -9,7 +9,7 @@ tribes:new_ware_type {
    icon = dirname .. "menu.png",
    default_target_quantity = {
       atlanteans = 40,
-      empire = 40
+      empire = 20
    },
    preciousness = {
       atlanteans = 10,


### PR DESCRIPTION
Closes #3161 