### PR TITLE
add HQ Hunter win condition

### DIFF
--- a/data/scripting/win_conditions/defeat_hq.lua
+++ b/data/scripting/win_conditions/defeat_hq.lua
@@ -1,0 +1,60 @@
+-- =======================================================================
+--                         Defeat all Win condition
+-- =======================================================================
+
+include "scripting/coroutine.lua" -- for sleep
+include "scripting/win_conditions/win_condition_functions.lua"
+
+set_textdomain("win_conditions")
+
+include "scripting/win_conditions/win_condition_texts.lua"
+
+local wc_name = "HQ Hunter"
+-- This needs to be exactly like wc_name, but localized, because wc_name
+-- will be used as the key to fetch the translation in C++
+local wc_descname = _("HQ Hunter")
+local wc_version = 1
+local wc_desc = _ "The tribe or team that can destroy all other headquarters wins the game!"
+return {
+    name = wc_name,
+    description = wc_desc,
+    peaceful_mode_allowed = false,
+    func = function()
+        local plrs = wl.Game().players
+
+        -- set the objective with the game type for all players
+        broadcast_objective("win_condition", wc_descname, wc_desc)
+
+        -- Iterate all players, if one is defeated, remove him
+        -- from the list, send him a defeated message and give him full vision
+        repeat
+            sleep(5000)
+
+            for idx,p in ipairs(plrs) do
+                if (#p:get_buildings("barbarians_headquarters") + #p:get_buildings("atlanteans_headquarters") + #p:get_buildings("empire_headquarters") + #p:get_buildings("frisians_headquarters")) == 0 then
+                    for idx,b in ipairs(p:get_buildings("barbarians_warehouse")) do
+                        b:destroy()
+                    end
+                    for idx,b in ipairs(p:get_buildings("atlanteans_warehouse")) do
+                        b:destroy()
+                    end
+                    for idx,b in ipairs(p:get_buildings("empire_warehouse")) do
+                        b:destroy()
+                    end
+                    for idx,b in ipairs(p:get_buildings("frisians_warehouse")) do
+                        b:destroy()
+                    end
+                end
+            end
+            check_player_defeated(plrs, lost_game.title, lost_game.body, wc_descname, wc_version)
+        until count_factions(plrs) <= 1
+
+        -- Send congratulations to all remaining players
+        broadcast_win(plrs,
+        won_game.title,
+        won_game.body,{},
+        wc_descname, wc_version
+        )
+
+    end,
+}

--- a/data/scripting/win_conditions/defeat_hq.lua
+++ b/data/scripting/win_conditions/defeat_hq.lua
@@ -3,6 +3,7 @@
 -- =======================================================================
 
 include "scripting/coroutine.lua" -- for sleep
+include "scripting/table.lua"
 include "scripting/win_conditions/win_condition_functions.lua"
 
 set_textdomain("win_conditions")
@@ -31,17 +32,22 @@ return {
             sleep(5000)
 
             for idx,p in ipairs(plrs) do
-                if (#p:get_buildings("barbarians_headquarters") + #p:get_buildings("atlanteans_headquarters") + #p:get_buildings("empire_headquarters") + #p:get_buildings("frisians_headquarters")) == 0 then
-                    for idx,b in ipairs(p:get_buildings("barbarians_warehouse")) do
-                        b:destroy()
-                    end
-                    for idx,b in ipairs(p:get_buildings("atlanteans_warehouse")) do
-                        b:destroy()
-                    end
-                    for idx,b in ipairs(p:get_buildings("empire_warehouse")) do
-                        b:destroy()
-                    end
-                    for idx,b in ipairs(p:get_buildings("frisians_warehouse")) do
+                if (
+                    #p:get_buildings("barbarians_headquarters") + 
+                    #p:get_buildings("atlanteans_headquarters") + 
+                    #p:get_buildings("empire_headquarters") + 
+                    #p:get_buildings("frisians_headquarters")
+                ) == 0 then
+                    for idx,b in ipairs(array_combine(
+                        p:get_buildings("barbarians_warehouse"),
+                        p:get_buildings("atlanteans_warehouse"),
+                        p:get_buildings("empire_warehouse"),
+                        p:get_buildings("frisians_warehouse"),
+                        p:get_buildings("barbarians_port"),
+                        p:get_buildings("atlanteans_port"),
+                        p:get_buildings("empire_port"),
+                        p:get_buildings("frisians_port")
+                    )) do
                         b:destroy()
                     end
                 end

--- a/data/scripting/win_conditions/init.lua
+++ b/data/scripting/win_conditions/init.lua
@@ -8,6 +8,7 @@ return {
    dirname .. "territorial_time.lua",
    dirname .. "territorial_lord.lua",
    dirname .. "defeat_all.lua",
+   dirname .. "defeat_hq.lua",
    dirname .. "endless_game.lua",
    dirname .. "endless_game_fogless.lua",
 }


### PR DESCRIPTION
As suggested in the [forum](https://www.widelands.org/forum/topic/4787/) I added a win condition where a player is defeated when he looses his headquarter.

Detecting the missing HQ and then destroying all warehouses was the only way I found to achieve this. If there is a simpler possibility I'm open for suggestions of better implementations.

Also if there is a way to get a building type across tribes ("get all warehouses of player xy, no matter which tribe the player is") I'd like to change it to that one.