### PR TITLE
Fix text alignment problem

### DIFF
--- a/src/graphic/text/sdl_ttf_font.cc
+++ b/src/graphic/text/sdl_ttf_font.cc
@@ -52,8 +52,11 @@ SdlTtfFont::~SdlTtfFont() {
 void SdlTtfFont::dimensions(const std::string& txt, int style, uint16_t* gw, uint16_t* gh) {
 	set_style(style);
 
+	// Getting height from TTF_SizeUTF8() was sometimes causing misaligned text,
+	// so use TTF_FontHeight() to get it instead
 	int w, h;
-	TTF_SizeUTF8(font_, txt.c_str(), &w, &h);
+	TTF_SizeUTF8(font_, txt.c_str(), &w, NULL);
+	h = TTF_FontHeight(font_);
 
 	if (style & SHADOW) {
 		w += SHADOW_OFFSET;


### PR DESCRIPTION
Fixes #590 

Some words in a text were positioned one pixel higher or lower than others.

Before the fix:
![Screenshot_2020-04-16_18-54-55](https://user-images.githubusercontent.com/4470900/79484664-4d220d80-8014-11ea-9dae-6eb4f1f06716.png)

After the fix:
![Screenshot_2020-04-16_18-56-23](https://user-images.githubusercontent.com/4470900/79484682-5317ee80-8014-11ea-9272-b9f5652c487b.png)
