### PR TITLE
Scenarios should include all scripts from the init.lua

### DIFF
--- a/data/campaigns/atl01.wmf/scripting/init.lua
+++ b/data/campaigns/atl01.wmf/scripting/init.lua
@@ -6,6 +6,8 @@ include "scripting/coroutine.lua"
 include "scripting/infrastructure.lua"
 include "scripting/messages.lua"
 include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
+include "scripting/set.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
 

--- a/data/campaigns/atl01.wmf/scripting/texts.lua
+++ b/data/campaigns/atl01.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 --                 Texts for the Atlantean tutorial mission
 -- =======================================================================
 
-include "scripting/richtext_scenarios.lua"
-
 function jundlina(title, text)
    return speech("map:princess.png", "2F9131", title, text)
 end

--- a/data/campaigns/atl01.wmf/scripting/water_rising.lua
+++ b/data/campaigns/atl01.wmf/scripting/water_rising.lua
@@ -2,8 +2,6 @@
 --                        Water rising Functionality
 -- =======================================================================
 
-include "scripting/set.lua"
-
 -- ================
 -- Helper function
 -- ================

--- a/data/campaigns/bar01.wmf/scripting/init.lua
+++ b/data/campaigns/bar01.wmf/scripting/init.lua
@@ -5,10 +5,13 @@
 set_textdomain("scenario_bar01.wmf")
 
 include "scripting/coroutine.lua"
-include "scripting/objective_utils.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
 include "scripting/messages.lua"
-include "scripting/field_animations.lua"
+include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
+include "scripting/table.lua"
+include "scripting/ui.lua"
 
 -- ==========
 -- Constants

--- a/data/campaigns/bar01.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/bar01.wmf/scripting/mission_thread.lua
@@ -2,9 +2,6 @@
 --                            Main mission thread
 -- =======================================================================
 
-include "scripting/table.lua"
-include "scripting/ui.lua"
-
 quarry_done = false
 enhance_buildings_done = false
 build_materials_done = false

--- a/data/campaigns/bar01.wmf/scripting/texts.lua
+++ b/data/campaigns/bar01.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 -- Some formating functions
 -- =========================
 
-include "scripting/richtext_scenarios.lua"
-
 function thron(title, text)
    return speech("map:chieftain.png", "2F9131", title, text)
 end

--- a/data/campaigns/bar02.wmf/scripting/init.lua
+++ b/data/campaigns/bar02.wmf/scripting/init.lua
@@ -5,8 +5,11 @@
 set_textdomain("scenario_bar02.wmf")
 
 include "scripting/coroutine.lua"
-include "scripting/objective_utils.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
+include "scripting/messages.lua"
+include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
 

--- a/data/campaigns/bar02.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/bar02.wmf/scripting/mission_thread.lua
@@ -2,9 +2,6 @@
 --                          Various mission threads
 -- =======================================================================
 
-include "scripting/messages.lua"
-include "scripting/field_animations.lua"
-
 local game = wl.Game()
 -- Mountain and frontier fields
 local mountain = game.map:get_field(71,14)

--- a/data/campaigns/bar02.wmf/scripting/texts.lua
+++ b/data/campaigns/bar02.wmf/scripting/texts.lua
@@ -1,5 +1,3 @@
-include "scripting/richtext_scenarios.lua"
-
 function thron(title, text)
    return speech("map:chieftain.png", "2F9131", title, text)
 end

--- a/data/campaigns/emp01.wmf/scripting/init.lua
+++ b/data/campaigns/emp01.wmf/scripting/init.lua
@@ -4,12 +4,16 @@
 set_textdomain("scenario_emp01.wmf")
 
 include "scripting/coroutine.lua"
-include "scripting/objective_utils.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
+include "scripting/messages.lua"
+include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
 
 p1 = wl.Game().players[1]
 
+include "map:scripting/helper_functions.lua"
 include "map:scripting/texts.lua"
 include "map:scripting/mission_thread.lua"

--- a/data/campaigns/emp01.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/emp01.wmf/scripting/mission_thread.lua
@@ -1,7 +1,3 @@
-include "scripting/messages.lua"
-include "map:scripting/helper_functions.lua"
-include "scripting/field_animations.lua"
-
 function mission_thread()
    sleep(1000)
 

--- a/data/campaigns/emp01.wmf/scripting/texts.lua
+++ b/data/campaigns/emp01.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 -- Some formating functions
 -- =========================
 
-include "scripting/richtext_scenarios.lua"
-
 function lutius(title, text)
    return speech("map:Lutius.png", "2F9131", title, text)
 end

--- a/data/campaigns/emp02.wmf/scripting/init.lua
+++ b/data/campaigns/emp02.wmf/scripting/init.lua
@@ -4,8 +4,11 @@
 set_textdomain("scenario_emp02.wmf")
 
 include "scripting/coroutine.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
+include "scripting/messages.lua"
 include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
 

--- a/data/campaigns/emp02.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/emp02.wmf/scripting/mission_thread.lua
@@ -2,9 +2,6 @@
 --                              Mission Threads
 -- =======================================================================
 
-include "scripting/messages.lua"
-include "scripting/field_animations.lua"
-
 function building_materials()
    reveal_concentric(p1, wl.Game().map.player_slots[1].starting_field, 13)
    sleep(1000)

--- a/data/campaigns/emp02.wmf/scripting/texts.lua
+++ b/data/campaigns/emp02.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 -- Some formating functions
 -- =========================
 
-include "scripting/richtext_scenarios.lua"
-
 function lutius(title, text)
    return speech("map:Lutius.png", "2F9131", title, text)
 end

--- a/data/campaigns/emp03.wmf/scripting/init.lua
+++ b/data/campaigns/emp03.wmf/scripting/init.lua
@@ -4,15 +4,18 @@
 set_textdomain("scenario_emp03.wmf")
 
 include "scripting/coroutine.lua"
-include "scripting/objective_utils.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
+include "scripting/messages.lua"
+include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
-
 
 p1 = wl.Game().players[1]
 p2 = wl.Game().players[2]
 
+include "map:scripting/helper_functions.lua"
 include "map:scripting/texts.lua"
 include "map:scripting/mission_thread.lua"
 

--- a/data/campaigns/emp03.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/emp03.wmf/scripting/mission_thread.lua
@@ -1,8 +1,3 @@
-include "scripting/messages.lua"
-include "map:scripting/helper_functions.lua"
-include "scripting/field_animations.lua"
-
-
 -- Some objectives need to be waited for in separate threads
 local obj_build_port_and_shipyard_done = false
 local obj_find_artifacts_done = false

--- a/data/campaigns/emp03.wmf/scripting/texts.lua
+++ b/data/campaigns/emp03.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 -- Some formating functions
 -- =========================
 
-include "scripting/richtext_scenarios.lua"
-
 function lutius(title, text)
    return speech("map:Lutius.png", "2F9131", title, text)
 end

--- a/data/campaigns/emp04.wmf/scripting/init.lua
+++ b/data/campaigns/emp04.wmf/scripting/init.lua
@@ -5,10 +5,15 @@
 set_textdomain("scenario_emp04.wmf")
 
 include "scripting/coroutine.lua"
-include "scripting/objective_utils.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
+include "scripting/messages.lua"
+include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
+
+include "map:scripting/helper_functions.lua"
 
 p1 = wl.Game().players[1]
 p2 = wl.Game().players[2]

--- a/data/campaigns/emp04.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/emp04.wmf/scripting/mission_thread.lua
@@ -1,7 +1,3 @@
-include "scripting/messages.lua"
-include "map:scripting/helper_functions.lua"
-include "scripting/field_animations.lua"
-
 -- Some objectives need to be waited for in separate threads
 local obj_find_monastery_done = false
 local julia_conquered = false

--- a/data/campaigns/emp04.wmf/scripting/texts.lua
+++ b/data/campaigns/emp04.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 -- Some formating functions
 -- =========================
 
-include "scripting/richtext_scenarios.lua"
-
 function lutius(title, text)
    return speech("map:Lutius.png", "2F9131", title, text)
 end

--- a/data/campaigns/fri01.wmf/scripting/init.lua
+++ b/data/campaigns/fri01.wmf/scripting/init.lua
@@ -4,8 +4,11 @@
 set_textdomain("scenario_fri01.wmf")
 
 include "scripting/coroutine.lua"
-include "scripting/objective_utils.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
+include "scripting/messages.lua"
+include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
 

--- a/data/campaigns/fri01.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/fri01.wmf/scripting/mission_thread.lua
@@ -1,6 +1,3 @@
-include "scripting/messages.lua"
-include "scripting/field_animations.lua"
-
 show_warning_early_attack = true
 show_warning_reed = true
 show_warning_clay = true

--- a/data/campaigns/fri01.wmf/scripting/texts.lua
+++ b/data/campaigns/fri01.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 -- Some formating functions
 -- =========================
 
-include "scripting/richtext_scenarios.lua"
-
 function reebaud(title, text)
    return speech ("map:reebaud.png", "55BB55", title, text)
 end

--- a/data/campaigns/fri02.wmf/scripting/init.lua
+++ b/data/campaigns/fri02.wmf/scripting/init.lua
@@ -4,11 +4,13 @@
 set_textdomain("scenario_fri02.wmf")
 
 include "scripting/coroutine.lua"
-include "scripting/objective_utils.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
+include "scripting/messages.lua"
+include "scripting/objective_utils.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
-include "scripting/messages.lua"
 
 game = wl.Game()
 p1 = game.players[1] -- Reebaud – player’s tribe

--- a/data/campaigns/fri02.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/fri02.wmf/scripting/mission_thread.lua
@@ -1,5 +1,3 @@
-include "scripting/field_animations.lua"
-
 local done_mining = false
 local done_fighting = false
 

--- a/data/campaigns/fri02.wmf/scripting/texts.lua
+++ b/data/campaigns/fri02.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 -- Some formating functions
 -- =========================
 
-include "scripting/richtext_scenarios.lua"
-
 function reebaud(title, text)
    return speech("map:reebaud.png", "55BB55", title, text)
 end

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/init.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/init.lua
@@ -6,11 +6,12 @@ plr = wl.Game().players[1]
 map = wl.Game().map
 
 include "scripting/coroutine.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
 include "scripting/messages.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
-include "scripting/field_animations.lua"
 
 -- Constants
 sf = map.player_slots[1].starting_field

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/texts.lua
@@ -2,8 +2,6 @@
 --                      Texts for the tutorial mission
 -- =======================================================================
 
-include "scripting/richtext_scenarios.lua"
-
 -- ================
 -- General messages
 -- ================

--- a/data/campaigns/tutorial02_warfare.wmf/scripting/init.lua
+++ b/data/campaigns/tutorial02_warfare.wmf/scripting/init.lua
@@ -8,11 +8,12 @@ map = wl.Game().map
 set_textdomain("scenario_tutorial02_warfare.wmf")
 
 include "scripting/coroutine.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
 include "scripting/messages.lua"
 include "scripting/table.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/ui.lua"
-include "scripting/field_animations.lua"
 
 sf = map.player_slots[1].starting_field
 

--- a/data/campaigns/tutorial02_warfare.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial02_warfare.wmf/scripting/texts.lua
@@ -2,12 +2,6 @@
 --                      Texts for the tutorial mission
 -- =======================================================================
 
--- =========================
--- Some formating functions
--- =========================
-
-include "scripting/richtext_scenarios.lua"
-
 -- We want the soldier here so we can get some actual stats.
 local tribe = wl.Game():get_tribe_description("barbarians")
 local soldier = wl.Game():get_worker_description(tribe.soldier)

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/init.lua
@@ -8,11 +8,12 @@ map = wl.Game().map
 set_textdomain("scenario_tutorial03_seafaring.wmf")
 
 include "scripting/coroutine.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
 include "scripting/messages.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
-include "scripting/field_animations.lua"
 
 sf = map.player_slots[1].starting_field
 second_port_field = map:get_field(37, 27)

--- a/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua
@@ -2,13 +2,6 @@
 --                      Texts for the tutorial mission
 -- =======================================================================
 
--- =========================
--- Some formating functions
--- =========================
-
-include "scripting/richtext_scenarios.lua"
-
-
 -- =============
 -- Texts below
 -- =============

--- a/data/campaigns/tutorial04_economy.wmf/scripting/init.lua
+++ b/data/campaigns/tutorial04_economy.wmf/scripting/init.lua
@@ -8,11 +8,12 @@ plr2 = wl.Game().players[2]
 set_textdomain("scenario_tutorial04_economy.wmf")
 
 include "scripting/coroutine.lua"
+include "scripting/field_animations.lua"
 include "scripting/infrastructure.lua"
 include "scripting/messages.lua"
+include "scripting/richtext_scenarios.lua"
 include "scripting/table.lua"
 include "scripting/ui.lua"
-include "scripting/field_animations.lua"
 
 map = wl.Game().map
 mv = wl.ui.MapView()

--- a/data/campaigns/tutorial04_economy.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial04_economy.wmf/scripting/texts.lua
@@ -2,12 +2,6 @@
 --                      Texts for the tutorial mission
 -- =======================================================================
 
--- =========================
--- Some formating functions
--- =========================
-
-include "scripting/richtext_scenarios.lua"
-
 -- =============
 -- Texts below
 -- =============


### PR DESCRIPTION
Fixes #3826 
The empire and frisian scenarios can now be started again.
Moved all includes in the campaigns to the init.lua and reordered them in alphabetical order: first general includes, then map-specific includes.