### PR TITLE
Ignore multiple enhance commands

### DIFF
--- a/src/logic/playercommand.cc
+++ b/src/logic/playercommand.cc
@@ -755,7 +755,9 @@ CmdEnhanceBuilding::CmdEnhanceBuilding(StreamRead& des) : PlayerCommand(0, des.u
 void CmdEnhanceBuilding::execute(Game& game) {
 	MapObject* mo = game.objects().get_object(serial_);
 	if (upcast(ConstructionSite, cs, mo)) {
-		cs->enhance(game);
+		if (bi_ == cs->building().enhancement()) {
+			cs->enhance(game);
+		}
 	} else if (upcast(Building, building, mo)) {
 		game.get_player(sender())->enhance_building(building, bi_, keep_wares_);
 	}

--- a/src/wui/actionconfirm.cc
+++ b/src/wui/actionconfirm.cc
@@ -339,7 +339,7 @@ void EnhanceConfirm::ok() {
 		upcast(Widelands::ConstructionSite, cs, object_.get(game));
 		if (cs && iaplayer().can_act(cs->owner().player_number())) {
 			game.send_player_enhance_building(
-			   *cs, Widelands::INVALID_INDEX, checkbox_ && checkbox_->get_state());
+			   *cs, cs->building().enhancement(), checkbox_ && checkbox_->get_state());
 		}
 	} else {
 		upcast(Widelands::Building, building, object_.get(game));

--- a/src/wui/buildingwindow.cc
+++ b/src/wui/buildingwindow.cc
@@ -465,7 +465,7 @@ void BuildingWindow::act_enhance(Widelands::DescriptionIndex id, bool csite) {
 		assert(construction_site);
 		if (SDL_GetModState() & KMOD_CTRL) {
 			igbase()->game().send_player_enhance_building(
-			   *construction_site, Widelands::INVALID_INDEX, false);
+			   *construction_site, construction_site->building().enhancement(), false);
 		} else {
 			show_enhance_confirm(dynamic_cast<InteractivePlayer&>(*igbase()), *construction_site,
 			                     construction_site->get_info().becomes->enhancement(), true);


### PR DESCRIPTION
If the enhance button is pressed multiple times in a row while the game is paused or running very slowly, perform the enhance action only once. Fixes #3952 