### PR TITLE
Sphinx documentation: Corrected typo

### DIFF
--- a/src/scripting/lua_bases.cc
+++ b/src/scripting/lua_bases.cc
@@ -879,7 +879,7 @@ int LuaPlayerBase::conquer(lua_State* L) {
 
       :arg name: name of the worker to get
       :type name: :class:`string`.
-      :returns: the number of wares
+      :returns: the number of workers
 */
 // UNTESTED
 int LuaPlayerBase::get_workers(lua_State* L) {


### PR DESCRIPTION
Corrected typo in documentation of PlayerBase::get_workers() method
Issue: #3775