### PR TITLE
Fix wares stuck on flag after loading savegame

### DIFF
--- a/src/logic/map_objects/tribes/carrier.cc
+++ b/src/logic/map_objects/tribes/carrier.cc
@@ -556,8 +556,8 @@ void Carrier::Loader::load(FileRead& fr) {
 		// TODO(GunChleoc): Remove savegame compatibility after Build 21.
 		if (packet_version <= kCurrentPacketVersion && packet_version >= 1) {
 			Carrier& carrier = get<Carrier>();
-			// TODO(GunChleoc): std::min is for savegame compatibility. Remove after Build 21.
-			carrier.promised_pickup_to_ = std::min(-1, fr.signed_32());
+			// TODO(GunChleoc): std::max is for savegame compatibility. Remove after Build 21.
+			carrier.promised_pickup_to_ = std::max(-1, fr.signed_32());
 		} else {
 			throw UnhandledVersionError("Carrier", packet_version, kCurrentPacketVersion);
 		}


### PR DESCRIPTION
This fixes a bug that causes wares to be stuck on a flag and never picked up after loading a game. (see #1085 and #3440)

This is a partial fix. It should prevent the bug from happening when loading a good savegame, [like this one](https://github.com/widelands/widelands/files/4240001/ware_stuck_at_flag_1.wgf.zip).

However, if the game was saved again after this bug had already occured (like [this one](https://github.com/widelands/widelands/files/4240002/ware_stuck_at_flag_2.wgf.zip)) then the savegame is broken and needs an additional fix. It would probably need to scan all wares at flags after loading and detect those that are marked as acked but have no carrier coming for them.