### PR TITLE
Fix wrong colors on Big Endian systems

### DIFF
--- a/src/graphic/sdl_utils.cc
+++ b/src/graphic/sdl_utils.cc
@@ -23,6 +23,10 @@
 
 SDL_Surface* empty_sdl_surface(int16_t w, int16_t h) {
 	SDL_Surface* const surface =
+#if SDL_BYTEORDER == SDL_LIL_ENDIAN
 	   SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+#else
+	   SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+#endif
 	return surface;
 }


### PR DESCRIPTION
Reverse the order of bytes when creating SDL surface on big endian architectures.

Fixes #3887 ... hopefully. I have no PowerPC to test.