### PR TITLE
Quickfix for shippingitems without destination

### DIFF
--- a/src/economy/portdock.cc
+++ b/src/economy/portdock.cc
@@ -284,7 +284,8 @@ void PortDock::update_shippingitem(Game& game, Worker& worker) {
 	}
 }
 
-std::list<ShippingItem>::iterator PortDock::update_shippingitem(Game& game, std::list<ShippingItem>::iterator it) {
+std::list<ShippingItem>::iterator
+PortDock::update_shippingitem(Game& game, std::list<ShippingItem>::iterator it) {
 	it->update_destination(game, *this);
 
 	const PortDock* dst = it->get_destination(game);
@@ -372,7 +373,8 @@ void PortDock::ship_arrived(Game& game, Ship& ship) {
 		}
 	}
 
-	for (auto it = waiting_.begin(); it != waiting_.end(); it = update_shippingitem(game, it));
+	for (auto it = waiting_.begin(); it != waiting_.end(); it = update_shippingitem(game, it))
+		;
 
 	ship.pop_destination(game, *this);
 	fleet_->push_next_destinations(game, ship, *this);

--- a/src/economy/portdock.cc
+++ b/src/economy/portdock.cc
@@ -373,6 +373,8 @@ void PortDock::ship_arrived(Game& game, Ship& ship) {
 		}
 	}
 
+	// TODO(Nordfriese): Quick and dirty fix to make #3683 #3544 #503 happen less often.
+	// The real fix will be part of Noordfrees:shipping-tweaks
 	for (auto it = waiting_.begin(); it != waiting_.end(); it = update_shippingitem(game, it))
 		;
 

--- a/src/economy/portdock.cc
+++ b/src/economy/portdock.cc
@@ -284,7 +284,7 @@ void PortDock::update_shippingitem(Game& game, Worker& worker) {
 	}
 }
 
-void PortDock::update_shippingitem(Game& game, std::list<ShippingItem>::iterator it) {
+std::list<ShippingItem>::iterator PortDock::update_shippingitem(Game& game, std::list<ShippingItem>::iterator it) {
 	it->update_destination(game, *this);
 
 	const PortDock* dst = it->get_destination(game);
@@ -296,11 +296,11 @@ void PortDock::update_shippingitem(Game& game, std::list<ShippingItem>::iterator
 		if (ships_coming_.empty()) {
 			set_need_ship(game, true);
 		}
+		return ++it;
 	} else {
 		it->set_location(game, warehouse_);
 		it->end_shipping(game);
-		*it = waiting_.back();
-		waiting_.pop_back();
+		return waiting_.erase(it);
 	}
 }
 
@@ -371,6 +371,8 @@ void PortDock::ship_arrived(Game& game, Ship& ship) {
 			return;
 		}
 	}
+
+	for (auto it = waiting_.begin(); it != waiting_.end(); it = update_shippingitem(game, it));
 
 	ship.pop_destination(game, *this);
 	fleet_->push_next_destinations(game, ship, *this);

--- a/src/economy/portdock.h
+++ b/src/economy/portdock.h
@@ -139,7 +139,7 @@ private:
 
 	void init_fleet(EditorGameBase& egbase);
 	void set_fleet(ShipFleet* fleet);
-	void update_shippingitem(Game&, std::list<ShippingItem>::iterator);
+	std::list<ShippingItem>::iterator update_shippingitem(Game&, std::list<ShippingItem>::iterator);
 	void set_need_ship(Game&, bool need);
 
 	void load_wares(Game&, Ship&);


### PR DESCRIPTION
Quick & dirty fix for certain variants of #3683 #3544 #503 , just to make it possible again to play without annoying segfaults after losing a port.
Real fix is being developed in a more complex branch that still needs some time.