### PR TITLE
More seafaring tutorial improvements

### DIFF
--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
@@ -86,3 +86,15 @@ function get_waterway_fields(area)
    end
    return fields
 end
+
+-- Scroll to first building of `which` type
+-- Return prior center map pixel of the MapView,
+--  otherwise nil if no building exists
+function scroll_to_first_building(which)
+   local buildings = plr:get_buildings(which)
+   if #buildings > 0 then
+      local first = buildings[1]
+      return scroll_to_field(first.fields[1])
+   end
+   return nil
+end

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
@@ -94,7 +94,7 @@ function scroll_to_first_building(which)
    local buildings = plr:get_buildings(which)
    if #buildings > 0 then
       local first = buildings[1]
-      return scroll_to_field(first.fields[1])
+      return wait_for_roadbuilding_and_scroll(first.fields[1])
    end
    return nil
 end

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
@@ -54,7 +54,8 @@ function get_swimmable_fields()
    for x = 0, (map.width - 1) do
       for y = 0, (map.height - 1) do
          local f = map:get_field(x, y)
-         if f:has_caps("swimmable") then
+         -- don't use f:has_caps("swimmable"), ferry can sit on a beach
+         if f.terr == "summer_water" or f.terd == "summer_water" then
             table.insert(fields, f)
          end
       end
@@ -62,7 +63,7 @@ function get_swimmable_fields()
    return fields
 end
 
--- Returns array of fields where bob is "atlanteans_ferry"
+-- Returns array of fields in area where bob is "atlanteans_ferry"
 function get_fields_with_ferry(area)
    local fields = {}
    for i,field in pairs(area) do
@@ -70,6 +71,17 @@ function get_fields_with_ferry(area)
          if bob.descr.name == "atlanteans_ferry" then
             table.insert(fields, field)
          end
+      end
+   end
+   return fields
+end
+
+-- Returns array of fields in area of "waterway" type
+function get_waterway_fields(area)
+   local fields = {}
+   for i,field in pairs(area) do
+      if field.immovable and field.immovable.descr.type_name == "waterway" then
+         table.insert(fields, field)
       end
    end
    return fields

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/helper_functions.lua
@@ -47,3 +47,30 @@ function construction_started_region(region, building_desc)
    end
    return false
 end
+
+-- Returns array of all swimmable fields in the map
+function get_swimmable_fields()
+   local fields = {}
+   for x = 0, (map.width - 1) do
+      for y = 0, (map.height - 1) do
+         local f = map:get_field(x, y)
+         if f:has_caps("swimmable") then
+            table.insert(fields, f)
+         end
+      end
+   end
+   return fields
+end
+
+-- Returns array of fields where bob is "atlanteans_ferry"
+function get_fields_with_ferry(area)
+   local fields = {}
+   for i,field in pairs(area) do
+      for j,bob in pairs(field.bobs) do
+         if bob.descr.name == "atlanteans_ferry" then
+            table.insert(fields, field)
+         end
+      end
+   end
+   return fields
+end

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
@@ -18,6 +18,7 @@ sf = map.player_slots[1].starting_field
 second_port_field = map:get_field(37, 27)
 shipyard_tip = map:get_field(37, 41)
 port_on_island = map:get_field(102, 36)
+iron_on_island = map:get_field(97,35)
 additional_port_space = map:get_field(85, 5)
 castle_field = map:get_field(36, 20)
 waterway_field = map:get_field(27, 95)

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
@@ -30,6 +30,8 @@ include "map:scripting/texts.lua"
 include "map:scripting/helper_functions.lua"
 include "map:scripting/helper_functions_demonstration.lua"
 
+swimmable_fields = get_swimmable_fields()
+
 include "map:scripting/starting_conditions.lua"
 
 include "map:scripting/mission_thread.lua"

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
@@ -23,6 +23,7 @@ castle_field = map:get_field(36, 20)
 waterway_field = map:get_field(27, 95)
 gold_mine = map:get_field(23, 102)
 shore = map:get_field(34, 68)
+home_bay = map:get_field(39, 34)
 
 include "map:scripting/texts.lua"
 include "map:scripting/helper_functions.lua"

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -144,8 +144,13 @@ function complete_ferries()
 end
 
 function watch_ferry_production()
-   -- warn player about over-producing
-   while plr:get_workers("atlanteans_ferry") < 1 do sleep(3000) end
+   -- warn player about over-producing after third ferry
+   while #get_fields_with_ferry(swimmable_fields) < 3 do sleep(3000) end
+   local ferry_yards = plr:get_buildings("atlanteans_ferry_yard")
+   if #ferry_yards > 0 then
+      local yard = ferry_yards[1]
+      scroll_to_field(yard.fields[1])
+   end
    message_box_objective(plr, ferry_yard_production)
 end
 

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -137,21 +137,32 @@ function complete_gold_mine()
    end
 end
 
-function complete_ferries()
-   -- wait until 4 ferries are assigned to waterways
-   while plr:get_workers("atlanteans_ferry") < 4 do sleep(3000) end
-   ferries_done = true
-end
-
-function watch_ferry_production()
+function waterways_and_ferries()
    -- warn player about over-producing after third ferry
    while #get_fields_with_ferry(swimmable_fields) < 3 do sleep(3000) end
+
    local ferry_yards = plr:get_buildings("atlanteans_ferry_yard")
    if #ferry_yards > 0 then
       local yard = ferry_yards[1]
       scroll_to_field(yard.fields[1])
    end
    message_box_objective(plr, ferry_yard_production)
+
+   -- wait until 4 ferries are located on waterways
+   local pass, ff, wwf = 0, {}, {}
+   -- three passes to eliminate ferry crossing other ferry's waterway
+   while pass < 3 do
+      sleep(3000)
+      ff = get_fields_with_ferry(swimmable_fields)
+      wwf = get_waterway_fields(ff)
+      if #wwf >= 4 then
+         pass = pass + 1
+      else
+         pass = 0
+      end
+   end
+
+   ferries_done = true
 end
 
 function waterways()
@@ -185,8 +196,7 @@ function waterways()
    local o = message_box_objective(plr, ferry_5)
    -- check for goldmine, and waterways with ferries
    run(complete_gold_mine)
-   run(complete_ferries)
-   watch_ferry_production()
+   waterways_and_ferries()
    while not (gold_mine_done and ferries_done) do sleep(3000) end
    set_objective_done(o)
 

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -38,7 +38,7 @@ function watch_ship_production()
    -- warn player about over-producing
    while #plr:get_ships() < 2 do sleep(30*1000) end
    local ship2 = plr:get_ships()[2]
-   scroll_to_field(ship2.field)
+   wait_for_roadbuilding_and_scroll(ship2.field)
    message_box_objective(plr, shipyard_production(ship2.shipname))
 end
 
@@ -70,7 +70,7 @@ end
 
 function expedition()
    sleep(2000)
-   scroll_to_field(sf)
+   wait_for_roadbuilding_and_scroll(sf)
    message_box_objective(plr, expedition1)
    local o = message_box_objective(plr, expedition2)
 

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -147,24 +147,13 @@ end
 
 function complete_ferries()
    -- wait until 4 ferries are assigned to waterways
-   local n = 0
-   -- TODO: make oneline
-   while n < 4 do
-      sleep(3000)
-      -- get_workers reports assigned counts
-      n = plr:get_workers("atlanteans_ferry")
-   end
+   while plr:get_workers("atlanteans_ferry") < 4 do sleep(3000) end
    ferries_done = true
 end
 
 function watch_ferry_production()
    -- warn player about over-producing
-   local n = 0
-   -- TODO: make oneline
-   while n < 1 do
-      sleep(3000)
-      n = plr:get_workers("atlanteans_ferry")
-   end
+   while plr:get_workers("atlanteans_ferry") < 1 do sleep(3000) end
    message_box_objective(plr, ferry_yard_production)
 end
 

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -113,7 +113,6 @@ end
 function iron_mine()
    local o = message_box_objective(plr, expedition5)
    while #plr:get_buildings("atlanteans_ironmine") < 1 do sleep(3000) end
-   print(string.format("get_buildings('atlanteans_ironmine') = %d", #plr:get_buildings("atlanteans_ironmine")))
    set_objective_done(o)
    expedition_done = true
 end

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -54,7 +54,10 @@ function build_ships()
    while #plr:get_buildings("atlanteans_shipyard") < 1 do sleep(1000) end
    set_objective_done(o)
 
+   -- scroll to shipyard and back
+   local prior_center = scroll_to_first_building("atlanteans_shipyard")
    local o = message_box_objective(plr, tell_about_ships)
+   if prior_center then scroll_to_map_pixel(prior_center) end
 
    -- we only wait for one ship and a bit longer because it takes long enough
    while #plr:get_ships() < 1 do sleep(30*1000) end
@@ -67,6 +70,7 @@ end
 
 function expedition()
    sleep(2000)
+   scroll_to_field(sf)
    message_box_objective(plr, expedition1)
    local o = message_box_objective(plr, expedition2)
 
@@ -140,12 +144,7 @@ end
 function waterways_and_ferries()
    -- warn player about over-producing after third ferry
    while #get_fields_with_ferry(swimmable_fields) < 3 do sleep(3000) end
-
-   local ferry_yards = plr:get_buildings("atlanteans_ferry_yard")
-   if #ferry_yards > 0 then
-      local yard = ferry_yards[1]
-      scroll_to_field(yard.fields[1])
-   end
+   scroll_to_first_building("atlanteans_ferry_yard")
    message_box_objective(plr, ferry_yard_production)
 
    -- wait until 4 ferries are located on waterways

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -36,13 +36,7 @@ end
 
 function watch_ship_production()
    -- warn player about over-producing
-   local ship1 = plr:get_ships()[1]
-   print(ship1.shipname)
-   local n = 0
-   while n < 2 do
-      sleep(30*1000)
-      n = #plr:get_ships()
-   end
+   while #plr:get_ships() < 2 do sleep(30*1000) end
    local ship2 = plr:get_ships()[2]
    scroll_to_field(ship2.field)
    message_box_objective(plr, shipyard_production(ship2.shipname))

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -125,17 +125,16 @@ function complete_ferry_yard()
 end
 
 function complete_gold_mine()
-   local field_for_mine = map:get_field(20, 102):region(5)
-   while field_for_mine do
+   local fields_for_mine = map:get_field(20, 102):region(5)
+   while not gold_mine_done do
       sleep(3000)
-      for i,f in pairs(field_for_mine) do
+      for i,f in pairs(fields_for_mine) do
          if f.immovable and f.immovable.descr.name == "atlanteans_goldmine" then
-            field_for_mine = nil
+            gold_mine_done = true
             break
          end
       end
    end
-   gold_mine_done = true
 end
 
 function complete_ferries()

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -129,7 +129,6 @@ function complete_ferries()
       sleep(3000)
       -- get_workers reports assigned counts
       n = plr:get_workers("atlanteans_ferry")
-      print(string.format("### complete_ferries: get_workers('atlanteans_ferry'): %d", n))
    end
    ferries_done = true
 end
@@ -140,7 +139,6 @@ function watch_ferry_production()
    while n < 1 do
       sleep(3000)
       n = plr:get_workers("atlanteans_ferry")
-      print(string.format("### watch_ferry_production: get_workers('atlanteans_ferry'): %d", n))
    end
    message_box_objective(plr, ferry_yard_production)
 end

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -34,6 +34,20 @@ function build_port()
    set_objective_done(o)
 end
 
+function watch_ship_production()
+   -- warn player about over-producing
+   local ship1 = plr:get_ships()[1]
+   print(ship1.shipname)
+   local n = 0
+   while n < 2 do
+      sleep(30*1000)
+      n = #plr:get_ships()
+   end
+   local ship2 = plr:get_ships()[2]
+   scroll_to_field(ship2.field)
+   message_box_objective(plr, shipyard_production(ship2.shipname))
+end
+
 function build_ships()
    sleep(20*1000)
    local o = message_box_objective(plr, tell_about_shipyard)
@@ -50,10 +64,10 @@ function build_ships()
 
    -- we only wait for one ship and a bit longer because it takes long enough
    while #plr:get_ships() < 1 do sleep(30*1000) end
-   sleep(5*60*1000)
+   run(watch_ship_production)
+   sleep(3*60*1000)
 
    set_objective_done(o)
-
    expedition()
 end
 

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/mission_thread.lua
@@ -92,7 +92,7 @@ function expedition()
    set_objective_done(o)
 
    -- places 5 signs with iron to show the player he really found some iron ore
-   local fields = map:get_field(97,35):region(3)
+   local fields = iron_on_island:region(3)
    for i=1,5 do
       local successful = false
       while not successful do
@@ -112,13 +112,22 @@ end
 function conclude_expedition()
    additional_port_space.terr = "desert_steppe" -- make it land again so that the player can build a port
    message_box_objective(plr, expedition4)
+   sleep(3000)
+   iron_mine()
+end
+
+function iron_mine()
+   local o = message_box_objective(plr, expedition5)
+   while #plr:get_buildings("atlanteans_ironmine") < 1 do sleep(3000) end
+   print(string.format("get_buildings('atlanteans_ironmine') = %d", #plr:get_buildings("atlanteans_ironmine")))
+   set_objective_done(o)
    expedition_done = true
 end
 
 function complete_ferry_yard()
    plr:allow_buildings{"atlanteans_ferry_yard"}
    local o = message_box_objective(plr, ferry_2)
-   while #plr:get_buildings("atlanteans_ferry_yard") < 1 do sleep(200) end
+   while #plr:get_buildings("atlanteans_ferry_yard") < 1 do sleep(3000) end
    set_objective_done(o)
 end
 
@@ -139,6 +148,7 @@ end
 function complete_ferries()
    -- wait until 4 ferries are assigned to waterways
    local n = 0
+   -- TODO: make oneline
    while n < 4 do
       sleep(3000)
       -- get_workers reports assigned counts
@@ -150,6 +160,7 @@ end
 function watch_ferry_production()
    -- warn player about over-producing
    local n = 0
+   -- TODO: make oneline
    while n < 1 do
       sleep(3000)
       n = plr:get_workers("atlanteans_ferry")
@@ -168,6 +179,8 @@ function waterways()
    local area = shore:region(37)
    while not construction_started_region(area, "atlanteans_ferry_yard") do sleep(1000) end
    sleep(5000)
+   -- place resource indicator again in case player preferred ships/exploring
+   map:place_immovable("atlanteans_resi_gold_2", gold_mine, "tribes")
 
    message_box_objective(plr, ferry_3)
    sleep(500)
@@ -189,8 +202,8 @@ function waterways()
    run(complete_ferries)
    watch_ferry_production()
    while not (gold_mine_done and ferries_done) do sleep(3000) end
-
    set_objective_done(o)
+
    message_box_objective(plr, ferry_6)
    waterways_done = true
 end

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -164,7 +164,7 @@ expedition3 = {
    )
 }
 
-conclusion = {
+expedition4 = {
    position = "topright",
    field = port_on_island,
    title = _"Conclusion",
@@ -184,12 +184,13 @@ ferry_1 = {
    title = _"There is more to it…",
    body = (
       h1(_"Another gold mountain") ..
-      p(_[[Now that you have learned all about ships, there is another way of water-based transport I would like to teach you.]]) ..
+      p(_[[We have some time before your shipyard is finished. There is another way of water-based transport I would like to teach you.]]) ..
       p(_[[Ships have the advantage that they can carry large quantities of wares and workers at a time, but unfortunately their destinations are limited to a handful of spaces suited for a port.]]) ..
       p(_[[Look at this valley here in the far south. We have found a mountain with gold down here and would like to mine ores from it as well. But the streams seperating it from our main colony are too wide to build bridges and too narrow for ships to pass them. Our roads would have to take long curves, which slows down ware transport a lot.]])
    ),
    h = 350
 }
+
 ferry_2 = {
    position = "topright",
    field = shore,
@@ -210,6 +211,7 @@ ferry_2 = {
       li_arrow(_[[You need to build the ferry yard close to the shore, otherwise it won’t be able to build ferries there.]])
    )
 }
+
 ferry_3 = {
    position = "topright",
    title = _"There is more to it…",
@@ -222,6 +224,7 @@ ferry_3 = {
    ),
    h = 350
 }
+
 ferry_4 = {
    position = "topright",
    title = _"There is more to it…",
@@ -231,6 +234,7 @@ ferry_4 = {
    ),
    h = 150
 }
+
 ferry_5 = {
    field = gold_mine,
    position = "topright",
@@ -250,19 +254,32 @@ ferry_5 = {
       li_arrow(_[[The only rule for waterway placement is that the two triangles directly adjacent to each segment of the waterway have to be water, and the entire path needs to be within your territory.]])
    )
 }
+
 ferry_6 = {
    position = "topright",
    title = _"Conclusion",
    body = (
       h1(_"About Ferries") ..
       p(_[[Now there are only a few more things I would like you to keep in mind whenever using ferries.]]) ..
-      p(_[[Do remember to stop your ferry yard when you don’t need any new ferries to be produced. As long as a ferry services a waterway, its lifetime is unlimited, but unemployed ferries will rot away and eventually sink.]]) ..
       p(_[[Never forget that these rowboats are too small to carry workers. You can use them as shortcuts for ware transport within parts of your territory, but not to claim regions you can reach neither by road nor by ship. Never cut all your roads between two places connected by waterways unless you are certain no worker will ever have to walk there.]]) ..
       p(_[[And if your waterways present a significant shortcut between your road networks, your economy will tend to send many wares over the waterway. As a waterway can hold only one ferry – unlike roads, which receive a second carrier if they are very busy –, and as they often tend to be rather longer than the two or three fields recommended for roads, there is always a risk of waterways becoming severe bottlenecks in your economy. Try to build several of them in parallel to distribute the strain. If this is not possible, it is in some cases even more efficient not to use waterways.]])
    ),
    h = 450
 }
-ferry_7 = {
+
+ferry_yard_production = {
+   position = "topright",
+   title = _"Ferry yard production",
+   body = (
+      h1(_"Rowboat is ready") ..
+      p(_[[Your first ferry line has opened.]]) ..
+      p(_[[Do remember to stop your ferry yard when you don’t need any new ferries to be produced. As long as a ferry services a waterway, its lifetime is unlimited, but unemployed ferries will rot away and eventually sink.]]) ..
+      li_image("images/ui_basic/stop.png", _[[This is the icon for stopping production. You will find it in the building window.]])
+   ),
+   h = 250
+}
+
+congratulation = {
    position = "topright",
    title = _"Congratulations",
    body = (

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -304,7 +304,7 @@ ferry_yard_production = {
    position = "topright",
    title = _"Ferry yard production",
    body = (
-      h1(_"Rowboat is ready") ..
+      h1(_"Ferry is ready") ..
       p(_[[Your first ferry line has opened.]]) ..
       p(_[[Do remember to stop your ferry yard when you don’t need any new ferries to be produced. As long as a ferry services a waterway, its lifetime is unlimited, but unemployed ferries will rot away and eventually sink.]]) ..
       li_image("images/ui_basic/stop.png", _[[This is the icon for stopping production. You will find it in the building window.]])

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -217,7 +217,7 @@ ferry_1 = {
    title = _"There is more to it…",
    body = (
       h1(_"Another gold mountain") ..
-      p(_[[We have some time before your shipyard is finished. There is another way of water-based transport I would like to teach you.]]) ..
+      p(_[[It will take some time for your shipyard to build some ships. While we’re waiting for them, there is another way of water-based transport I would like to teach you.]]) ..
       p(_[[Ships have the advantage that they can carry large quantities of wares and workers at a time, but unfortunately their destinations are limited to a handful of spaces suited for a port.]]) ..
       p(_[[Look at this valley here in the far south. We have found a mountain with gold down here and would like to mine ores from it as well. But the streams seperating it from our main colony are too wide to build bridges and too narrow for ships to pass them. Our roads would have to take long curves, which slows down ware transport a lot.]])
    ),

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -198,7 +198,7 @@ expedition5 = {
    title = _"Our mission",
    body = (
       h1(_"Start mining") ..
-      li_object('atlanteans_ironmine', p(_[[It was long and expensive job to get here. The island has not much to offer, but there is some iron ore inside its mountain. Our economy needs iron ore, so we have to build an iron mine.]]), plr.color) ..
+      li_object('atlanteans_ironmine', p(_[[It was a long and expensive job to get here. The island has not much to offer, but there is some iron ore inside its mountain. Our economy needs iron ore, so we have to build an iron mine.]]), plr.color) ..
       li(_[[Start mining iron ore in the mountain.]])
    ),
    h = 300,

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -95,21 +95,35 @@ tell_about_shipyard = {
 tell_about_ships = {
    position = "topright",
    title = _"Constructing ships",
-   body =
+   body = (
       h1(_"Waiting for the ships") ..
-      p(_[[Very good. Your shipyard is finished and your shipwright immediately started working. For the construction of ships, he needs logs, planks and spidercloth, which will be transported to the shipyard.]] .. " " ..
-      _[[The shipwright will take the ware he needs to a free spot at the shoreline and build a ship there. When the first ship is finished, it will launch onto the sea, and the shipwright will construct another one.]]) ..
-      li(_[[We should wait until we have two ships. That should be enough for now.]]) ..
-      li_arrow(_[[You need to stop your shipyard when you have enough ships. Otherwise, your shipwright will consume all your logs and spidercloth, producing dozens of ships.]]) ..
-      li_image("images/ui_basic/stop.png", _[[This is the icon for stopping production. You will find it in the building window.]]),
+      p(_[[Very good. Your shipyard is finished and your shipwright immediately started working. For the construction of ships, he needs logs, planks and spidercloth, which will be transported to the shipyard.]]) ..
+      p(_[[The shipwright will take the ware he needs to a free spot at the shoreline and build a ship there. When the first ship is finished, it will launch onto the sea, and the shipwright will construct another one.]]) ..
+      li(_[[We should wait until we have two ships. That should be enough for now.]])
+   ),
    obj_name = "wait_for_ships",
    obj_title = _"Construct two ships",
    obj_body = (
       p(_[[Ships are constructed automatically when the shipyard is complete and the needed wares have been delivered.]]) ..
       li(_[[Wait until the shipwright has constructed two ships.]]) ..
       li_arrow(_[[Do not forget to stop your shipyard when you have enough ships.]])
-   )
+   ),
+   h = 300
 }
+
+function shipyard_production(shipname)
+   return {
+      position = "topright",
+      title = _"Shipyard production",
+      body = (
+         h1(_"We have enough ships") ..
+         p(_[[Your second ship, "]] .. shipname .. _[[", is ready now.]]) ..
+         li_arrow(_[[You need to stop your shipyard when you have enough ships. Otherwise, your shipwright will consume all your logs and spidercloth, producing dozens of ships.]]) ..
+         li_image("images/ui_basic/stop.png", _[[This is the icon for stopping production. You will find it in the building window.]])
+      ),
+      h = 250
+   }
+end
 
 expedition1 = {
    position = "topright",

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -181,9 +181,9 @@ expedition3 = {
 expedition4 = {
    position = "topright",
    field = port_on_island,
-   title = _"Conclusion",
+   title = _"New colony",
    body = (
-      h1(_"Congratulations") ..
+      h1(_"Your colony has been founded") ..
       li_object('atlanteans_resi_iron_2', _[[You’ve lead the expedition to a successful end and founded a new colony. I’ve sent out some geologists – they already report that they’ve found some iron ore.]]) ..
       p(_[[So far you have learned everything about seafaring: how to build ports and ships and how to send out an expedition. Remember that expeditions are sometimes the fastest way to reach essential resources – and sometimes the only one.]]) ..
       p(_[[But I want to speak a word of warning. Ports are like headquarters: they can be attacked by a nearby enemy. While your headquarters has soldiers to defend it, your newly built port won’t. You should therefore avoid settling next to an enemy.]]) ..

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -184,12 +184,31 @@ expedition4 = {
    title = _"Conclusion",
    body = (
       h1(_"Congratulations") ..
-      p(_[[You’ve lead the expedition to a successful end and founded a new colony. I’ve sent out some geologists – they already report that they’ve found some iron ore.]]) ..
+      li_object('atlanteans_resi_iron_2', _[[You’ve lead the expedition to a successful end and founded a new colony. I’ve sent out some geologists – they already report that they’ve found some iron ore.]]) ..
       p(_[[So far you have learned everything about seafaring: how to build ports and ships and how to send out an expedition. Remember that expeditions are sometimes the fastest way to reach essential resources – and sometimes the only one.]]) ..
       p(_[[But I want to speak a word of warning. Ports are like headquarters: they can be attacked by a nearby enemy. While your headquarters has soldiers to defend it, your newly built port won’t. You should therefore avoid settling next to an enemy.]]) ..
       p(_[[On this map, there is no enemy to fear. In other games, you should make building one or two military fortifications around your new colonies a priority.]])
    ),
    h = 400
+}
+
+expedition5 = {
+   position = "topright",
+   field = iron_on_island,
+   title = _"Our mission",
+   body = (
+      h1(_"Start mining") ..
+      li_object('atlanteans_ironmine', p(_[[It was long and expensive job to get here. The island has not much to offer, but there is some iron ore inside its mountain. Our economy needs iron ore, so we have to build an iron mine.]]), plr.color) ..
+      li(_[[Start mining iron ore in the mountain.]])
+   ),
+   h = 300,
+   obj_name = "build_iron_mine",
+   obj_title = _"Build an irone mine on the island",
+   obj_body = (
+      h1(_"Build an iron mine") ..
+      p(_[[Our economy lacks resources.]]) ..
+      li_arrow(_[[Start mining iron ore in mountains on the island.]])
+   )
 }
 
 ferry_1 = {

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -117,7 +117,7 @@ function shipyard_production(shipname)
       title = _"Shipyard production",
       body = (
          h1(_"We have enough ships") ..
-         p(_[[Your second ship, "]] .. shipname .. _[[", is ready now.]]) ..
+         p((_[[Your second ship, "%1%", is ready now.]]):bformat(shipname)) ..
          li_arrow(_[[You need to stop your shipyard when you have enough ships. Otherwise, your shipwright will consume all your logs and spidercloth, producing dozens of ships.]]) ..
          li_image("images/ui_basic/stop.png", _[[This is the icon for stopping production. You will find it in the building window.]])
       ),

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -304,8 +304,7 @@ ferry_yard_production = {
    position = "topright",
    title = _"Ferry yard production",
    body = (
-      h1(_"Ferry is ready") ..
-      p(_[[Your first ferry line has opened.]]) ..
+      h1(_"More ferries needed?") ..
       p(_[[Do remember to stop your ferry yard when you don’t need any new ferries to be produced. As long as a ferry services a waterway, its lifetime is unlimited, but unemployed ferries will rot away and eventually sink.]]) ..
       li_image("images/ui_basic/stop.png", _[[This is the icon for stopping production. You will find it in the building window.]])
    ),


### PR DESCRIPTION
Follow-up on #3675 ([original PR](https://github.com/widelands/widelands/pull/3782))
- Run waterways tutorial along with shipyard objective
- New objective: Build an iron mine
- Remind player to stop ferry yard production
- Remind player to stop shipyard production when second ship is built
- Evaluate gold mine and ferries simultaneously