### PR TITLE
Prettier stdout files when regression_test is run with python 3

### DIFF
--- a/regression_test.py
+++ b/regression_test.py
@@ -21,12 +21,16 @@ except AttributeError:
         return iter(d.values())
     def iteritems(d):
         return iter(d.items())
+    def bytes_to_str(bytes):
+        return str(bytes, 'utf-8')
 else:
     # Python 2
     def itervalues(d):
         return d.itervalues()
     def iteritems(d):
         return d.iteritems()
+    def bytes_to_str(bytes):
+        return str(bytes)
 
 def datadir():
     return os.path.join(os.path.dirname(__file__), "data")
@@ -99,7 +103,7 @@ class WidelandsTestCase(unittest.TestCase):
                 line = widelands.stdout.readline()
                 if not line:
                     break
-                stdout_file.write(str(line))
+                stdout_file.write(bytes_to_str(line))
                 stdout_file.flush()
             widelands.communicate()
             self.widelands_returncode = widelands.returncode


### PR DESCRIPTION
Previously, the output was printed as raw byte strings and the output
started like this:

b'This is Widelands Version r24504[28e2244@reg-test-output] (Debug)\n'b'Adding home directory: ...

i.e., everything on one line, with b' and ' enclosing every output from
widelands. Note that testing was still correct using python 3, but
debugging the output files was not easy.