### PR TITLE
Fix visual glitches and division by zero in WuiPlotArea

### DIFF
--- a/src/wui/plot_area.cc
+++ b/src/wui/plot_area.cc
@@ -488,7 +488,13 @@ void WuiPlotArea::update() {
 void WuiPlotArea::draw(RenderTarget& dst) {
 	dst.tile(Recti(Vector2i::zero(), get_inner_w(), get_inner_h()), g_gr->images().get(BG_PIC),
 	         Vector2i::zero());
-	draw_plot(dst, get_inner_h() - kSpaceBottom, std::to_string(highest_scale_), highest_scale_);
+	if (needs_update_) {
+		update();
+		needs_update_ = false;
+	}
+	if (highest_scale_) {
+		draw_plot(dst, get_inner_h() - kSpaceBottom, std::to_string(highest_scale_), highest_scale_);
+	}
 	// Print the 0
 	draw_value((boost::format("%u") % (0)).str(),
 	           g_gr->styles().statistics_plot_style().x_tick_font(),


### PR DESCRIPTION
Sometimes the plot was drawn without updating `highest_scale_` first.
This resulted in the graph being drawn with an incorrect height for a brief time, possibly outside the statistics window.
And if `highest_scale_` was zero, it could also lead to division by zero in `scale_value()`.

Testing steps:
1. Load the [test savegame](https://github.com/widelands/widelands/files/4461322/362.wgf.zip).
2. Open General Statistics window and move it to the bottom of the screen.
3. Switch a few times between graphs Land/Military buildings lost. You may briefly see [case 1 (wrong height) screenshot](https://user-images.githubusercontent.com/4470900/78987604-cd390680-7b2e-11ea-942c-e1d5133ff01f.png).
4. Switch to the Military graph.
5. Open and close the General Statistics window a few times. You may briefly see [case 2 (division by zero) screenshot](https://user-images.githubusercontent.com/4470900/78987609-d0cc8d80-7b2e-11ea-9e39-e5ab34441491.png).