### PR TITLE
Faster game saving with endless_game_fogless win condition

### DIFF
--- a/data/scripting/win_conditions/endless_game_fogless.lua
+++ b/data/scripting/win_conditions/endless_game_fogless.lua
@@ -39,6 +39,7 @@ return {
       for idx, plr in ipairs(game.players) do
          plr:reveal_fields(fields)
       end
+      fields = nil
 
       -- Iterate all players, if one is defeated, remove him
       -- from the list, send him a defeated message and give him full vision


### PR DESCRIPTION
Speeds up saving the game on big maps with many players with the "Endless Game Fogless" win condition by deleting a big variable when it is no longer needed.

Before
``` Writing Scripting Data ... took 38041ms```
After
``` Writing Scripting Data ... took 456ms```
