### PR TITLE
Let Barbarians produce cloth on maps without seafaring

### DIFF
--- a/data/tribes/buildings/productionsites/atlanteans/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/shipyard/init.lua
@@ -76,7 +76,6 @@ tribes:new_productionsite_type {
          -- TRANSLATORS: Completed/Skipped/Did not start constructing a ship because ...
          descname = _"constructing a ship",
          actions = {
-            "checkmap=seafaring",
             "construct=atlanteans_shipconstruction buildship 6",
             "sleep=20000",
          }

--- a/data/tribes/buildings/productionsites/barbarians/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/shipyard/init.lua
@@ -64,7 +64,6 @@ tribes:new_productionsite_type {
          -- TRANSLATORS: Completed/Skipped/Did not start constructing a ship because ...
          descname = _"constructing a ship",
          actions = {
-            "checkmap=seafaring",
             "construct=barbarians_shipconstruction buildship 6",
             "sleep=20000",
          }

--- a/data/tribes/buildings/productionsites/barbarians/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/weaving_mill/init.lua
@@ -57,7 +57,6 @@ tribes:new_productionsite_type {
          descname = _"weaving",
          actions = {
             "sleep=25000",
-            "checkmap=seafaring",
             "return=skipped unless economy needs cloth",
             "consume=reed",
             "playsound=sound/barbarians/weaver 120",

--- a/data/tribes/buildings/productionsites/empire/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/empire/shipyard/init.lua
@@ -75,7 +75,6 @@ tribes:new_productionsite_type {
          -- TRANSLATORS: Completed/Skipped/Did not start constructing a ship because ...
          descname = _"constructing a ship",
          actions = {
-            "checkmap=seafaring",
             "construct=empire_shipconstruction buildship 6",
             "sleep=20000",
          }

--- a/data/tribes/buildings/productionsites/frisians/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/shipyard/init.lua
@@ -76,7 +76,6 @@ tribes:new_productionsite_type {
          -- TRANSLATORS: Completed/Skipped/Did not start constructing a ship because ...
          descname = _"constructing a ship",
          actions = {
-            "checkmap=seafaring",
             "construct=frisians_shipconstruction buildship 6",
             "sleep=20000",
          }

--- a/doc/sphinx/source/productionsite_program.rst
+++ b/doc/sphinx/source/productionsite_program.rst
@@ -89,7 +89,6 @@ Command Types
 - `produce`_
 - `mine`_
 - `checksoldier`_
-- `checkmap`_
 - `train`_
 - `playsound`_
 
@@ -275,14 +274,6 @@ exhausted for a while already.
 checksoldier
 ------------
 Returns failure unless there are a specified amount of soldiers with specified level of specified properties. This command type is subject to change.
-
-checkmap
---------
-Checks the map for properties. At the moment, only 'seafaring' is available as parameter.
-
-Parameter syntax::
-
-  parameters ::= seafaring
 
 train
 -----

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -694,27 +694,6 @@ void ProductionProgram::ActSleep::execute(Game& game, ProductionSite& ps) const 
 	return ps.program_step(game, duration_ ? duration_ : 0, ps.top_state().phase);
 }
 
-ProductionProgram::ActCheckMap::ActCheckMap(const std::vector<std::string>& arguments) {
-	if (arguments.size() != 1 || arguments.front() != "seafaring") {
-		throw GameDataError("Usage: checkmap=seafaring");
-	}
-	feature_ = Feature::kSeafaring;
-}
-
-void ProductionProgram::ActCheckMap::execute(Game& game, ProductionSite& ps) const {
-	switch (feature_) {
-	case Feature::kSeafaring: {
-		if (game.map().allows_seafaring()) {
-			return ps.program_step(game, 0);
-		} else {
-			ps.set_production_result(_("No use for ships on this map!"));
-			return ps.program_end(game, ProgramResult::kFailed);
-		}
-	}
-	}
-	NEVER_HERE();
-}
-
 ProductionProgram::ActAnimate::ActAnimate(const std::vector<std::string>& arguments,
                                           ProductionSiteDescr* descr) {
 	parameters = MapObjectProgram::parse_act_animate(arguments, *descr, false);
@@ -1440,9 +1419,6 @@ ProductionProgram::ProductionProgram(const std::string& init_name,
 			} else if (parseinput.name == "construct") {
 				actions_.push_back(std::unique_ptr<ProductionProgram::Action>(
 				   new ActConstruct(parseinput.arguments, name(), building)));
-			} else if (parseinput.name == "checkmap") {
-				actions_.push_back(
-				   std::unique_ptr<ProductionProgram::Action>(new ActCheckMap(parseinput.arguments)));
 			} else {
 				throw GameDataError(
 				   "Unknown command '%s' in line '%s'", parseinput.name.c_str(), line.c_str());

--- a/src/logic/map_objects/tribes/production_program.h
+++ b/src/logic/map_objects/tribes/production_program.h
@@ -326,25 +326,6 @@ struct ProductionProgram : public MapObjectProgram {
 		Duration duration_;
 	};
 
-	/// Checks whether the map has a certain feature enabled.
-	///
-	/// Parameter syntax:
-	///    parameters ::= feature
-	/// Parameter semantics:
-	///    feature:
-	///       The name of the feature that should be checked. Possible values are:
-	///       * Seafaring : to check whether the map has at least two port build spaces
-	///
-	/// Ends the program if the feature is not enabled.
-	struct ActCheckMap : public Action {
-		explicit ActCheckMap(const std::vector<std::string>& arguments);
-		void execute(Game&, ProductionSite&) const override;
-
-	private:
-		enum class Feature { kSeafaring = 1 };
-		Feature feature_;
-	};
-
 	/// Runs an animation.
 	///
 	/// Parameter syntax:

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -169,7 +169,6 @@ class ProductionSite : public Building {
 	friend struct ProductionProgram::ActCall;
 	friend struct ProductionProgram::ActCallWorker;
 	friend struct ProductionProgram::ActSleep;
-	friend struct ProductionProgram::ActCheckMap;
 	friend struct ProductionProgram::ActAnimate;
 	friend struct ProductionProgram::ActConsume;
 	friend struct ProductionProgram::ActProduce;


### PR DESCRIPTION
Removed redundant check from the Weaving mill, so cloth can be produced on maps without seafaring but with waterways.
The building can't be built on maps without waterways and seafaring anyway so there's no need to check it during production.
Fixes #3699