### PR TITLE
Replace deprecated reveal_scenario with mark_scenario_as_solved in frisian campaign

### DIFF
--- a/data/campaigns/fri01.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/fri01.wmf/scripting/mission_thread.lua
@@ -462,7 +462,7 @@ function mission_thread()
    -- 2 soldiers with health-1/attack-2/defense-0.
    wl.Game():save_campaign_data("frisians", "fri01", persist)
    campaign_message_box(victory_1)
-   p1:reveal_scenario("frisians01")
+   p1:mark_scenario_as_solved("fri01.wmf")
    -- END OF MISSION 1
 end
 

--- a/data/campaigns/fri02.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/fri02.wmf/scripting/mission_thread.lua
@@ -315,7 +315,7 @@ function victory()
    while not (done_mining and done_fighting) do sleep(4731) end
    sleep(10000)
    campaign_message_box(victory_1)
-   p1:reveal_scenario("frisians02")
+   p1:mark_scenario_as_solved("fri02.wmf")
    --END OF MISSION 2
 end
 


### PR DESCRIPTION
Fixes #3823 