### PR TITLE
Suggested teams truncated

### DIFF
--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -48,8 +48,7 @@ MapDetails::MapDetails(
                  UI::Align::kLeft,
                  UI::MultilineTextarea::ScrollMode::kNoScrolling),
      descr_(&main_box_, 0, 0, UI::Scrollbar::kSize, 0, style, ""),
-     suggested_teams_box_(
-        new UI::SuggestedTeamsBox(this, 0, 0, UI::Box::Vertical, padding_, 0, w)) {
+     suggested_teams_box_(new UI::SuggestedTeamsBox(this, 0, 0, UI::Box::Vertical, padding_, 0)) {
 
 	main_box_.add(&name_label_);
 	main_box_.add_space(padding_);
@@ -160,6 +159,7 @@ void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
 		if (mapdata.suggested_teams.empty()) {
 			suggested_teams_box_->hide();
 		} else {
+			suggested_teams_box_->set_size(get_parent()->get_w(), 0);
 			suggested_teams_box_->show(mapdata.suggested_teams);
 		}
 	}

--- a/src/wui/suggested_teams_box.cc
+++ b/src/wui/suggested_teams_box.cc
@@ -46,7 +46,6 @@ SuggestedTeamsBox::SuggestedTeamsBox(Panel* parent,
                    padding),
      suggested_teams_box_label_(new UI::Textarea(this)),
      lineup_box_(nullptr) {
-	set_size(max_x, max_y);
 	add(suggested_teams_box_label_);
 }
 SuggestedTeamsBox::~SuggestedTeamsBox() {


### PR DESCRIPTION
fixes #3786

The width of the box was set statically to 100 and never changed.
The width of the parent box is recalculated during runtime which must also be propagated to the box.

I removed the initialiation (set_size()) in the constructor because it is overriden anyways later on and I was confused why my first tries did not have the desired effect.