### PR TITLE
Fix recycling center hotspot

### DIFF
--- a/data/tribes/buildings/productionsites/frisians/recycling_center/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/recycling_center/init.lua
@@ -35,7 +35,7 @@ tribes:new_productionsite_type {
       working_metal = {
          directory = dirname,
          basename = "working_metal",
-         hotspot = {50, 61}, -- the whole animation is one pixel lower
+         hotspot = {50, 71}, -- the whole animation is one pixel lower
          frames = 10,
          columns = 5,
          rows = 2,


### PR DESCRIPTION
Fixes #3921 
This typo must have slipped in when re-exporting the mipmaps. This is a small anim-hotspot-only change so we can have it for b21.