### PR TITLE
Refactor loader_ui

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -16,8 +16,8 @@ build)
        cd ..
        ./regression_test.py -b build/src/widelands
        mkdir temp_web
-       ./wl_map_object_info temp_web
-       ./wl_map_info data/maps/Archipelago_Sea.wmf
+       build/src/widelands/wl_map_object_info temp_web
+       build/src/widelands/wl_map_info data/maps/Archipelago_Sea.wmf
    fi
    ;;
 codecheck)

--- a/.travis.sh
+++ b/.travis.sh
@@ -40,4 +40,14 @@ documentation)
    sphinx-build -W -b json -d build/doctrees source build/json
    popd
    ;;
+website)
+   # Ensure that the website tools won't crash.
+   if [ "$TRAVIS_OS_NAME" = linux ]; then
+       cd ..
+       mkdir temp_web
+       ./wl_create_spritesheet barbarians_carrier idle temp_web
+       ./wl_map_object_info temp_web
+       ./wl_map_info data/maps/Archipelago_Sea.wmf
+   fi
+   ;;
 esac

--- a/.travis.sh
+++ b/.travis.sh
@@ -17,6 +17,9 @@ build)
       ./regression_test.py -b build/src/widelands
       if [ "$BUILD_WEBSITE_TOOLS" = ON ]; then
          mkdir temp_web
+         # NOCOM where are the web binaries?
+         ls -la build/src
+         ls -la
          build/src/wl_map_object_info temp_web
          build/src/wl_map_info data/maps/Archipelago_Sea.wmf
       fi

--- a/.travis.sh
+++ b/.travis.sh
@@ -17,11 +17,8 @@ build)
       ./regression_test.py -b build/src/widelands
       if [ "$BUILD_WEBSITE_TOOLS" = ON ]; then
          mkdir temp_web
-         # NOCOM where are the web binaries?
-         ls -la build/src
-         ls -la
-         build/src/wl_map_object_info temp_web
-         build/src/wl_map_info data/maps/Archipelago_Sea.wmf
+         build/src/website/wl_map_object_info temp_web
+         build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf
       fi
    fi
    ;;

--- a/.travis.sh
+++ b/.travis.sh
@@ -15,6 +15,9 @@ build)
    if [ "$TRAVIS_OS_NAME" = linux ]; then
        cd ..
        ./regression_test.py -b build/src/widelands
+       mkdir temp_web
+       ./wl_map_object_info temp_web
+       ./wl_map_info data/maps/Archipelago_Sea.wmf
    fi
    ;;
 codecheck)
@@ -39,14 +42,5 @@ documentation)
    ./extract_rst.py
    sphinx-build -W -b json -d build/doctrees source build/json
    popd
-   ;;
-website)
-   # Ensure that the website tools won't crash.
-   if [ "$TRAVIS_OS_NAME" = linux ]; then
-       cd ..
-       mkdir temp_web
-       ./wl_map_object_info temp_web
-       ./wl_map_info data/maps/Archipelago_Sea.wmf
-   fi
    ;;
 esac

--- a/.travis.sh
+++ b/.travis.sh
@@ -45,7 +45,6 @@ website)
    if [ "$TRAVIS_OS_NAME" = linux ]; then
        cd ..
        mkdir temp_web
-       ./wl_create_spritesheet barbarians_carrier idle temp_web
        ./wl_map_object_info temp_web
        ./wl_map_info data/maps/Archipelago_Sea.wmf
    fi

--- a/.travis.sh
+++ b/.travis.sh
@@ -17,8 +17,8 @@ build)
       ./regression_test.py -b build/src/widelands
       if [ "$BUILD_WEBSITE_TOOLS" = ON ]; then
          mkdir temp_web
-         ./build/src/widelands/wl_map_object_info temp_web
-         ./build/src/widelands/wl_map_info data/maps/Archipelago_Sea.wmf
+         build/src/wl_map_object_info temp_web
+         build/src/wl_map_info data/maps/Archipelago_Sea.wmf
       fi
    fi
    ;;

--- a/.travis.sh
+++ b/.travis.sh
@@ -13,11 +13,13 @@ build)
    # Run the regression suite only if compiling didn't take too long (to avoid timeouts).
    # On macOS it always fails with a broken GL installation message, so we ommit it.
    if [ "$TRAVIS_OS_NAME" = linux ]; then
-       cd ..
-       ./regression_test.py -b build/src/widelands
-       mkdir temp_web
-       build/src/widelands/wl_map_object_info temp_web
-       build/src/widelands/wl_map_info data/maps/Archipelago_Sea.wmf
+      cd ..
+      ./regression_test.py -b build/src/widelands
+      if [ "$BUILD_WEBSITE_TOOLS" = ON ]; then
+         mkdir temp_web
+         ./build/src/widelands/wl_map_object_info temp_web
+         ./build/src/widelands/wl_map_info data/maps/Archipelago_Sea.wmf
+      fi
    fi
    ;;
 codecheck)

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -76,7 +76,7 @@ using Widelands::Building;
 
 // Load all tribes from disk.
 void load_all_tribes(Widelands::EditorGameBase* egbase) {
-    assert(egbase->has_loader_ui());
+	assert(egbase->has_loader_ui());
 	egbase->step_loader_ui(_("Loading tribes"));
 	egbase->tribes();
 }
@@ -443,7 +443,7 @@ void EditorInteractive::showhide_menu_selected(ShowHideEntry entry) {
 
 void EditorInteractive::load(const std::string& filename) {
 	assert(filename.size());
-    assert(egbase().has_loader_ui());
+	assert(egbase().has_loader_ui());
 
 	Widelands::Map* map = egbase().mutable_map();
 
@@ -473,7 +473,7 @@ void EditorInteractive::load(const std::string& filename) {
 	egbase().postload();
 	egbase().load_graphics();
 	map_changed(MapWas::kReplaced);
-    egbase().remove_loader_ui();
+	egbase().remove_loader_ui();
 }
 
 void EditorInteractive::cleanup_for_load() {
@@ -921,7 +921,7 @@ void EditorInteractive::run_editor(const std::string& filename, const std::strin
 		}
 	}
 
-    egbase.remove_loader_ui();
+	egbase.remove_loader_ui();
 	eia.run<UI::Panel::Returncodes>();
 
 	egbase.cleanup_objects();

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -473,7 +473,6 @@ void EditorInteractive::load(const std::string& filename) {
 	egbase().postload();
 	egbase().load_graphics();
 	map_changed(MapWas::kReplaced);
-	egbase().remove_loader_ui();
 }
 
 void EditorInteractive::cleanup_for_load() {

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -69,7 +69,6 @@
 #include "ui_basic/messagebox.h"
 #include "ui_basic/progresswindow.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 #include "wui/interactive_base.h"
 
 namespace {

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -76,6 +76,7 @@ using Widelands::Building;
 
 // Load all tribes from disk.
 void load_all_tribes(Widelands::EditorGameBase* egbase) {
+    assert(egbase->has_loader_ui());
 	egbase->step_loader_ui(_("Loading tribes"));
 	egbase->tribes();
 }
@@ -442,6 +443,7 @@ void EditorInteractive::showhide_menu_selected(ShowHideEntry entry) {
 
 void EditorInteractive::load(const std::string& filename) {
 	assert(filename.size());
+    assert(egbase().has_loader_ui());
 
 	Widelands::Map* map = egbase().mutable_map();
 

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -886,7 +886,7 @@ void EditorInteractive::run_editor(const std::string& filename, const std::strin
 	EditorInteractive& eia = *new EditorInteractive(egbase);
 	egbase.set_ibase(&eia);  // TODO(unknown): get rid of this
 	{
-        egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+		egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 
 		{
 			if (filename.empty()) {

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -473,6 +473,7 @@ void EditorInteractive::load(const std::string& filename) {
 	egbase().postload();
 	egbase().load_graphics();
 	map_changed(MapWas::kReplaced);
+    egbase().remove_loader_ui();
 }
 
 void EditorInteractive::cleanup_for_load() {
@@ -919,6 +920,8 @@ void EditorInteractive::run_editor(const std::string& filename, const std::strin
 			eia.egbase().lua().run_script(script_to_run);
 		}
 	}
+
+    egbase.remove_loader_ui();
 	eia.run<UI::Panel::Returncodes>();
 
 	egbase.cleanup_objects();

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -888,7 +888,7 @@ void EditorInteractive::run_editor(const std::string& filename, const std::strin
 	EditorInteractive& eia = *new EditorInteractive(egbase);
 	egbase.set_ibase(&eia);  // TODO(unknown): get rid of this
 	{
-		egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+		egbase.create_loader_ui({"editor"}, true, "images/loadscreens/editor.jpg");
 
 		{
 			if (filename.empty()) {

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -77,8 +77,7 @@ using Widelands::Building;
 
 // Load all tribes from disk.
 void load_all_tribes(Widelands::EditorGameBase* egbase) {
-	assert(egbase->get_loader_ui());
-	egbase->get_loader_ui()->step(_("Loading tribes"));
+	egbase->step_loader_ui(_("Loading tribes"));
 	egbase->tribes();
 }
 
@@ -457,20 +456,11 @@ void EditorInteractive::load(const std::string& filename) {
 		   filename.c_str());
 	ml->preload_map(true);
 
-	UI::ProgressWindow* loader_ui = egbase().get_loader_ui();
-	// We already have a loader window if Widelands was started with --editor=mapname
-	const bool create_loader_ui = !loader_ui;
-	if (create_loader_ui) {
-		loader_ui = new UI::ProgressWindow("images/loadscreens/editor.jpg");
-		GameTips editortips(*loader_ui, {"editor"});
-		egbase().set_loader_ui(loader_ui);
-	}
-
 	load_all_tribes(&egbase());
 
 	// Create the players. TODO(SirVer): this must be managed better
 	// TODO(GunChleoc): Ugly - we only need this for the test suite right now
-	loader_ui->step(_("Creating players"));
+	egbase().step_loader_ui(_("Creating players"));
 	iterate_player_numbers(p, map->get_nrplayers()) {
 		if (!map->get_scenario_player_tribe(p).empty()) {
 			egbase().add_player(
@@ -482,11 +472,6 @@ void EditorInteractive::load(const std::string& filename) {
 	egbase().postload();
 	egbase().load_graphics();
 	map_changed(MapWas::kReplaced);
-	if (create_loader_ui) {
-		// We created it, so we have to unset and delete it
-		egbase().set_loader_ui(nullptr);
-		delete loader_ui;
-	}
 }
 
 void EditorInteractive::cleanup_for_load() {
@@ -902,13 +887,11 @@ void EditorInteractive::run_editor(const std::string& filename, const std::strin
 	EditorInteractive& eia = *new EditorInteractive(egbase);
 	egbase.set_ibase(&eia);  // TODO(unknown): get rid of this
 	{
-		UI::ProgressWindow loader_ui("images/loadscreens/editor.jpg");
-		GameTips editortips(loader_ui, {"editor"});
-		egbase.set_loader_ui(&loader_ui);
+        egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 
 		{
 			if (filename.empty()) {
-				loader_ui.step(_("Creating empty map…"));
+				egbase.step_loader_ui(_("Creating empty map…"));
 				egbase.mutable_map()->create_empty_map(
 				   egbase, 64, 64, 0,
 				   /** TRANSLATORS: Default name for new map */
@@ -920,15 +903,14 @@ void EditorInteractive::run_editor(const std::string& filename, const std::strin
 				load_all_tribes(&egbase);
 
 				egbase.load_graphics();
-				loader_ui.step(std::string());
+				egbase.step_loader_ui(std::string());
 			} else {
-				loader_ui.step((boost::format(_("Loading map “%s”…")) % filename).str());
+				egbase.step_loader_ui((boost::format(_("Loading map “%s”…")) % filename).str());
 				eia.load(filename);
 			}
 		}
 
 		egbase.postload();
-		egbase.set_loader_ui(nullptr);
 
 		eia.start();
 

--- a/src/editor/ui_menus/main_menu_load_map.cc
+++ b/src/editor/ui_menus/main_menu_load_map.cc
@@ -53,7 +53,7 @@ void MainMenuLoadMap::clicked_ok() {
 		fill_table();
 	} else {
 		EditorInteractive& eia = dynamic_cast<EditorInteractive&>(*get_parent());
-        eia.egbase().create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+		eia.egbase().create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 		eia.load(mapdata.filename);
 		// load() will delete us.
 	}

--- a/src/editor/ui_menus/main_menu_load_map.cc
+++ b/src/editor/ui_menus/main_menu_load_map.cc
@@ -56,6 +56,7 @@ void MainMenuLoadMap::clicked_ok() {
 		eia.egbase().create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 		eia.load(mapdata.filename);
 		// load() will delete us.
+		eia.egbase().remove_loader_ui();
 	}
 }
 

--- a/src/editor/ui_menus/main_menu_load_map.cc
+++ b/src/editor/ui_menus/main_menu_load_map.cc
@@ -53,7 +53,7 @@ void MainMenuLoadMap::clicked_ok() {
 		fill_table();
 	} else {
 		EditorInteractive& eia = dynamic_cast<EditorInteractive&>(*get_parent());
-		eia.egbase().create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+		eia.egbase().create_loader_ui({"editor"}, true, "images/loadscreens/editor.jpg");
 		eia.load(mapdata.filename);
 		// load() will delete us.
 		eia.egbase().remove_loader_ui();

--- a/src/editor/ui_menus/main_menu_load_map.cc
+++ b/src/editor/ui_menus/main_menu_load_map.cc
@@ -53,6 +53,7 @@ void MainMenuLoadMap::clicked_ok() {
 		fill_table();
 	} else {
 		EditorInteractive& eia = dynamic_cast<EditorInteractive&>(*get_parent());
+        eia.egbase().create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 		eia.load(mapdata.filename);
 		// load() will delete us.
 	}

--- a/src/editor/ui_menus/main_menu_new_map.cc
+++ b/src/editor/ui_menus/main_menu_new_map.cc
@@ -114,7 +114,7 @@ void MainMenuNewMap::clicked_create_map() {
 
 	map->recalc_whole_map(egbase);
 	parent.map_changed(EditorInteractive::MapWas::kReplaced);
-    egbase.remove_loader_ui();
+	egbase.remove_loader_ui();
 	die();
 }
 

--- a/src/editor/ui_menus/main_menu_new_map.cc
+++ b/src/editor/ui_menus/main_menu_new_map.cc
@@ -101,10 +101,8 @@ void MainMenuNewMap::clicked_create_map() {
 	EditorInteractive& parent = eia();
 	Widelands::EditorGameBase& egbase = parent.egbase();
 	Widelands::Map* map = egbase.mutable_map();
-	UI::ProgressWindow* loader_ui = new UI::ProgressWindow("images/loadscreens/editor.jpg");
-	GameTips tips(*loader_ui, {"editor"});
-
-	loader_ui->step(_("Creating empty map…"));
+	egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+	egbase.step_loader_ui(_("Creating empty map…"));
 
 	parent.cleanup_for_load();
 
@@ -112,14 +110,11 @@ void MainMenuNewMap::clicked_create_map() {
 	                      list_.get_selected(), _("No Name"),
 	                      get_config_string("realname", pgettext("author_name", "Unknown")));
 
-	egbase.set_loader_ui(loader_ui);
 	egbase.postload();
 	egbase.load_graphics();
 
 	map->recalc_whole_map(egbase);
 	parent.map_changed(EditorInteractive::MapWas::kReplaced);
-	egbase.set_loader_ui(nullptr);
-	delete loader_ui;
 	die();
 }
 

--- a/src/editor/ui_menus/main_menu_new_map.cc
+++ b/src/editor/ui_menus/main_menu_new_map.cc
@@ -37,7 +37,6 @@
 #include "logic/map_objects/world/world.h"
 #include "ui_basic/progresswindow.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 
 inline EditorInteractive& MainMenuNewMap::eia() {
 	return dynamic_cast<EditorInteractive&>(*get_parent());

--- a/src/editor/ui_menus/main_menu_new_map.cc
+++ b/src/editor/ui_menus/main_menu_new_map.cc
@@ -114,6 +114,7 @@ void MainMenuNewMap::clicked_create_map() {
 
 	map->recalc_whole_map(egbase);
 	parent.map_changed(EditorInteractive::MapWas::kReplaced);
+    egbase.remove_loader_ui();
 	die();
 }
 

--- a/src/editor/ui_menus/main_menu_new_map.cc
+++ b/src/editor/ui_menus/main_menu_new_map.cc
@@ -100,7 +100,7 @@ void MainMenuNewMap::clicked_create_map() {
 	EditorInteractive& parent = eia();
 	Widelands::EditorGameBase& egbase = parent.egbase();
 	Widelands::Map* map = egbase.mutable_map();
-	egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+	egbase.create_loader_ui({"editor"}, true, "images/loadscreens/editor.jpg");
 	egbase.step_loader_ui(_("Creating empty map…"));
 
 	parent.cleanup_for_load();

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -40,7 +40,6 @@
 #include "ui_basic/messagebox.h"
 #include "ui_basic/progresswindow.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 
 namespace {
 // The map generator can't find starting positions for too many players

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -535,7 +535,7 @@ void MainMenuNewRandomMap::clicked_create_map() {
 	     "or be stuck on an island or on top of a mountain."),
 	   UI::WLMessageBox::MBoxType::kOk);
 	mbox.run<UI::Panel::Returncodes>();
-    egbase.remove_loader_ui();
+	egbase.remove_loader_ui();
 	die();
 }
 

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -535,6 +535,7 @@ void MainMenuNewRandomMap::clicked_create_map() {
 	     "or be stuck on an island or on top of a mountain."),
 	   UI::WLMessageBox::MBoxType::kOk);
 	mbox.run<UI::Panel::Returncodes>();
+    egbase.remove_loader_ui();
 	die();
 }
 

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -469,7 +469,7 @@ void MainMenuNewRandomMap::clicked_create_map() {
 	EditorInteractive& eia = dynamic_cast<EditorInteractive&>(*get_parent());
 	Widelands::EditorGameBase& egbase = eia.egbase();
 	Widelands::Map* map = egbase.mutable_map();
-	egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+	egbase.create_loader_ui({"editor"}, true, "images/loadscreens/editor.jpg");
 	eia.cleanup_for_load();
 
 	UniqueRandomMapInfo map_info;

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -470,9 +470,7 @@ void MainMenuNewRandomMap::clicked_create_map() {
 	EditorInteractive& eia = dynamic_cast<EditorInteractive&>(*get_parent());
 	Widelands::EditorGameBase& egbase = eia.egbase();
 	Widelands::Map* map = egbase.mutable_map();
-	UI::ProgressWindow* loader_ui = new UI::ProgressWindow("images/loadscreens/editor.jpg");
-	GameTips tips(*loader_ui, {"editor"});
-
+    egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 	eia.cleanup_for_load();
 
 	UniqueRandomMapInfo map_info;
@@ -490,7 +488,7 @@ void MainMenuNewRandomMap::clicked_create_map() {
 	map->create_empty_map(egbase, map_info.w, map_info.h, 0, _("No Name"),
 	                      get_config_string("realname", pgettext("author_name", "Unknown")),
 	                      sstrm.str().c_str());
-	loader_ui->step(_("Generating random map…"));
+	egbase.step_loader_ui(_("Generating random map…"));
 
 	log("============== Generating Map ==============\n");
 	log("ID:            %s\n", map_id_edit_.text().c_str());
@@ -516,7 +514,6 @@ void MainMenuNewRandomMap::clicked_create_map() {
 	}
 	log("\n");
 
-	egbase.set_loader_ui(loader_ui);
 	gen.create_random_map();
 
 	egbase.postload();
@@ -524,8 +521,6 @@ void MainMenuNewRandomMap::clicked_create_map() {
 
 	map->recalc_whole_map(egbase);
 	eia.map_changed(EditorInteractive::MapWas::kReplaced);
-	egbase.set_loader_ui(nullptr);
-	delete loader_ui;
 	UI::WLMessageBox mbox(
 	   &eia,
 	   /** TRANSLATORS: Window title. This is shown after a random map has been created in the

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -469,7 +469,7 @@ void MainMenuNewRandomMap::clicked_create_map() {
 	EditorInteractive& eia = dynamic_cast<EditorInteractive&>(*get_parent());
 	Widelands::EditorGameBase& egbase = eia.egbase();
 	Widelands::Map* map = egbase.mutable_map();
-    egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+	egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 	eia.cleanup_for_load();
 
 	UniqueRandomMapInfo map_info;

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -344,10 +344,8 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 		map->delete_tag("artifacts");
 	}
 
-	UI::ProgressWindow* loader_ui = new UI::ProgressWindow("images/loadscreens/editor.jpg");
-	GameTips tips(*loader_ui, {"editor"});
-	loader_ui->step("Saving the map…");
-	egbase.set_loader_ui(loader_ui);
+    egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+	egbase.step_loader_ui("Saving the map…");
 
 	// Try saving the map.
 	GenericSaveHandler gsh(
@@ -357,9 +355,6 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 		},
 	   complete_filename, binary ? FileSystem::ZIP : FileSystem::DIR);
 	GenericSaveHandler::Error error = gsh.save();
-
-	egbase.set_loader_ui(nullptr);
-	delete loader_ui;
 
 	// If only the temporary backup couldn't be deleted, we still treat it as
 	// success. Automatic cleanup will deal with later. No need to bother the

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -343,7 +343,7 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 		map->delete_tag("artifacts");
 	}
 
-	egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+	egbase.create_loader_ui({"editor"}, true, "images/loadscreens/editor.jpg");
 	egbase.step_loader_ui("Saving the map…");
 
 	// Try saving the map.

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -355,6 +355,8 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 	   complete_filename, binary ? FileSystem::ZIP : FileSystem::DIR);
 	GenericSaveHandler::Error error = gsh.save();
 
+    egbase.remove_loader_ui();
+
 	// If only the temporary backup couldn't be deleted, we still treat it as
 	// success. Automatic cleanup will deal with later. No need to bother the
 	// player with it.

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -355,7 +355,7 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 	   complete_filename, binary ? FileSystem::ZIP : FileSystem::DIR);
 	GenericSaveHandler::Error error = gsh.save();
 
-    egbase.remove_loader_ui();
+	egbase.remove_loader_ui();
 
 	// If only the temporary backup couldn't be deleted, we still treat it as
 	// success. Automatic cleanup will deal with later. No need to bother the

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -42,7 +42,6 @@
 #include "ui_basic/messagebox.h"
 #include "ui_basic/progresswindow.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 #include "wui/mapdetails.h"
 #include "wui/maptable.h"
 

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -343,7 +343,7 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 		map->delete_tag("artifacts");
 	}
 
-    egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
+	egbase.create_loader_ui({"editor"}, "images/loadscreens/editor.jpg");
 	egbase.step_loader_ui("Saving the map…");
 
 	// Try saving the map.

--- a/src/game_io/game_loader.cc
+++ b/src/game_io/game_loader.cc
@@ -66,6 +66,7 @@ int32_t GameLoader::preload_game(GamePreloadPacket& mp) {
 int32_t GameLoader::load_game(bool const multiplayer) {
 	ScopedTimer timer("GameLoader::load() took %ums");
 
+    assert(game_.has_loader_ui());
 	auto set_progress_message = [this](std::string text, unsigned step) {
 		game_.step_loader_ui(
 		   (boost::format(_("Loading game: %1$s (%2$u/%3$d)")) % text % step % 6).str());

--- a/src/game_io/game_loader.cc
+++ b/src/game_io/game_loader.cc
@@ -66,9 +66,8 @@ int32_t GameLoader::preload_game(GamePreloadPacket& mp) {
 int32_t GameLoader::load_game(bool const multiplayer) {
 	ScopedTimer timer("GameLoader::load() took %ums");
 
-	assert(game_.get_loader_ui());
 	auto set_progress_message = [this](std::string text, unsigned step) {
-		game_.get_loader_ui()->step(
+		game_.step_loader_ui(
 		   (boost::format(_("Loading game: %1$s (%2$u/%3$d)")) % text % step % 6).str());
 	};
 	set_progress_message(_("Elemental data"), 1);

--- a/src/game_io/game_loader.cc
+++ b/src/game_io/game_loader.cc
@@ -66,7 +66,7 @@ int32_t GameLoader::preload_game(GamePreloadPacket& mp) {
 int32_t GameLoader::load_game(bool const multiplayer) {
 	ScopedTimer timer("GameLoader::load() took %ums");
 
-    assert(game_.has_loader_ui());
+	assert(game_.has_loader_ui());
 	auto set_progress_message = [this](std::string text, unsigned step) {
 		game_.step_loader_ui(
 		   (boost::format(_("Loading game: %1$s (%2$u/%3$d)")) % text % step % 6).str());

--- a/src/game_io/game_saver.cc
+++ b/src/game_io/game_saver.cc
@@ -44,6 +44,7 @@ GameSaver::GameSaver(FileSystem& fs, Game& game) : fs_(fs), game_(game) {
 void GameSaver::save() {
 	ScopedTimer timer("GameSaver::save() took %ums");
 
+    // We might not have a loader UI during emergency saves, so we don't assert that we have one.
 	auto set_progress_message = [this](std::string text, int step) {
 		game_.step_loader_ui(
 		   step < 0 ? text :

--- a/src/game_io/game_saver.cc
+++ b/src/game_io/game_saver.cc
@@ -44,9 +44,8 @@ GameSaver::GameSaver(FileSystem& fs, Game& game) : fs_(fs), game_(game) {
 void GameSaver::save() {
 	ScopedTimer timer("GameSaver::save() took %ums");
 
-	assert(game_.get_loader_ui());
 	auto set_progress_message = [this](std::string text, int step) {
-		game_.get_loader_ui()->step(
+		game_.step_loader_ui(
 		   step < 0 ? text :
 		              (boost::format(_("Saving game: %1$s (%2$d/%3$d)")) % text % step % 5).str());
 	};

--- a/src/game_io/game_saver.cc
+++ b/src/game_io/game_saver.cc
@@ -44,8 +44,8 @@ GameSaver::GameSaver(FileSystem& fs, Game& game) : fs_(fs), game_(game) {
 void GameSaver::save() {
 	ScopedTimer timer("GameSaver::save() took %ums");
 
-    // We might not have a loader UI during emergency saves, so we don't assert that we have one.
-    // We also don't want it for game objectives.
+	// We might not have a loader UI during emergency saves, so we don't assert that we have one.
+	// We also don't want it for game objectives.
 	auto set_progress_message = [this](std::string text, int step) {
 		game_.step_loader_ui(
 		   step < 0 ? text :

--- a/src/game_io/game_saver.cc
+++ b/src/game_io/game_saver.cc
@@ -45,6 +45,7 @@ void GameSaver::save() {
 	ScopedTimer timer("GameSaver::save() took %ums");
 
     // We might not have a loader UI during emergency saves, so we don't assert that we have one.
+    // We also don't want it for game objectives.
 	auto set_progress_message = [this](std::string text, int step) {
 		game_.step_loader_ui(
 		   step < 0 ? text :

--- a/src/logic/CMakeLists.txt
+++ b/src/logic/CMakeLists.txt
@@ -260,6 +260,7 @@ wl_library(logic
     ui_basic
     widelands_options
     wui # TODO(GunChleoc): Circular dependency
+    wui_game_tips
 )
 
 add_subdirectory(map_objects)

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -332,19 +332,24 @@ void EditorGameBase::load_graphics() {
 	tribes_->load_graphics();
 }
 
-UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts,
+UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts, bool show_game_tips,
                                                      const std::string& background) {
 	assert(!has_loader_ui());
 	loader_ui_.reset(new UI::ProgressWindow(background));
-	game_tips_.reset(tipstexts.empty() ? nullptr : new GameTips(*loader_ui_, tipstexts));
+    registered_game_tips_ = tipstexts;
+    if (show_game_tips) {
+        game_tips_.reset(registered_game_tips_.empty() ? nullptr : new GameTips(*loader_ui_, registered_game_tips_));
+    }
 	return *loader_ui_.get();
 }
 void EditorGameBase::change_loader_ui_background(const std::string& background) {
 	assert(has_loader_ui());
-	if (!background.empty()) {
-		loader_ui_->set_background(background);
-		game_tips_.reset(nullptr);
-	}
+    assert(game_tips_ == nullptr);
+    if (background.empty()) {
+        game_tips_.reset(registered_game_tips_.empty() ? nullptr : new GameTips(*loader_ui_, registered_game_tips_));
+    } else {
+        loader_ui_->set_background(background);
+    }
 }
 void EditorGameBase::step_loader_ui(const std::string& text) const {
 	if (loader_ui_ != nullptr) {
@@ -355,6 +360,7 @@ void EditorGameBase::remove_loader_ui() {
 	assert(loader_ui_ != nullptr);
 	loader_ui_.reset(nullptr);
 	game_tips_.reset(nullptr);
+    registered_game_tips_.clear();
 }
 
 /**

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -352,6 +352,7 @@ void EditorGameBase::step_loader_ui(const std::string& text) const {
 void EditorGameBase::remove_loader_ui() {
 	assert(loader_ui_ != nullptr);
 	loader_ui_.reset(nullptr);
+	game_tips_.reset(nullptr);
 }
 
 /**

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -57,7 +57,6 @@
 #include "scripting/lua_table.h"
 #include "sound/sound_handler.h"
 #include "ui_basic/progresswindow.h"
-#include "wui/game_tips.h"
 #include "wui/interactive_base.h"
 #include "wui/interactive_gamebase.h"
 
@@ -331,20 +330,15 @@ void EditorGameBase::load_graphics() {
 	tribes_->load_graphics();
 }
 
-UI::ProgressWindow& EditorGameBase::create_loader_ui(std::vector<std::string> tipstexts, const std::string& background) {
-    if (loader_ui_ == nullptr) {
-        loader_ui_.reset(new UI::ProgressWindow(background));
-    }
-    if (!tipstexts.empty()) {
-        GameTips tips(*loader_ui_, tipstext);
-    }
+UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts, const std::string& background) {
+    loader_ui_.reset(new UI::ProgressWindow(background));
+    game_tips_.reset(tipstexts.empty() ? nullptr : new GameTips(*loader_ui_, tipstexts));
     return *loader_ui_.get();
 }
 void EditorGameBase::remove_loader_ui() {
     assert(loader_ui_ != nullptr);
     loader_ui_.reset(nullptr);
 }
-
 void EditorGameBase::step_loader_ui(const std::string& text) const {
     if (loader_ui_ != nullptr) {
         loader_ui_->step(text);

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -335,10 +335,6 @@ UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::stri
     game_tips_.reset(tipstexts.empty() ? nullptr : new GameTips(*loader_ui_, tipstexts));
     return *loader_ui_.get();
 }
-void EditorGameBase::remove_loader_ui() {
-    assert(loader_ui_ != nullptr);
-    loader_ui_.reset(nullptr);
-}
 void EditorGameBase::step_loader_ui(const std::string& text) const {
     if (loader_ui_ != nullptr) {
         loader_ui_->step(text);

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -349,6 +349,10 @@ void EditorGameBase::step_loader_ui(const std::string& text) const {
 		loader_ui_->step(text);
 	}
 }
+void EditorGameBase::remove_loader_ui() {
+    assert(loader_ui_ != nullptr);
+    loader_ui_.reset(nullptr);
+}
 
 /**
  * Instantly create a building at the given x/y location. There is no build time.

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -332,24 +332,29 @@ void EditorGameBase::load_graphics() {
 	tribes_->load_graphics();
 }
 
-UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts, bool show_game_tips,
+UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts,
+                                                     bool show_game_tips,
                                                      const std::string& background) {
 	assert(!has_loader_ui());
 	loader_ui_.reset(new UI::ProgressWindow(background));
-    registered_game_tips_ = tipstexts;
-    if (show_game_tips) {
-        game_tips_.reset(registered_game_tips_.empty() ? nullptr : new GameTips(*loader_ui_, registered_game_tips_));
-    }
+	registered_game_tips_ = tipstexts;
+	if (show_game_tips) {
+		game_tips_.reset(registered_game_tips_.empty() ?
+		                    nullptr :
+		                    new GameTips(*loader_ui_, registered_game_tips_));
+	}
 	return *loader_ui_.get();
 }
 void EditorGameBase::change_loader_ui_background(const std::string& background) {
 	assert(has_loader_ui());
-    assert(game_tips_ == nullptr);
-    if (background.empty()) {
-        game_tips_.reset(registered_game_tips_.empty() ? nullptr : new GameTips(*loader_ui_, registered_game_tips_));
-    } else {
-        loader_ui_->set_background(background);
-    }
+	assert(game_tips_ == nullptr);
+	if (background.empty()) {
+		game_tips_.reset(registered_game_tips_.empty() ?
+		                    nullptr :
+		                    new GameTips(*loader_ui_, registered_game_tips_));
+	} else {
+		loader_ui_->set_background(background);
+	}
 }
 void EditorGameBase::step_loader_ui(const std::string& text) const {
 	if (loader_ui_ != nullptr) {
@@ -360,7 +365,7 @@ void EditorGameBase::remove_loader_ui() {
 	assert(loader_ui_ != nullptr);
 	loader_ui_.reset(nullptr);
 	game_tips_.reset(nullptr);
-    registered_game_tips_.clear();
+	registered_game_tips_.clear();
 }
 
 /**

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -330,15 +330,16 @@ void EditorGameBase::load_graphics() {
 	tribes_->load_graphics();
 }
 
-UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts, const std::string& background) {
-    loader_ui_.reset(new UI::ProgressWindow(background));
-    game_tips_.reset(tipstexts.empty() ? nullptr : new GameTips(*loader_ui_, tipstexts));
-    return *loader_ui_.get();
+UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts,
+                                                     const std::string& background) {
+	loader_ui_.reset(new UI::ProgressWindow(background));
+	game_tips_.reset(tipstexts.empty() ? nullptr : new GameTips(*loader_ui_, tipstexts));
+	return *loader_ui_.get();
 }
 void EditorGameBase::step_loader_ui(const std::string& text) const {
-    if (loader_ui_ != nullptr) {
-        loader_ui_->step(text);
-    }
+	if (loader_ui_ != nullptr) {
+		loader_ui_->step(text);
+	}
 }
 
 /**

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -341,8 +341,10 @@ UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::stri
 }
 void EditorGameBase::change_loader_ui_background(const std::string& background) {
 	assert(has_loader_ui());
-	loader_ui_->set_background(background);
-	game_tips_.reset(nullptr);
+    if (!background.empty()) {
+        loader_ui_->set_background(background);
+        game_tips_.reset(nullptr);
+    }
 }
 void EditorGameBase::step_loader_ui(const std::string& text) const {
 	if (loader_ui_ != nullptr) {

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -327,22 +327,22 @@ void EditorGameBase::postload() {
  */
 void EditorGameBase::load_graphics() {
 	assert(tribes_);
-    assert(has_loader_ui());
+	assert(has_loader_ui());
 	step_loader_ui(_("Loading graphics"));
 	tribes_->load_graphics();
 }
 
 UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts,
                                                      const std::string& background) {
-    assert(!has_loader_ui());
+	assert(!has_loader_ui());
 	loader_ui_.reset(new UI::ProgressWindow(background));
 	game_tips_.reset(tipstexts.empty() ? nullptr : new GameTips(*loader_ui_, tipstexts));
 	return *loader_ui_.get();
 }
 void EditorGameBase::change_loader_ui_background(const std::string& background) {
-    assert(has_loader_ui());
-    loader_ui_->set_background(background);
-    game_tips_.reset(nullptr);
+	assert(has_loader_ui());
+	loader_ui_->set_background(background);
+	game_tips_.reset(nullptr);
 }
 void EditorGameBase::step_loader_ui(const std::string& text) const {
 	if (loader_ui_ != nullptr) {
@@ -350,8 +350,8 @@ void EditorGameBase::step_loader_ui(const std::string& text) const {
 	}
 }
 void EditorGameBase::remove_loader_ui() {
-    assert(loader_ui_ != nullptr);
-    loader_ui_.reset(nullptr);
+	assert(loader_ui_ != nullptr);
+	loader_ui_.reset(nullptr);
 }
 
 /**

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -70,11 +70,12 @@ initialization
 ============
 */
 EditorGameBase::EditorGameBase(LuaInterface* lua_interface)
-   : loader_ui_(nullptr),
-     gametime_(0),
+   : gametime_(0),
      lua_(lua_interface),
      player_manager_(new PlayersManager(*this)),
      ibase_(nullptr),
+     loader_ui_(nullptr),
+     game_tips_(nullptr),
      tmp_fs_(nullptr) {
 	if (!lua_)  // TODO(SirVer): this is sooo ugly, I can't say
 		lua_.reset(new LuaEditorInterface(this));
@@ -326,15 +327,22 @@ void EditorGameBase::postload() {
  */
 void EditorGameBase::load_graphics() {
 	assert(tribes_);
+    assert(has_loader_ui());
 	step_loader_ui(_("Loading graphics"));
 	tribes_->load_graphics();
 }
 
 UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::string>& tipstexts,
                                                      const std::string& background) {
+    assert(!has_loader_ui());
 	loader_ui_.reset(new UI::ProgressWindow(background));
 	game_tips_.reset(tipstexts.empty() ? nullptr : new GameTips(*loader_ui_, tipstexts));
 	return *loader_ui_.get();
+}
+void EditorGameBase::change_loader_ui_background(const std::string& background) {
+    assert(has_loader_ui());
+    loader_ui_->set_background(background);
+    game_tips_.reset(nullptr);
 }
 void EditorGameBase::step_loader_ui(const std::string& text) const {
 	if (loader_ui_ != nullptr) {

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -341,10 +341,10 @@ UI::ProgressWindow& EditorGameBase::create_loader_ui(const std::vector<std::stri
 }
 void EditorGameBase::change_loader_ui_background(const std::string& background) {
 	assert(has_loader_ui());
-    if (!background.empty()) {
-        loader_ui_->set_background(background);
-        game_tips_.reset(nullptr);
-    }
+	if (!background.empty()) {
+		loader_ui_->set_background(background);
+		game_tips_.reset(nullptr);
+	}
 }
 void EditorGameBase::step_loader_ui(const std::string& text) const {
 	if (loader_ui_ != nullptr) {

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -136,6 +136,9 @@ public:
     }
 #endif
 
+    // Destroy the loader UI
+    void remove_loader_ui();
+
 	void set_road(const FCoords&, uint8_t direction, RoadSegment roadtype);
 
 	// warping stuff. instantly creating map_objects

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -119,10 +119,11 @@ public:
 	void load_graphics();
 	virtual void cleanup_for_load();
 
-    // Create a new loader UI
-    UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts, const std::string& background = std::string());
-    // Set step text for the current loader UI if it's not nullptr.
-    void step_loader_ui(const std::string& text) const;
+	// Create a new loader UI
+	UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts,
+	                                     const std::string& background = std::string());
+	// Set step text for the current loader UI if it's not nullptr.
+	void step_loader_ui(const std::string& text) const;
 
 	void set_road(const FCoords&, uint8_t direction, RoadSegment roadtype);
 
@@ -265,7 +266,7 @@ private:
 	std::unique_ptr<InteractiveBase> ibase_;
 	Map map_;
 
-    std::unique_ptr<GameTips> game_tips_;
+	std::unique_ptr<GameTips> game_tips_;
 
 	/// Even after a map is fully loaded, some static data (images, scripts)
 	/// will still be read from a filesystem whenever a map/game is saved.

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -120,14 +120,15 @@ public:
 	virtual void cleanup_for_load();
 
 	/// Create a new loader UI and register which type of gametips to select from.
-    /// If 'show_game_tips' is true, game tips will be shown immediately.
-    /// Optionally sets a background image.
-	UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts, bool show_game_tips,
+	/// If 'show_game_tips' is true, game tips will be shown immediately.
+	/// Optionally sets a background image.
+	UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts,
+	                                     bool show_game_tips,
 	                                     const std::string& background = std::string());
 
 	/// If 'background' is not empty, change the background image for the loader UI.
-    /// If 'backgound' is empty, show game tips instead.
-    /// There must be a loader ui and no game tips.
+	/// If 'backgound' is empty, show game tips instead.
+	/// There must be a loader ui and no game tips.
 	void change_loader_ui_background(const std::string& background);
 
 	/// Set step text for the current loader UI if it's not nullptr.
@@ -284,7 +285,7 @@ private:
 	// Shown while loading or saving a game/map
 	std::unique_ptr<UI::ProgressWindow> loader_ui_;
 	std::unique_ptr<GameTips> game_tips_;
-    std::vector<std::string> registered_game_tips_;
+	std::vector<std::string> registered_game_tips_;
 
 	/// Even after a map is fully loaded, some static data (images, scripts)
 	/// will still be read from a filesystem whenever a map/game is saved.

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -122,8 +122,19 @@ public:
 	// Create a new loader UI
 	UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts,
 	                                     const std::string& background = std::string());
+
+    // Change the background image for the loader UI and remove the game tips
+    void change_loader_ui_background(const std::string& background);
+
 	// Set step text for the current loader UI if it's not nullptr.
 	void step_loader_ui(const std::string& text) const;
+
+#ifndef NDEBUG
+    // Check whether we currently have a loader_ui. Used for asserts only.
+    bool has_loader_ui() const {
+        return loader_ui_ != nullptr;
+    }
+#endif
 
 	void set_road(const FCoords&, uint8_t direction, RoadSegment roadtype);
 
@@ -206,9 +217,6 @@ public:
 	// Returns the mutable tribes. Prefer tribes() whenever possible.
 	Tribes* mutable_tribes();
 
-protected:
-	std::unique_ptr<UI::ProgressWindow> loader_ui_;
-
 private:
 	/// Common function for create_critter and create_ship.
 	Bob& create_bob(Coords, const BobDescr&, Player* owner = nullptr);
@@ -266,6 +274,8 @@ private:
 	std::unique_ptr<InteractiveBase> ibase_;
 	Map map_;
 
+    // Shown while loading or saving a game/map
+	std::unique_ptr<UI::ProgressWindow> loader_ui_;
 	std::unique_ptr<GameTips> game_tips_;
 
 	/// Even after a map is fully loaded, some static data (images, scripts)

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -123,21 +123,21 @@ public:
 	UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts,
 	                                     const std::string& background = std::string());
 
-    // Change the background image for the loader UI and remove the game tips
-    void change_loader_ui_background(const std::string& background);
+	// Change the background image for the loader UI and remove the game tips
+	void change_loader_ui_background(const std::string& background);
 
 	// Set step text for the current loader UI if it's not nullptr.
 	void step_loader_ui(const std::string& text) const;
 
 #ifndef NDEBUG
-    // Check whether we currently have a loader_ui. Used for asserts only.
-    bool has_loader_ui() const {
-        return loader_ui_ != nullptr;
-    }
+	// Check whether we currently have a loader_ui. Used for asserts only.
+	bool has_loader_ui() const {
+		return loader_ui_ != nullptr;
+	}
 #endif
 
-    // Destroy the loader UI
-    void remove_loader_ui();
+	// Destroy the loader UI
+	void remove_loader_ui();
 
 	void set_road(const FCoords&, uint8_t direction, RoadSegment roadtype);
 
@@ -277,7 +277,7 @@ private:
 	std::unique_ptr<InteractiveBase> ibase_;
 	Map map_;
 
-    // Shown while loading or saving a game/map
+	// Shown while loading or saving a game/map
 	std::unique_ptr<UI::ProgressWindow> loader_ui_;
 	std::unique_ptr<GameTips> game_tips_;
 

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -117,10 +117,13 @@ public:
 	virtual void postload();
 	void load_graphics();
 	virtual void cleanup_for_load();
-	void set_loader_ui(UI::ProgressWindow*);
-	UI::ProgressWindow* get_loader_ui() {
-		return loader_ui_;
-	}
+
+    // Create a new loader UI
+    UI::ProgressWindow& create_loader_ui(std::vector<std::string> tipstexts, const std::string& background = std::string());
+    // Destroy the loader UI
+    void remove_loader_ui();
+    // Set step text for the current loader UI if it's not nullptr.
+    void step_loader_ui(const std::string& text) const;
 
 	void set_road(const FCoords&, uint8_t direction, RoadSegment roadtype);
 
@@ -204,7 +207,7 @@ public:
 	Tribes* mutable_tribes();
 
 protected:
-	UI::ProgressWindow* loader_ui_;
+	std::unique_ptr<UI::ProgressWindow> loader_ui_;
 
 private:
 	/// Common function for create_critter and create_ship.

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -136,7 +136,7 @@ public:
 	}
 #endif
 
-	// Destroy the loader UI
+	// Destroy the loader UI and game tips
 	void remove_loader_ui();
 
 	void set_road(const FCoords&, uint8_t direction, RoadSegment roadtype);

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -121,8 +121,6 @@ public:
 
     // Create a new loader UI
     UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts, const std::string& background = std::string());
-    // Destroy the loader UI
-    void remove_loader_ui();
     // Set step text for the current loader UI if it's not nullptr.
     void step_loader_ui(const std::string& text) const;
 

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -32,6 +32,7 @@
 #include "logic/player_area.h"
 #include "notifications/notifications.h"
 #include "scripting/lua_interface.h"
+#include "wui/game_tips.h"
 
 namespace UI {
 struct ProgressWindow;
@@ -119,7 +120,7 @@ public:
 	virtual void cleanup_for_load();
 
     // Create a new loader UI
-    UI::ProgressWindow& create_loader_ui(std::vector<std::string> tipstexts, const std::string& background = std::string());
+    UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts, const std::string& background = std::string());
     // Destroy the loader UI
     void remove_loader_ui();
     // Set step text for the current loader UI if it's not nullptr.
@@ -265,6 +266,8 @@ private:
 	std::unique_ptr<Tribes> tribes_;
 	std::unique_ptr<InteractiveBase> ibase_;
 	Map map_;
+
+    std::unique_ptr<GameTips> game_tips_;
 
 	/// Even after a map is fully loaded, some static data (images, scripts)
 	/// will still be read from a filesystem whenever a map/game is saved.

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -119,18 +119,22 @@ public:
 	void load_graphics();
 	virtual void cleanup_for_load();
 
-	// Create a new loader UI
-	UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts,
+	/// Create a new loader UI and register which type of gametips to select from.
+    /// If 'show_game_tips' is true, game tips will be shown immediately.
+    /// Optionally sets a background image.
+	UI::ProgressWindow& create_loader_ui(const std::vector<std::string>& tipstexts, bool show_game_tips,
 	                                     const std::string& background = std::string());
 
-	// Change the background image for the loader UI and remove the game tips
+	/// If 'background' is not empty, change the background image for the loader UI.
+    /// If 'backgound' is empty, show game tips instead.
+    /// There must be a loader ui and no game tips.
 	void change_loader_ui_background(const std::string& background);
 
-	// Set step text for the current loader UI if it's not nullptr.
+	/// Set step text for the current loader UI if it's not nullptr.
 	void step_loader_ui(const std::string& text) const;
 
 #ifndef NDEBUG
-	// Check whether we currently have a loader_ui. Used for asserts only.
+	/// Check whether we currently have a loader_ui. Used for asserts only.
 	bool has_loader_ui() const {
 		return loader_ui_ != nullptr;
 	}
@@ -280,6 +284,7 @@ private:
 	// Shown while loading or saving a game/map
 	std::unique_ptr<UI::ProgressWindow> loader_ui_;
 	std::unique_ptr<GameTips> game_tips_;
+    std::vector<std::string> registered_game_tips_;
 
 	/// Even after a map is fully loaded, some static data (images, scripts)
 	/// will still be read from a filesystem whenever a map/game is saved.

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -208,9 +208,10 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	set_write_replay(false);
 
 	std::unique_ptr<MapLoader> maploader(mutable_map()->get_correct_loader(mapname));
-	if (!maploader)
+    if (!maploader) {
 		throw wexception("could not load \"%s\"", mapname.c_str());
-	assert(!has_loader_ui());
+    }
+
 	create_loader_ui({"general_game"});
 
 	step_loader_ui(_("Preloading map…"));
@@ -390,7 +391,6 @@ void Game::init_savegame(const GameSettings& settings) {
 }
 
 bool Game::run_load_game(const std::string& filename, const std::string& script_to_run) {
-	assert(!has_loader_ui());
 	create_loader_ui({"general_game", "singleplayer"});
 	int8_t player_nr;
 

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -563,6 +563,8 @@ bool Game::run(StartGameType const start_game_type,
 
 	state_ = gs_running;
 
+    remove_loader_ui();
+
 	get_ibase()->run<UI::Panel::Returncodes>();
 
 	state_ = gs_ending;

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -362,7 +362,7 @@ void Game::init_savegame(const GameSettings& settings) {
 		GameLoader gl(settings.mapfilename, *this);
 		Widelands::GamePreloadPacket gpdp;
 		gl.preload_game(gpdp);
-        change_loader_ui_background(gpdp.get_background());
+		change_loader_ui_background(gpdp.get_background());
 
 		win_condition_displayname_ = gpdp.get_win_condition();
 		if (win_condition_displayname_ == "Scenario") {
@@ -395,7 +395,7 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 
 		Widelands::GamePreloadPacket gpdp;
 		gl.preload_game(gpdp);
-        change_loader_ui_background(gpdp.get_background());
+		change_loader_ui_background(gpdp.get_background());
 
 		win_condition_displayname_ = gpdp.get_win_condition();
 		if (win_condition_displayname_ == "Scenario") {

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -216,11 +216,7 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 
 	step_loader_ui(_("Preloading map…"));
 	maploader->preload_map(true);
-
-	const std::string& background = map().get_background();
-	if (!background.empty()) {
-		change_loader_ui_background(background);
-	}
+	change_loader_ui_background(map().get_background());
 
 	step_loader_ui(_("Loading world…"));
 	world();
@@ -280,6 +276,7 @@ void Game::init_newgame(const GameSettings& settings) {
 	std::unique_ptr<MapLoader> maploader(mutable_map()->get_correct_loader(settings.mapfilename));
 	assert(maploader != nullptr);
 	maploader->preload_map(settings.scenario);
+	change_loader_ui_background(map().get_background());
 
 	step_loader_ui(_("Loading world…"));
 	world();
@@ -287,10 +284,6 @@ void Game::init_newgame(const GameSettings& settings) {
 	step_loader_ui(_("Loading tribes…"));
 	tribes();
 
-	std::string const background = map().get_background();
-	if (!background.empty()) {
-		change_loader_ui_background(background);
-	}
 	step_loader_ui(_("Creating players…"));
 
 	std::vector<PlayerSettings> shared;
@@ -369,13 +362,14 @@ void Game::init_savegame(const GameSettings& settings) {
 		GameLoader gl(settings.mapfilename, *this);
 		Widelands::GamePreloadPacket gpdp;
 		gl.preload_game(gpdp);
+        change_loader_ui_background(gpdp.get_background());
+
 		win_condition_displayname_ = gpdp.get_win_condition();
 		if (win_condition_displayname_ == "Scenario") {
 			// Replays can't handle scenarios
 			set_write_replay(false);
 		}
-		std::string background(gpdp.get_background());
-		change_loader_ui_background(background);
+
 		step_loader_ui(_("Loading…"));
 		gl.load_game(settings.multiplayer);
 		// Players might have selected a different AI type
@@ -401,13 +395,14 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 
 		Widelands::GamePreloadPacket gpdp;
 		gl.preload_game(gpdp);
-		std::string background(gpdp.get_background());
+        change_loader_ui_background(gpdp.get_background());
+
 		win_condition_displayname_ = gpdp.get_win_condition();
 		if (win_condition_displayname_ == "Scenario") {
 			// Replays can't handle scenarios
 			set_write_replay(false);
 		}
-		change_loader_ui_background(background);
+
 		player_nr = gpdp.get_player_nr();
 		set_ibase(new InteractivePlayer(*this, get_config_section(), player_nr, false));
 

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -215,10 +215,15 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 
 	step_loader_ui(_("Preloading map…"));
 	maploader->preload_map(true);
-	std::string const background = map().get_background();
-	if (!background.empty()) {
-		loader_ui_->set_background(background);
-	}
+
+    // If the scenario has no special background image, show game tips instead.
+	const std::string& background = map().get_background();
+	if (background.empty()) {
+        create_loader_ui({"general_game"});
+    } else {
+        loader_ui_->set_background(background);
+    }
+
 	step_loader_ui(_("Loading world…"));
 	world();
 	step_loader_ui(_("Loading tribes…"));

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -210,18 +210,15 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	std::unique_ptr<MapLoader> maploader(mutable_map()->get_correct_loader(mapname));
 	if (!maploader)
 		throw wexception("could not load \"%s\"", mapname.c_str());
-	assert(!loader_ui_);
-	create_loader_ui({});
+	assert(!has_loader_ui());
+	create_loader_ui({"general_game"});
 
 	step_loader_ui(_("Preloading map…"));
 	maploader->preload_map(true);
 
-    // If the scenario has no special background image, show game tips instead.
 	const std::string& background = map().get_background();
-	if (background.empty()) {
-        create_loader_ui({"general_game"});
-    } else {
-        loader_ui_->set_background(background);
+	if (!background.empty()) {
+        change_loader_ui_background(background);
     }
 
 	step_loader_ui(_("Loading world…"));
@@ -275,7 +272,7 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
  *
  */
 void Game::init_newgame(const GameSettings& settings) {
-	assert(loader_ui_);
+	assert(has_loader_ui());
 
 	step_loader_ui(_("Preloading map…"));
 
@@ -291,7 +288,7 @@ void Game::init_newgame(const GameSettings& settings) {
 
 	std::string const background = map().get_background();
 	if (!background.empty()) {
-		loader_ui_->set_background(background);
+		change_loader_ui_background(background);
 	}
 	step_loader_ui(_("Creating players…"));
 
@@ -363,7 +360,7 @@ void Game::init_newgame(const GameSettings& settings) {
  * run<Returncode>() takes care about this difference.
  */
 void Game::init_savegame(const GameSettings& settings) {
-	assert(loader_ui_);
+	assert(has_loader_ui());
 
 	step_loader_ui(_("Preloading map…"));
 
@@ -377,7 +374,7 @@ void Game::init_savegame(const GameSettings& settings) {
 			set_write_replay(false);
 		}
 		std::string background(gpdp.get_background());
-		loader_ui_->set_background(background);
+		change_loader_ui_background(background);
 		step_loader_ui(_("Loading…"));
 		gl.load_game(settings.multiplayer);
 		// Players might have selected a different AI type
@@ -393,7 +390,7 @@ void Game::init_savegame(const GameSettings& settings) {
 }
 
 bool Game::run_load_game(const std::string& filename, const std::string& script_to_run) {
-	assert(!loader_ui_);
+	assert(!has_loader_ui());
 	create_loader_ui({"general_game", "singleplayer"});
 	int8_t player_nr;
 
@@ -410,7 +407,7 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 			// Replays can't handle scenarios
 			set_write_replay(false);
 		}
-		loader_ui_->set_background(background);
+		change_loader_ui_background(background);
 		player_nr = gpdp.get_player_nr();
 		set_ibase(new InteractivePlayer(*this, get_config_section(), player_nr, false));
 
@@ -467,7 +464,7 @@ bool Game::run(StartGameType const start_game_type,
                const std::string& script_to_run,
                bool replay,
                const std::string& prefix_for_replays) {
-	assert(loader_ui_);
+	assert(has_loader_ui());
 
 	replay_ = replay;
 	postload();

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -67,7 +67,6 @@
 #include "sound/sound_handler.h"
 #include "ui_basic/progresswindow.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 #include "wui/interactive_player.h"
 
 namespace Widelands {
@@ -212,7 +211,7 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	if (!maploader)
 		throw wexception("could not load \"%s\"", mapname.c_str());
 	assert(!loader_ui_);
-	create_loader_ui();
+	create_loader_ui({});
 
 	step_loader_ui(_("Preloading map…"));
 	maploader->preload_map(true);

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -255,12 +255,10 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	set_game_controller(new SinglePlayerGameController(*this, true, 1));
 	try {
 		bool const result = run(NewSPScenario, script_to_run, false, "single_player");
-		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		return result;
 	} catch (...) {
-		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		throw;
@@ -421,12 +419,10 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 	set_game_controller(new SinglePlayerGameController(*this, true, player_nr));
 	try {
 		bool const result = run(Loaded, script_to_run, false, "single_player");
-		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		return result;
 	} catch (...) {
-		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		throw;

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -216,13 +216,13 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	step_loader_ui(_("Preloading map…"));
 	maploader->preload_map(true);
 
-    // If the scenario has no special background image, show game tips instead.
+	// If the scenario has no special background image, show game tips instead.
 	const std::string& background = map().get_background();
 	if (background.empty()) {
-        create_loader_ui({"general_game"});
-    } else {
-        loader_ui_->set_background(background);
-    }
+		create_loader_ui({"general_game"});
+	} else {
+		loader_ui_->set_background(background);
+	}
 
 	step_loader_ui(_("Loading world…"));
 	world();

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -212,17 +212,17 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	if (!maploader)
 		throw wexception("could not load \"%s\"", mapname.c_str());
 	assert(!loader_ui_);
-	loader_ui_ = new UI::ProgressWindow();
+	create_loader_ui();
 
-	loader_ui_->step(_("Preloading map…"));
+	step_loader_ui(_("Preloading map…"));
 	maploader->preload_map(true);
 	std::string const background = map().get_background();
 	if (!background.empty()) {
 		loader_ui_->set_background(background);
 	}
-	loader_ui_->step(_("Loading world…"));
+	step_loader_ui(_("Loading world…"));
 	world();
-	loader_ui_->step(_("Loading tribes…"));
+	step_loader_ui(_("Loading tribes…"));
 	tribes();
 
 	// If the scenario has custrom tribe entites, load them.
@@ -232,7 +232,7 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	}
 
 	// We have to create the players here.
-	loader_ui_->step(_("Creating players…"));
+	step_loader_ui(_("Creating players…"));
 	PlayerNumber const nr_players = map().get_nrplayers();
 	iterate_player_numbers(p, nr_players) {
 		// If tribe name is empty, pick a random tribe
@@ -249,21 +249,19 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 
 	set_ibase(new InteractivePlayer(*this, get_config_section(), 1, false));
 
-	loader_ui_->step(_("Loading map…"));
+	step_loader_ui(_("Loading map…"));
 	maploader->load_map_complete(*this, Widelands::MapLoader::LoadType::kScenario);
 	maploader.reset();
 
 	set_game_controller(new SinglePlayerGameController(*this, true, 1));
 	try {
 		bool const result = run(NewSPScenario, script_to_run, false, "single_player");
-		delete loader_ui_;
-		loader_ui_ = nullptr;
+		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		return result;
 	} catch (...) {
-		delete loader_ui_;
-		loader_ui_ = nullptr;
+		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		throw;
@@ -277,23 +275,23 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 void Game::init_newgame(const GameSettings& settings) {
 	assert(loader_ui_);
 
-	loader_ui_->step(_("Preloading map…"));
+	step_loader_ui(_("Preloading map…"));
 
 	std::unique_ptr<MapLoader> maploader(mutable_map()->get_correct_loader(settings.mapfilename));
 	assert(maploader != nullptr);
 	maploader->preload_map(settings.scenario);
 
-	loader_ui_->step(_("Loading world…"));
+	step_loader_ui(_("Loading world…"));
 	world();
 
-	loader_ui_->step(_("Loading tribes…"));
+	step_loader_ui(_("Loading tribes…"));
 	tribes();
 
 	std::string const background = map().get_background();
 	if (!background.empty()) {
 		loader_ui_->set_background(background);
 	}
-	loader_ui_->step(_("Creating players…"));
+	step_loader_ui(_("Creating players…"));
 
 	std::vector<PlayerSettings> shared;
 	std::vector<uint8_t> shared_num;
@@ -321,14 +319,14 @@ void Game::init_newgame(const GameSettings& settings) {
 		   ->add_further_starting_position(shared_num.at(n), shared.at(n).initialization_index);
 	}
 
-	loader_ui_->step(_("Loading map…"));
+	step_loader_ui(_("Loading map…"));
 	maploader->load_map_complete(*this, settings.scenario ?
 	                                       Widelands::MapLoader::LoadType::kScenario :
 	                                       Widelands::MapLoader::LoadType::kGame);
 
 	// Check for win_conditions
 	if (!settings.scenario) {
-		loader_ui_->step(_("Initializing game…"));
+		step_loader_ui(_("Initializing game…"));
 		if (settings.peaceful) {
 			for (uint32_t i = 1; i < settings.players.size(); ++i) {
 				if (Player* p1 = get_player(i)) {
@@ -365,7 +363,7 @@ void Game::init_newgame(const GameSettings& settings) {
 void Game::init_savegame(const GameSettings& settings) {
 	assert(loader_ui_);
 
-	loader_ui_->step(_("Preloading map…"));
+	step_loader_ui(_("Preloading map…"));
 
 	try {
 		GameLoader gl(settings.mapfilename, *this);
@@ -378,7 +376,7 @@ void Game::init_savegame(const GameSettings& settings) {
 		}
 		std::string background(gpdp.get_background());
 		loader_ui_->set_background(background);
-		loader_ui_->step(_("Loading…"));
+		step_loader_ui(_("Loading…"));
 		gl.load_game(settings.multiplayer);
 		// Players might have selected a different AI type
 		for (uint8_t i = 0; i < settings.players.size(); ++i) {
@@ -394,14 +392,10 @@ void Game::init_savegame(const GameSettings& settings) {
 
 bool Game::run_load_game(const std::string& filename, const std::string& script_to_run) {
 	assert(!loader_ui_);
-	loader_ui_ = new UI::ProgressWindow();
-	std::vector<std::string> tipstext;
-	tipstext.push_back("general_game");
-	tipstext.push_back("singleplayer");
-	GameTips tips(*loader_ui_, tipstext);
+	create_loader_ui({"general_game", "singleplayer"});
 	int8_t player_nr;
 
-	loader_ui_->step(_("Preloading map…"));
+	step_loader_ui(_("Preloading map…"));
 
 	{
 		GameLoader gl(filename, *this);
@@ -418,7 +412,7 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 		player_nr = gpdp.get_player_nr();
 		set_ibase(new InteractivePlayer(*this, get_config_section(), player_nr, false));
 
-		loader_ui_->step(_("Loading…"));
+		step_loader_ui(_("Loading…"));
 		gl.load_game();
 	}
 
@@ -428,14 +422,12 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 	set_game_controller(new SinglePlayerGameController(*this, true, player_nr));
 	try {
 		bool const result = run(Loaded, script_to_run, false, "single_player");
-		delete loader_ui_;
-		loader_ui_ = nullptr;
+		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		return result;
 	} catch (...) {
-		delete loader_ui_;
-		loader_ui_ = nullptr;
+		remove_loader_ui();
 		delete ctrl_;
 		ctrl_ = nullptr;
 		throw;
@@ -483,7 +475,7 @@ bool Game::run(StartGameType const start_game_type,
 	if (start_game_type != Loaded) {
 		PlayerNumber const nr_players = map().get_nrplayers();
 		if (start_game_type == NewNonScenario) {
-			loader_ui_->step(_("Creating player infrastructure…"));
+			step_loader_ui(_("Creating player infrastructure…"));
 			iterate_players_existing(p, nr_players, *this, plr) {
 				plr->create_default_infrastructure();
 			}

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -208,9 +208,9 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 	set_write_replay(false);
 
 	std::unique_ptr<MapLoader> maploader(mutable_map()->get_correct_loader(mapname));
-    if (!maploader) {
+	if (!maploader) {
 		throw wexception("could not load \"%s\"", mapname.c_str());
-    }
+	}
 
 	create_loader_ui({"general_game"});
 

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -212,7 +212,7 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 		throw wexception("could not load \"%s\"", mapname.c_str());
 	}
 
-	create_loader_ui({"general_game"});
+	create_loader_ui({"general_game"}, false);
 
 	step_loader_ui(_("Preloading map…"));
 	maploader->preload_map(true);
@@ -385,7 +385,7 @@ void Game::init_savegame(const GameSettings& settings) {
 }
 
 bool Game::run_load_game(const std::string& filename, const std::string& script_to_run) {
-	create_loader_ui({"general_game", "singleplayer"});
+	create_loader_ui({"general_game", "singleplayer"}, false);
 	int8_t player_nr;
 
 	step_loader_ui(_("Preloading map…"));

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -218,8 +218,8 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 
 	const std::string& background = map().get_background();
 	if (!background.empty()) {
-        change_loader_ui_background(background);
-    }
+		change_loader_ui_background(background);
+	}
 
 	step_loader_ui(_("Loading world…"));
 	world();
@@ -563,7 +563,7 @@ bool Game::run(StartGameType const start_game_type,
 
 	state_ = gs_running;
 
-    remove_loader_ui();
+	remove_loader_ui();
 
 	get_ibase()->run<UI::Panel::Returncodes>();
 

--- a/src/logic/save_handler.cc
+++ b/src/logic/save_handler.cc
@@ -128,6 +128,8 @@ bool SaveHandler::check_next_tick(Widelands::Game& game, uint32_t realtime) {
 	log("Autosave: %d ms interval elapsed, current gametime: %s, saving...\n",
 	    autosave_interval_in_ms_, gametimestring(game.get_gametime(), true).c_str());
 
+	game.get_ibase()->log_message(_("Saving game…"));
+
 	return true;
 }
 

--- a/src/map_io/map_saver.cc
+++ b/src/map_io/map_saver.cc
@@ -82,9 +82,8 @@ void MapSaver::save() {
 
 	bool is_game = is_a(Game, &egbase_);
 
-	assert(egbase_.get_loader_ui());
 	auto set_progress_message = [this](std::string text, int step) {
-		egbase_.get_loader_ui()->step(
+		egbase_.step_loader_ui(
 		   step < 0 ? text :
 		              (boost::format(_("Saving map: %1$s (%2$d/%3$d)")) % text % step % 23).str());
 	};

--- a/src/map_io/widelands_map_loader.cc
+++ b/src/map_io/widelands_map_loader.cc
@@ -126,10 +126,8 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 
 	// MANDATORY PACKETS
 	// PRELOAD DATA BEGIN
-	UI::ProgressWindow* ui = egbase.get_loader_ui();
-	assert(ui);
-	auto set_progress_message = [ui, is_editor](std::string text, unsigned step) {
-		ui->step(
+	auto set_progress_message = [&egbase, is_editor](std::string text, unsigned step) {
+		egbase.step_loader_ui(
 		   (boost::format(_("Loading map: %1$s (%2$u/%3$d)")) % text % step % (is_editor ? 9 : 24))
 		      .str());
 	};

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -263,11 +263,11 @@ void GameClient::run() {
 	game.set_write_syncstream(get_config_bool("write_syncstreams", true));
 
 	try {
-        std::vector<std::string> tipstexts{"general_game", "multiplayer"};
-        if (has_players_tribe()) {
-            tipstexts.push_back(get_players_tribe());
-        }
-        UI::ProgressWindow& loader_ui = game.create_loader_ui(tipstexts);
+		std::vector<std::string> tipstexts{"general_game", "multiplayer"};
+		if (has_players_tribe()) {
+			tipstexts.push_back(get_players_tribe());
+		}
+		UI::ProgressWindow& loader_ui = game.create_loader_ui(tipstexts);
 
 		d->game = &game;
 		InteractiveGameBase* igb = d->init_game(this, loader_ui);

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -102,9 +102,9 @@ struct GameClientImpl {
 	void send_player_command(Widelands::PlayerCommand*);
 
 	bool run_map_menu(GameClient* parent);
-	void run_game(InteractiveGameBase* igb, UI::ProgressWindow*);
+	void run_game(InteractiveGameBase* igb);
 
-	InteractiveGameBase* init_game(GameClient* parent, UI::ProgressWindow*);
+	InteractiveGameBase* init_game(GameClient* parent, UI::ProgressWindow&);
 };
 
 void GameClientImpl::send_hello() {
@@ -148,22 +148,19 @@ bool GameClientImpl::run_map_menu(GameClient* parent) {
 /**
  * Show progress dialog and load map or saved game.
  */
-InteractiveGameBase* GameClientImpl::init_game(GameClient* parent, UI::ProgressWindow* loader) {
-	assert(loader);
-	std::vector<std::string> tipstext;
-	tipstext.push_back("general_game");
-	tipstext.push_back("multiplayer");
+InteractiveGameBase* GameClientImpl::init_game(GameClient* parent, UI::ProgressWindow& loader) {
+    std::vector<std::string> tipstexts{"general_game", "multiplayer"};
 	if (parent->has_players_tribe()) {
-		tipstext.push_back(parent->get_players_tribe());
+		tipstexts.push_back(parent->get_players_tribe());
 	}
-	GameTips tips(*loader, tipstext);
+    // NOCOM lose loader in parameter
+    game->create_loader_ui(tipstexts);
 
-	modal = loader;
+	modal = &loader;
 
-	loader->step(_("Preparing game"));
+	game->step_loader_ui(_("Preparing game"));
 
 	game->set_game_controller(parent);
-	game->set_loader_ui(loader);
 	uint8_t const pn = settings.playernum + 1;
 	game->save_handler().set_autosave_filename(
 	   (boost::format("%s_netclient%u") % kAutosavePrefix % static_cast<unsigned int>(pn)).str());
@@ -180,21 +177,19 @@ InteractiveGameBase* GameClientImpl::init_game(GameClient* parent, UI::ProgressW
 	} else {  //  new map
 		game->init_newgame(settings);
 	}
-	game->set_loader_ui(nullptr);
 	return igb;
 }
 
 /**
  * Run the actual game and cleanup when done.
  */
-void GameClientImpl::run_game(InteractiveGameBase* igb, UI::ProgressWindow* loader) {
+void GameClientImpl::run_game(InteractiveGameBase* igb) {
 	time.reset(game->get_gametime());
 	lasttimestamp = game->get_gametime();
 	lasttimestamp_realtime = SDL_GetTicks();
 
 	modal = igb;
-	assert(loader);
-	game->set_loader_ui(loader);
+
 	game->run(settings.savegame ? Widelands::Game::Loaded : settings.scenario ?
 	                              Widelands::Game::NewMPScenario :
 	                              Widelands::Game::NewNonScenario,
@@ -205,7 +200,6 @@ void GameClientImpl::run_game(InteractiveGameBase* igb, UI::ProgressWindow* load
 		InternetGaming::ref().set_game_done();
 	}
 	modal = nullptr;
-	game->set_loader_ui(nullptr);
 	game = nullptr;
 }
 
@@ -277,11 +271,11 @@ void GameClient::run() {
 	game.set_write_syncstream(get_config_bool("write_syncstreams", true));
 
 	try {
-		std::unique_ptr<UI::ProgressWindow> loader_ui(new UI::ProgressWindow());
+        UI::ProgressWindow& loader_ui = d->game->create_loader_ui();
 
 		d->game = &game;
-		InteractiveGameBase* igb = d->init_game(this, loader_ui.get());
-		d->run_game(igb, loader_ui.get());
+		InteractiveGameBase* igb = d->init_game(this, loader_ui);
+		d->run_game(igb);
 
 	} catch (...) {
 		WLApplication::emergency_save(game);

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -267,7 +267,7 @@ void GameClient::run() {
 		if (has_players_tribe()) {
 			tipstexts.push_back(get_players_tribe());
 		}
-		UI::ProgressWindow& loader_ui = game.create_loader_ui(tipstexts);
+		UI::ProgressWindow& loader_ui = game.create_loader_ui(tipstexts, false);
 
 		d->game = &game;
 		InteractiveGameBase* igb = d->init_game(this, loader_ui);

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -54,7 +54,6 @@
 #include "ui_fsmenu/launch_mpg.h"
 #include "wlapplication.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 #include "wui/interactive_player.h"
 #include "wui/interactive_spectator.h"
 
@@ -149,13 +148,6 @@ bool GameClientImpl::run_map_menu(GameClient* parent) {
  * Show progress dialog and load map or saved game.
  */
 InteractiveGameBase* GameClientImpl::init_game(GameClient* parent, UI::ProgressWindow& loader) {
-    std::vector<std::string> tipstexts{"general_game", "multiplayer"};
-	if (parent->has_players_tribe()) {
-		tipstexts.push_back(parent->get_players_tribe());
-	}
-    // NOCOM lose loader in parameter
-    game->create_loader_ui(tipstexts);
-
 	modal = &loader;
 
 	game->step_loader_ui(_("Preparing game"));
@@ -271,7 +263,11 @@ void GameClient::run() {
 	game.set_write_syncstream(get_config_bool("write_syncstreams", true));
 
 	try {
-        UI::ProgressWindow& loader_ui = d->game->create_loader_ui();
+        std::vector<std::string> tipstexts{"general_game", "multiplayer"};
+        if (has_players_tribe()) {
+            tipstexts.push_back(get_players_tribe());
+        }
+        UI::ProgressWindow& loader_ui = game.create_loader_ui(tipstexts);
 
 		d->game = &game;
 		InteractiveGameBase* igb = d->init_game(this, loader_ui);

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -661,7 +661,7 @@ void GameHost::run() {
 		if (d->hp.has_players_tribe()) {
 			tipstexts.push_back(d->hp.get_players_tribe());
 		}
-		game.create_loader_ui(tipstexts);
+		game.create_loader_ui(tipstexts, false);
 		game.step_loader_ui(_("Preparing game"));
 
 		d->game = &game;

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -63,7 +63,6 @@
 #include "ui_fsmenu/launch_mpg.h"
 #include "wlapplication.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 #include "wui/interactive_player.h"
 #include "wui/interactive_spectator.h"
 

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -657,11 +657,11 @@ void GameHost::run() {
 	game.set_write_syncstream(get_config_bool("write_syncstreams", true));
 
 	try {
-        std::vector<std::string> tipstexts{"general_game", "multiplayer"};
+		std::vector<std::string> tipstexts{"general_game", "multiplayer"};
 		if (d->hp.has_players_tribe()) {
 			tipstexts.push_back(d->hp.get_players_tribe());
 		}
-        game.create_loader_ui(tipstexts);
+		game.create_loader_ui(tipstexts);
 		game.step_loader_ui(_("Preparing game"));
 
 		d->game = &game;

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -658,22 +658,15 @@ void GameHost::run() {
 	game.set_write_syncstream(get_config_bool("write_syncstreams", true));
 
 	try {
-		std::unique_ptr<UI::ProgressWindow> loader_ui;
-		loader_ui.reset(new UI::ProgressWindow());
-
-		std::vector<std::string> tipstext;
-		tipstext.push_back("general_game");
-		tipstext.push_back("multiplayer");
+        std::vector<std::string> tipstexts{"general_game", "multiplayer"};
 		if (d->hp.has_players_tribe()) {
-			tipstext.push_back(d->hp.get_players_tribe());
+			tipstexts.push_back(d->hp.get_players_tribe());
 		}
-		std::unique_ptr<GameTips> tips(new GameTips(*loader_ui, tipstext));
-
-		loader_ui->step(_("Preparing game"));
+        game.create_loader_ui(tipstexts);
+		game.step_loader_ui(_("Preparing game"));
 
 		d->game = &game;
 		game.set_game_controller(this);
-		game.set_loader_ui(loader_ui.get());
 		InteractiveGameBase* igb;
 		uint8_t pn = d->settings.playernum + 1;
 		game.save_handler().set_autosave_filename(
@@ -720,7 +713,6 @@ void GameHost::run() {
 		                                Widelands::Game::NewNonScenario,
 		         "", false, "nethost");
 
-		game.set_loader_ui(nullptr);
 		// if this is an internet game, tell the metaserver that the game is done.
 		if (internet_) {
 			InternetGaming::ref().set_game_done();

--- a/src/scripting/lua_bases.cc
+++ b/src/scripting/lua_bases.cc
@@ -550,7 +550,7 @@ int LuaEditorGameBase::read_campaign_data(lua_State* L) {
       May be used from the init.lua files for tribe/world loading only.
 */
 int LuaEditorGameBase::set_loading_message(lua_State* L) {
-	get_egbase(L).get_loader_ui()->step(luaL_checkstring(L, 2));
+	get_egbase(L).step_loader_ui(luaL_checkstring(L, 2));
 	return 0;
 }
 

--- a/src/ui_basic/progresswindow.h
+++ b/src/ui_basic/progresswindow.h
@@ -21,7 +21,6 @@
 #define WL_UI_BASIC_PROGRESSWINDOW_H
 
 #include <cstring>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/ui_basic/progresswindow.h
+++ b/src/ui_basic/progresswindow.h
@@ -21,6 +21,7 @@
 #define WL_UI_BASIC_PROGRESSWINDOW_H
 
 #include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1353,7 +1353,7 @@ bool WLApplication::new_game() {
 			game.set_ibase(new InteractivePlayer(game, get_config_section(), pn, false));
 			std::unique_ptr<GameController> ctrl(new SinglePlayerGameController(game, true, pn));
 
-            std::vector<std::string> tipstexts{"general_game", "singleplayer"};
+			std::vector<std::string> tipstexts{"general_game", "singleplayer"};
 			if (sp.has_players_tribe()) {
 				tipstexts.push_back(sp.get_players_tribe());
 			}
@@ -1464,7 +1464,7 @@ void WLApplication::replay() {
 	}
 
 	try {
-        game.create_loader_ui({"general_game"});
+		game.create_loader_ui({"general_game"});
 		game.step_loader_ui(_("Loading…"));
 
 		game.set_ibase(new InteractiveSpectator(game, get_config_section()));

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1353,22 +1353,18 @@ bool WLApplication::new_game() {
 			// the chat
 			game.set_ibase(new InteractivePlayer(game, get_config_section(), pn, false));
 			std::unique_ptr<GameController> ctrl(new SinglePlayerGameController(game, true, pn));
-			UI::ProgressWindow loader_ui;
-			game.set_loader_ui(&loader_ui);
-			std::vector<std::string> tipstext;
-			tipstext.push_back("general_game");
-			tipstext.push_back("singleplayer");
-			if (sp.has_players_tribe()) {
-				tipstext.push_back(sp.get_players_tribe());
-			}
-			GameTips tips(loader_ui, tipstext);
 
-			loader_ui.step(_("Preparing game"));
+            std::vector<std::string> tipstexts{"general_game", "singleplayer"};
+			if (sp.has_players_tribe()) {
+				tipstexts.push_back(sp.get_players_tribe());
+			}
+			game.create_loader_ui(tipstexts);
+
+			game.step_loader_ui(_("Preparing game"));
 
 			game.set_game_controller(ctrl.get());
 			game.init_newgame(sp.settings());
 			game.run(Widelands::Game::NewNonScenario, "", false, "single_player");
-			game.set_loader_ui(nullptr);
 		} catch (const std::exception& e) {
 			log("Fatal exception: %s\n", e.what());
 			emergency_save(game);
@@ -1469,13 +1465,8 @@ void WLApplication::replay() {
 	}
 
 	try {
-		UI::ProgressWindow loader_ui;
-		game.set_loader_ui(&loader_ui);
-		std::vector<std::string> tipstext;
-		tipstext.push_back("general_game");
-		GameTips tips(loader_ui, tipstext);
-
-		loader_ui.step(_("Loading…"));
+        game.create_loader_ui({"general_game"});
+		game.step_loader_ui(_("Loading…"));
 
 		game.set_ibase(new InteractiveSpectator(game, get_config_section()));
 		game.set_write_replay(false);
@@ -1484,7 +1475,6 @@ void WLApplication::replay() {
 		game.save_handler().set_allow_saving(false);
 
 		game.run(Widelands::Game::Loaded, "", true, "replay");
-		game.set_loader_ui(nullptr);
 	} catch (const std::exception& e) {
 		log("Fatal Exception: %s\n", e.what());
 		emergency_save(game);

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1357,7 +1357,7 @@ bool WLApplication::new_game() {
 			if (sp.has_players_tribe()) {
 				tipstexts.push_back(sp.get_players_tribe());
 			}
-			game.create_loader_ui(tipstexts);
+			game.create_loader_ui(tipstexts, false);
 
 			game.step_loader_ui(_("Preparing game"));
 
@@ -1464,7 +1464,7 @@ void WLApplication::replay() {
 	}
 
 	try {
-		game.create_loader_ui({"general_game"});
+		game.create_loader_ui({"general_game"}, true);
 		game.step_loader_ui(_("Loading…"));
 
 		game.set_ibase(new InteractiveSpectator(game, get_config_section()));

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -93,7 +93,6 @@
 #include "ui_fsmenu/singleplayer.h"
 #include "wlapplication_messages.h"
 #include "wlapplication_options.h"
-#include "wui/game_tips.h"
 #include "wui/interactive_player.h"
 #include "wui/interactive_spectator.h"
 

--- a/src/wui/CMakeLists.txt
+++ b/src/wui/CMakeLists.txt
@@ -175,6 +175,23 @@ wl_library(wui_waresdisplay
 )
 
 
+wl_library(wui_game_tips
+  SRCS
+    game_tips.cc
+    game_tips.h
+  USES_SDL2
+  DEPENDS
+    base_i18n
+    graphic
+    graphic_fonthandler
+    graphic_text_layout
+    io_fileread
+    scripting_lua_table
+    scripting_lua_interface
+    ui_basic
+)
+
+
 wl_library(wui
   SRCS
     actionconfirm.cc
@@ -211,8 +228,6 @@ wl_library(wui
     game_options_sound_menu.h
     game_summary.cc
     game_summary.h
-    game_tips.cc
-    game_tips.h
     general_statistics_menu.cc
     general_statistics_menu.h
     helpwindow.cc
@@ -293,7 +308,6 @@ wl_library(wui
     graphic_text
     graphic_text_layout
     graphic_toolbar_imageset
-    io_fileread
     io_filesystem
     io_profile
     logic

--- a/src/wui/CMakeLists.txt
+++ b/src/wui/CMakeLists.txt
@@ -185,7 +185,6 @@ wl_library(wui_game_tips
     graphic
     graphic_fonthandler
     graphic_text_layout
-    io_fileread
     scripting_lua_table
     scripting_lua_interface
     ui_basic

--- a/src/wui/game_main_menu_save_game.cc
+++ b/src/wui/game_main_menu_save_game.cc
@@ -245,7 +245,7 @@ bool GameMainMenuSaveGame::save_game(std::string filename, bool binary) {
 	// Try saving the game.
 	Widelands::Game& game = igbase().game();
 
-	game.create_loader_ui({"general_game"});
+	game.create_loader_ui({"general_game"}, true);
 
 	GenericSaveHandler gsh(
 	   [&game](FileSystem& fs) {

--- a/src/wui/game_main_menu_save_game.cc
+++ b/src/wui/game_main_menu_save_game.cc
@@ -244,6 +244,9 @@ bool GameMainMenuSaveGame::save_game(std::string filename, bool binary) {
 
 	// Try saving the game.
 	Widelands::Game& game = igbase().game();
+
+    game.create_loader_ui({"general_game"});
+
 	GenericSaveHandler gsh(
 	   [&game](FileSystem& fs) {
 		   Widelands::GameSaver gs(fs, game);
@@ -251,6 +254,8 @@ bool GameMainMenuSaveGame::save_game(std::string filename, bool binary) {
 		},
 	   complete_filename, binary ? FileSystem::ZIP : FileSystem::DIR);
 	GenericSaveHandler::Error error = gsh.save();
+
+    game.remove_loader_ui();
 
 	// If only the temporary backup couldn't be deleted, we still treat it as
 	// success. Automatic cleanup will deal with later. No need to bother the

--- a/src/wui/game_main_menu_save_game.cc
+++ b/src/wui/game_main_menu_save_game.cc
@@ -245,7 +245,7 @@ bool GameMainMenuSaveGame::save_game(std::string filename, bool binary) {
 	// Try saving the game.
 	Widelands::Game& game = igbase().game();
 
-    game.create_loader_ui({"general_game"});
+	game.create_loader_ui({"general_game"});
 
 	GenericSaveHandler gsh(
 	   [&game](FileSystem& fs) {
@@ -255,7 +255,7 @@ bool GameMainMenuSaveGame::save_game(std::string filename, bool binary) {
 	   complete_filename, binary ? FileSystem::ZIP : FileSystem::DIR);
 	GenericSaveHandler::Error error = gsh.save();
 
-    game.remove_loader_ui();
+	game.remove_loader_ui();
 
 	// If only the temporary backup couldn't be deleted, we still treat it as
 	// success. Automatic cleanup will deal with later. No need to bother the

--- a/src/wui/game_tips.cc
+++ b/src/wui/game_tips.cc
@@ -26,7 +26,6 @@
 #include "graphic/graphic.h"
 #include "graphic/rendertarget.h"
 #include "graphic/text_layout.h"
-#include "io/fileread.h"
 #include "scripting/lua_interface.h"
 #include "scripting/lua_table.h"
 

--- a/src/wui/game_tips.cc
+++ b/src/wui/game_tips.cc
@@ -77,7 +77,7 @@ void GameTips::load_tips(const std::string& name) {
 }
 
 void GameTips::update(bool repaint) {
-	uint8_t ticks = SDL_GetTicks();
+	uint32_t ticks = SDL_GetTicks();
 	if (ticks >= (lastUpdated_ + updateAfter_)) {
 		const uint32_t next = rand() % tips_.size();
 		if (next == lastTip_)


### PR DESCRIPTION
* ProgressWindow and GameTips are now managed by EditorGameGase.
  This avoids ownership conflicts and crashes when we run without window.
* Show game tips on scenarios that don't have a special background image
* Remove ProgressWindow as early as possible
* Don't show progress on autosaves and scenario objective saves
* Test website binaries on Travis.
