### PR TITLE
Add numpad hotkeys

### DIFF
--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -708,6 +708,11 @@ bool EditorInteractive::handle_key(bool const down, SDL_Keysym const code) {
 	if (down) {
 		switch (code.sym) {
 		// Sel radius
+		case SDLK_KP_1:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_1:
 			if (code.mod & (KMOD_CTRL)) {
 				toggle_buildhelp();
@@ -715,6 +720,12 @@ bool EditorInteractive::handle_key(bool const down, SDL_Keysym const code) {
 				set_sel_radius_and_update_menu(0);
 			}
 			return true;
+
+		case SDLK_KP_2:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_2:
 			if (code.mod & (KMOD_CTRL)) {
 				toggle_immovables();
@@ -722,6 +733,12 @@ bool EditorInteractive::handle_key(bool const down, SDL_Keysym const code) {
 				set_sel_radius_and_update_menu(1);
 			}
 			return true;
+
+		case SDLK_KP_3:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_3:
 			if (code.mod & (KMOD_CTRL)) {
 				toggle_bobs();
@@ -729,6 +746,12 @@ bool EditorInteractive::handle_key(bool const down, SDL_Keysym const code) {
 				set_sel_radius_and_update_menu(2);
 			}
 			return true;
+
+		case SDLK_KP_4:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_4:
 			if (code.mod & (KMOD_CTRL)) {
 				toggle_resources();
@@ -736,21 +759,57 @@ bool EditorInteractive::handle_key(bool const down, SDL_Keysym const code) {
 				set_sel_radius_and_update_menu(3);
 			}
 			return true;
+
+		case SDLK_KP_5:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_5:
 			set_sel_radius_and_update_menu(4);
 			return true;
+
+		case SDLK_KP_6:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_6:
 			set_sel_radius_and_update_menu(5);
 			return true;
+
+		case SDLK_KP_7:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_7:
 			set_sel_radius_and_update_menu(6);
 			return true;
+
+		case SDLK_KP_8:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_8:
 			set_sel_radius_and_update_menu(7);
 			return true;
+
+		case SDLK_KP_9:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_9:
 			set_sel_radius_and_update_menu(8);
 			return true;
+
+		case SDLK_KP_0:
+			if (!(code.mod & KMOD_NUM)) {
+				break;
+			}
+			FALLS_THROUGH;
 		case SDLK_0:
 			if (!(code.mod & KMOD_CTRL)) {
 				set_sel_radius_and_update_menu(9);

--- a/src/wui/game_message_menu.cc
+++ b/src/wui/game_message_menu.cc
@@ -368,42 +368,79 @@ bool GameMessageMenu::handle_key(bool down, SDL_Keysym code) {
 			if (centerviewbtn_->enabled())
 				center_view();
 			return true;
+
+		case SDLK_KP_0:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_0:
 			if (code.mod & KMOD_ALT) {
 				filter_messages(Widelands::Message::Type::kAllMessages);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_1:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_1:
 			if (code.mod & KMOD_ALT) {
 				filter_messages(Widelands::Message::Type::kGeologists);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_2:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_2:
 			if (code.mod & KMOD_ALT) {
 				filter_messages(Widelands::Message::Type::kEconomy);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_3:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_3:
 			if (code.mod & KMOD_ALT) {
 				filter_messages(Widelands::Message::Type::kSeafaring);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_4:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_4:
 			if (code.mod & KMOD_ALT) {
 				filter_messages(Widelands::Message::Type::kWarfare);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_5:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_5:
 			if (code.mod & KMOD_ALT) {
 				filter_messages(Widelands::Message::Type::kScenario);
 				return true;
 			}
 			return false;
+
 		case SDLK_DELETE:
 			archive_or_restore();
 			return true;

--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -652,15 +652,26 @@ bool MapView::handle_key(bool down, SDL_Keysym code) {
 	}
 
 	switch (code.sym) {
+	case SDLK_KP_PLUS:
 	case SDLK_PLUS:
+	case SDLK_EQUALS:
 		increase_zoom();
 		return true;
+
+	case SDLK_KP_MINUS:
 	case SDLK_MINUS:
 		decrease_zoom();
 		return true;
+
+	case SDLK_KP_0:
+		if (!(code.mod & KMOD_NUM)) {
+			return false;
+		}
+		FALLS_THROUGH;
 	case SDLK_0:
 		reset_zoom();
 		return true;
+
 	default:
 		return false;
 	}

--- a/src/wui/quicknavigation.cc
+++ b/src/wui/quicknavigation.cc
@@ -69,6 +69,19 @@ bool QuickNavigation::handle_key(bool down, SDL_Keysym key) {
 		} else if (landmarks_[which].set) {
 			map_view_->set_view(landmarks_[which].view, MapView::Transition::Smooth);
 		}
+	} else if (key.sym >= SDLK_KP_1 && key.sym <= SDLK_KP_9) {
+		if (!(key.mod & KMOD_NUM)) {
+			return false;
+		}
+		int which = key.sym - SDLK_KP_1;
+		assert(which >= 0);
+		assert(which < kQuicknavSlots);
+
+		if (key.mod & KMOD_CTRL) {
+			set_landmark(which, current_);
+		} else if (landmarks_[which].set) {
+			map_view_->set_view(landmarks_[which].view, MapView::Transition::Smooth);
+		}
 	} else if (key.sym == SDLK_COMMA && !previous_locations_.empty()) {
 		// go to previous location
 		insert_if_applicable(next_locations_);

--- a/src/wui/seafaring_statistics_menu.cc
+++ b/src/wui/seafaring_statistics_menu.cc
@@ -369,42 +369,79 @@ bool SeafaringStatisticsMenu::handle_key(bool down, SDL_Keysym code) {
 		case SDLK_w:
 			watch_ship();
 			return true;
+
+		case SDLK_KP_0:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_0:
 			if (code.mod & KMOD_ALT) {
 				filter_ships(ShipFilterStatus::kAll);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_1:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_1:
 			if (code.mod & KMOD_ALT) {
 				filter_ships(ShipFilterStatus::kIdle);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_2:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_2:
 			if (code.mod & KMOD_ALT) {
 				filter_ships(ShipFilterStatus::kShipping);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_3:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_3:
 			if (code.mod & KMOD_ALT) {
 				filter_ships(ShipFilterStatus::kExpeditionWaiting);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_4:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_4:
 			if (code.mod & KMOD_ALT) {
 				filter_ships(ShipFilterStatus::kExpeditionScouting);
 				return true;
 			}
 			return false;
+
+		case SDLK_KP_5:
+			if (!(code.mod & KMOD_NUM)) {
+				return false;
+			}
+			FALLS_THROUGH;
 		case SDLK_5:
 			if (code.mod & KMOD_ALT) {
 				filter_ships(ShipFilterStatus::kExpeditionPortspaceFound);
 				return true;
 			}
 			return false;
+
 		case SDL_SCANCODE_KP_PERIOD:
 		case SDLK_KP_PERIOD:
 			if (code.mod & KMOD_NUM)


### PR DESCRIPTION
This adds support for using numpad keys for various hotkeys that were only usable with alphanumeric keyboard number keys. Num Lock must be on for these to work.

Hotkeys handled:
- Zooming the map with Ctrl+[+/-/0] keys (also handling the = key on alphanumeric keyboard as +)
- Editor tool sizes (number) and map details show/hide (Ctrl+number)
- Filtering seafaring statistics (Alt+number)
- Filtering game messages (Alt+number)
- Quick navigation (number and Ctrl+number)