### PR TITLE
Fix ship destination mismatch after order cancelling

### DIFF
--- a/src/economy/shipping_schedule.cc
+++ b/src/economy/shipping_schedule.cc
@@ -73,7 +73,7 @@ constexpr int16_t kNearbyDockMaxDistanceFactor = 8 * 1800;
 
 #define sslog(...)                                                                                 \
 	if (g_verbose)                                                                                  \
-		log(__VA_ARGS__)
+	log(__VA_ARGS__)
 
 ShippingSchedule::ShippingSchedule(ShipFleet& f) : fleet_(f), last_updated_(0), loader_(nullptr) {
 	assert(!fleet_.active());

--- a/src/economy/shipping_schedule.cc
+++ b/src/economy/shipping_schedule.cc
@@ -73,7 +73,7 @@ constexpr int16_t kNearbyDockMaxDistanceFactor = 8 * 1800;
 
 #define sslog(...)                                                                                 \
 	if (g_verbose)                                                                                  \
-		log(__VA_ARGS__);
+		log(__VA_ARGS__)
 
 ShippingSchedule::ShippingSchedule(ShipFleet& f) : fleet_(f), last_updated_(0), loader_(nullptr) {
 	assert(!fleet_.active());
@@ -955,6 +955,13 @@ Duration ShippingSchedule::update(Game& game) {
 				previt = it;
 				++it;
 			}
+		}
+		if (plans_[ship].empty()) {
+			sslog("No orders left, setting to idle\n");
+			ship->set_destination(game, nullptr);
+		} else if (plans_[ship].front().dock != ship->get_destination()) {
+			ship->set_destination(game, plans_[ship].front().dock.get(game));
+			sslog("Rerouted to %u\n", ship->get_destination()->serial());
 		}
 	}
 


### PR DESCRIPTION
Fixes the problem described in #3939.
This bug does not happen very often but IMHO it would be better if we have this fix in b21.