### PR TITLE
Add missing check for helmet in Frisian training camp

### DIFF
--- a/data/tribes/buildings/trainingsites/frisians/training_camp/init.lua
+++ b/data/tribes/buildings/trainingsites/frisians/training_camp/init.lua
@@ -177,6 +177,7 @@ tribes:new_trainingsite_type {
          descname = pgettext ("frisians_building", "upgrading soldier health from level 0 to level 1"),
          actions = {
             "checksoldier=soldier health 0",
+            "return=failed unless site has helmet",
             "return=failed unless site has bread_frisians,beer",
             "return=failed unless site has smoked_fish,smoked_meat",
             "sleep=15000",


### PR DESCRIPTION
When helmet was missing the camp was still attempting upgrade and wasting 30 seconds.