### PR TITLE
Fix road buttons added instead of waterway buttons

### DIFF
--- a/src/wui/fieldaction.cc
+++ b/src/wui/fieldaction.cc
@@ -1027,7 +1027,11 @@ void show_field_action(InteractiveBase* const ibase,
 		    (ibase->in_road_building_mode(RoadBuildingType::kWaterway) &&
 		     target != ibase->get_build_road_end())) {
 			FieldActionWindow& w = *new FieldActionWindow(ibase, player, registry);
-			w.add_buttons_road(false);
+			if (ibase->in_road_building_mode(RoadBuildingType::kRoad)) {
+				w.add_buttons_road(false);
+			} else {
+				w.add_buttons_waterway(false);
+			}
 			w.init();
 			return;
 		}
@@ -1052,9 +1056,9 @@ void show_field_action(InteractiveBase* const ibase,
 			} else {
 				FieldActionWindow& w = *new FieldActionWindow(ibase, player, registry);
 				if (ibase->in_road_building_mode(RoadBuildingType::kRoad)) {
-					w.add_buttons_waterway(false);
-				} else {
 					w.add_buttons_road(false);
+				} else {
+					w.add_buttons_waterway(false);
 				}
 				w.init();
 				return;


### PR DESCRIPTION
Fix a bug causing road buttons instead of waterway buttons to be added in waterway building mode when clicking on a field where the waterway can't be built.
The bug was introduced in a8c236de51e837df467a6f0ea55444b498c2752e