### PR TITLE
Don't start zoom animation if target zoom is the same as current

### DIFF
--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -543,8 +543,12 @@ void MapView::zoom_around(float new_zoom,
 	}
 
 	case Transition::Smooth: {
+		if (view_plans_.empty() && view_.zoom_near(new_zoom)) {
+			// We're already at the target zoom...
+			return;
+		}
 		if (!view_plans_.empty() && view_plans_.back().back().view.zoom_near(new_zoom)) {
-			// We're already there
+			// ...or on the way there.
 			return;
 		}
 		const int w = get_w();


### PR DESCRIPTION
Fixes #3660