### PR TITLE
Parse production outputs

### DIFF
--- a/data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua
@@ -45,7 +45,7 @@ dirname = path.dirname(__file__)
 --            },
 --
 --    **outputs**
---        *Optional*. The wares/workers produced by this building, e.g.::
+--        *DEPRECATED*. The wares/workers produced by this building, e.g.::
 --
 --            outputs = { "shield_advanced", "shield_steel" },
 --

--- a/data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua
@@ -144,10 +144,6 @@ tribes:new_productionsite_type {
       { name = "iron", amount = 8 },
       { name = "gold", amount = 8 }
    },
-   outputs = {
-      "shield_advanced",
-      "shield_steel"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/bakery/init.lua
@@ -45,9 +45,6 @@ tribes:new_productionsite_type {
       { name = "cornmeal", amount = 4 },
       { name = "blackroot_flour", amount = 4 }
    },
-   outputs = {
-      "atlanteans_bread"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/barracks/init.lua
@@ -48,9 +48,6 @@ tribes:new_productionsite_type {
       { name = "trident_light", amount = 8 },
       { name = "atlanteans_recruit", amount = 8 }
    },
-   outputs = {
-      "atlanteans_soldier",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/blackroot_farm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/blackroot_farm/init.lua
@@ -38,10 +38,6 @@ tribes:new_productionsite_type {
       atlanteans_blackroot_farmer = 1
    },
 
-   outputs = {
-      "blackroot"
-   },
-
    indicate_workarea_overlaps = {
       atlanteans_blackroot_farm = false,
       atlanteans_farm = false,

--- a/data/tribes/buildings/productionsites/atlanteans/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/charcoal_kiln/init.lua
@@ -41,9 +41,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "log", amount = 8 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/coalmine/init.lua
@@ -52,9 +52,6 @@ tribes:new_productionsite_type {
       { name = "smoked_meat", amount = 6 },
       { name = "atlanteans_bread", amount = 10 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/crystalmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/crystalmine/init.lua
@@ -48,11 +48,6 @@ tribes:new_productionsite_type {
       { name = "smoked_meat", amount = 6 },
       { name = "atlanteans_bread", amount = 10 }
    },
-   outputs = {
-      "diamond",
-      "quartz",
-      "granite"
-   },
 
    indicate_workarea_overlaps = {
       atlanteans_crystalmine = false,

--- a/data/tribes/buildings/productionsites/atlanteans/farm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/farm/init.lua
@@ -42,10 +42,6 @@ tribes:new_productionsite_type {
       atlanteans_farmer = 1
    },
 
-   outputs = {
-      "corn"
-   },
-
    indicate_workarea_overlaps = {
       atlanteans_blackroot_farm = false,
       atlanteans_farm = false,

--- a/data/tribes/buildings/productionsites/atlanteans/fishers_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/fishers_house/init.lua
@@ -37,10 +37,6 @@ tribes:new_productionsite_type {
       atlanteans_fisher = 1
    },
 
-   outputs = {
-      "fish"
-   },
-
    indicate_workarea_overlaps = {
       atlanteans_fishers_house = false,
       atlanteans_fishbreeders_house = true,

--- a/data/tribes/buildings/productionsites/atlanteans/gold_spinning_mill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/gold_spinning_mill/init.lua
@@ -41,9 +41,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "gold", amount = 5 }
    },
-   outputs = {
-      "gold_thread"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/goldmine/init.lua
@@ -48,9 +48,6 @@ tribes:new_productionsite_type {
       { name = "smoked_meat", amount = 6 },
       { name = "atlanteans_bread", amount = 10 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    indicate_workarea_overlaps = {
       atlanteans_goldmine = false,

--- a/data/tribes/buildings/productionsites/atlanteans/horsefarm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/horsefarm/init.lua
@@ -42,9 +42,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 8 },
       { name = "corn", amount = 8 }
    },
-   outputs = {
-      "atlanteans_horse"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/hunters_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/hunters_house/init.lua
@@ -34,10 +34,6 @@ tribes:new_productionsite_type {
       atlanteans_hunter = 1
    },
 
-   outputs = {
-      "meat"
-   },
-
    indicate_workarea_overlaps = {
       atlanteans_hunters_house = false,
    },

--- a/data/tribes/buildings/productionsites/atlanteans/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/ironmine/init.lua
@@ -52,9 +52,6 @@ tribes:new_productionsite_type {
       { name = "smoked_meat", amount = 6 },
       { name = "atlanteans_bread", amount = 10 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/mill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/mill/init.lua
@@ -45,10 +45,6 @@ tribes:new_productionsite_type {
       { name = "corn", amount = 6 },
       { name = "blackroot", amount = 6 }
    },
-   outputs = {
-      "cornmeal",
-      "blackroot_flour"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/quarry/init.lua
@@ -32,10 +32,6 @@ tribes:new_productionsite_type {
       atlanteans_stonecutter = 1
    },
 
-   outputs = {
-      "granite"
-   },
-
    indicate_workarea_overlaps = {
       atlanteans_quarry = false,
    },

--- a/data/tribes/buildings/productionsites/atlanteans/sawmill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/sawmill/init.lua
@@ -43,9 +43,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "log", amount = 8 }
    },
-   outputs = {
-      "planks"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/smelting_works/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/smelting_works/init.lua
@@ -45,10 +45,6 @@ tribes:new_productionsite_type {
       { name = "iron_ore", amount = 8 },
       { name = "gold_ore", amount = 8 }
    },
-   outputs = {
-      "iron",
-      "gold"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/smokery/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/smokery/init.lua
@@ -47,10 +47,6 @@ tribes:new_productionsite_type {
       { name = "meat", amount = 4 },
       { name = "log", amount = 8 }
    },
-   outputs = {
-      "smoked_meat",
-      "smoked_fish"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/spiderfarm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/spiderfarm/init.lua
@@ -43,9 +43,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 7 },
       { name = "corn", amount = 7 }
    },
-   outputs = {
-      "spider_silk"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/toolsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/toolsmithy/init.lua
@@ -43,20 +43,6 @@ tribes:new_productionsite_type {
       { name = "spidercloth", amount = 4 },
       { name = "iron", amount = 6 }
    },
-   outputs = {
-      "bread_paddle",
-      "buckets",
-      "fire_tongs",
-      "fishing_net",
-      "hammer",
-      "hook_pole",
-      "hunting_bow",
-      "milking_tongs",
-      "pick",
-      "saw",
-      "scythe",
-      "shovel"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/weaponsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/weaponsmithy/init.lua
@@ -47,13 +47,6 @@ tribes:new_productionsite_type {
       { name = "iron", amount = 8 },
       { name = "gold", amount = 8 }
    },
-   outputs = {
-      "trident_light",
-      "trident_long",
-      "trident_steel",
-      "trident_double",
-      "trident_heavy_double"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/weaving_mill/init.lua
@@ -46,11 +46,6 @@ tribes:new_productionsite_type {
       { name = "spider_silk", amount = 8 },
       { name = "gold_thread", amount = 4 }
    },
-   outputs = {
-      "spidercloth",
-      "tabard",
-      "tabard_golden"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/atlanteans/well/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/well/init.lua
@@ -39,10 +39,6 @@ tribes:new_productionsite_type {
       atlanteans_carrier = 1
    },
 
-   outputs = {
-      "water"
-   },
-
    indicate_workarea_overlaps = {
       atlanteans_well = false,
    },

--- a/data/tribes/buildings/productionsites/atlanteans/woodcutters_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/woodcutters_house/init.lua
@@ -33,10 +33,6 @@ tribes:new_productionsite_type {
       atlanteans_woodcutter = 1
    },
 
-   outputs = {
-      "log"
-   },
-
    indicate_workarea_overlaps = {
       atlanteans_foresters_house = true,
       atlanteans_woodcutters_house = false,

--- a/data/tribes/buildings/productionsites/barbarians/ax_workshop/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ax_workshop/init.lua
@@ -55,11 +55,6 @@ tribes:new_productionsite_type {
       { name = "coal", amount = 8 },
       { name = "iron", amount = 8 }
    },
-   outputs = {
-      "ax",
-      "ax_sharp",
-      "ax_broad"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/bakery/init.lua
@@ -48,9 +48,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 6 },
       { name = "wheat", amount = 6 }
    },
-   outputs = {
-      "barbarians_bread"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/barracks/init.lua
@@ -50,9 +50,6 @@ tribes:new_productionsite_type {
       { name = "ax", amount = 8 },
       { name = "barbarians_recruit", amount = 8 }
    },
-   outputs = {
-      "barbarians_soldier",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/big_inn/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/big_inn/init.lua
@@ -48,11 +48,6 @@ tribes:new_productionsite_type {
       { name = "beer", amount = 4 },
       { name = "beer_strong", amount = 4 }
    },
-   outputs = {
-      "ration",
-      "snack",
-      "meal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/brewery/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/brewery/init.lua
@@ -41,9 +41,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 8 },
       { name = "wheat", amount = 8 }
    },
-   outputs = {
-      "beer_strong"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/cattlefarm/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/cattlefarm/init.lua
@@ -42,9 +42,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 8 },
       { name = "wheat", amount = 8 }
    },
-   outputs = {
-      "barbarians_ox"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/charcoal_kiln/init.lua
@@ -45,9 +45,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "log", amount = 8 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine/init.lua
@@ -51,9 +51,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 6 }
    },
-   outputs = {
-      "coal"
-   },
 
    indicate_workarea_overlaps = {
       barbarians_coalmine = false,

--- a/data/tribes/buildings/productionsites/barbarians/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine_deep/init.lua
@@ -57,9 +57,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "snack", amount = 6 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/coalmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine_deeper/init.lua
@@ -56,9 +56,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "meal", amount = 6 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/farm/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/farm/init.lua
@@ -50,10 +50,6 @@ tribes:new_productionsite_type {
       barbarians_farmer = 1
    },
 
-   outputs = {
-      "wheat"
-   },
-
    indicate_workarea_overlaps = {
       barbarians_rangers_hut = false,
       barbarians_farm = false,

--- a/data/tribes/buildings/productionsites/barbarians/fishers_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/fishers_hut/init.lua
@@ -43,10 +43,6 @@ tribes:new_productionsite_type {
       barbarians_fisher = 1
    },
 
-   outputs = {
-      "fish"
-   },
-
    indicate_workarea_overlaps = {
       barbarians_fishers_hut = false,
    },

--- a/data/tribes/buildings/productionsites/barbarians/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine/init.lua
@@ -57,9 +57,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 6 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine_deep/init.lua
@@ -51,9 +51,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "snack", amount = 6 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    indicate_workarea_overlaps = {
       barbarians_goldmine = false,

--- a/data/tribes/buildings/productionsites/barbarians/goldmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine_deeper/init.lua
@@ -50,9 +50,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "meal", amount = 6 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    indicate_workarea_overlaps = {
       barbarians_goldmine = false,

--- a/data/tribes/buildings/productionsites/barbarians/granitemine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/granitemine/init.lua
@@ -53,9 +53,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 8 }
    },
-   outputs = {
-      "granite"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/helmsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/helmsmithy/init.lua
@@ -56,11 +56,6 @@ tribes:new_productionsite_type {
       { name = "iron", amount = 8 },
       { name = "gold", amount = 8 }
    },
-   outputs = {
-      "helmet",
-      "helmet_mask",
-      "helmet_warhelm"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/hunters_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/hunters_hut/init.lua
@@ -50,10 +50,6 @@ tribes:new_productionsite_type {
       barbarians_gamekeepers_hut = true,
    },
 
-   outputs = {
-      "meat"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start hunting because ...

--- a/data/tribes/buildings/productionsites/barbarians/inn/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/inn/init.lua
@@ -47,10 +47,6 @@ tribes:new_productionsite_type {
       { name = "barbarians_bread", amount = 4 },
       { name = "beer", amount = 4 }
    },
-   outputs = {
-      "ration",
-      "snack"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine/init.lua
@@ -51,9 +51,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 6 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    indicate_workarea_overlaps = {
       barbarians_ironmine = false,

--- a/data/tribes/buildings/productionsites/barbarians/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine_deep/init.lua
@@ -51,9 +51,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "snack", amount = 6 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    indicate_workarea_overlaps = {
       barbarians_ironmine = false,

--- a/data/tribes/buildings/productionsites/barbarians/ironmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine_deeper/init.lua
@@ -56,9 +56,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "meal", amount = 6 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/lime_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/lime_kiln/init.lua
@@ -45,9 +45,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 6 },
       { name = "coal", amount = 3 }
    },
-   outputs = {
-      "grout"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/lumberjacks_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/lumberjacks_hut/init.lua
@@ -40,10 +40,6 @@ tribes:new_productionsite_type {
       barbarians_lumberjack = 1
    },
 
-   outputs = {
-      "log"
-   },
-
    indicate_workarea_overlaps = {
       barbarians_rangers_hut = true,
       barbarians_lumberjacks_hut = false,

--- a/data/tribes/buildings/productionsites/barbarians/metal_workshop/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/metal_workshop/init.lua
@@ -58,18 +58,6 @@ tribes:new_productionsite_type {
       { name = "log", amount = 8 },
       { name = "iron", amount = 8 }
    },
-   outputs = {
-      "bread_paddle",
-      "felling_ax",
-      "fire_tongs",
-      "fishing_rod",
-      "hammer",
-      "hunting_spear",
-      "kitchen_tools",
-      "pick",
-      "scythe",
-      "shovel"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/micro_brewery/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/micro_brewery/init.lua
@@ -46,9 +46,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 8 },
       { name = "wheat", amount = 8 }
    },
-   outputs = {
-      "beer"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/quarry/init.lua
@@ -39,10 +39,6 @@ tribes:new_productionsite_type {
       barbarians_stonemason = 1
    },
 
-   outputs = {
-      "granite"
-   },
-
    indicate_workarea_overlaps = {
       barbarians_quarry = false,
    },

--- a/data/tribes/buildings/productionsites/barbarians/reed_yard/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/reed_yard/init.lua
@@ -34,10 +34,6 @@ tribes:new_productionsite_type {
       barbarians_gardener = 1
    },
 
-   outputs = {
-      "reed"
-   },
-
    indicate_workarea_overlaps = {
       barbarians_rangers_hut = false,
       barbarians_reed_yard = false,

--- a/data/tribes/buildings/productionsites/barbarians/smelting_works/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/smelting_works/init.lua
@@ -49,10 +49,6 @@ tribes:new_productionsite_type {
       { name = "iron_ore", amount = 8 },
       { name = "gold_ore", amount = 8 }
    },
-   outputs = {
-      "iron",
-      "gold"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/tavern/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/tavern/init.lua
@@ -51,9 +51,6 @@ tribes:new_productionsite_type {
       { name = "meat", amount = 4 },
       { name = "barbarians_bread", amount = 4 }
    },
-   outputs = {
-      "ration"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/warmill/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/warmill/init.lua
@@ -56,14 +56,6 @@ tribes:new_productionsite_type {
       { name = "iron", amount = 8 },
       { name = "gold", amount = 8 }
    },
-   outputs = {
-      "ax",
-      "ax_sharp",
-      "ax_broad",
-      "ax_bronze",
-      "ax_battle",
-      "ax_warriors"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/weaving_mill/init.lua
@@ -47,9 +47,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "reed", amount = 8 }
    },
-   outputs = {
-      "cloth"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/barbarians/well/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/well/init.lua
@@ -40,10 +40,6 @@ tribes:new_productionsite_type {
       barbarians_carrier = 1
    },
 
-   outputs = {
-      "water"
-   },
-
    indicate_workarea_overlaps = {
       barbarians_well = false,
    },

--- a/data/tribes/buildings/productionsites/barbarians/wood_hardener/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/wood_hardener/init.lua
@@ -65,9 +65,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "log", amount = 8 }
    },
-   outputs = {
-      "blackwood"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/armorsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/empire/armorsmithy/init.lua
@@ -55,12 +55,6 @@ tribes:new_productionsite_type {
       { name = "gold", amount = 8 },
       { name = "cloth", amount = 8 }
    },
-   outputs = {
-      "armor_helmet",
-      "armor",
-      "armor_chain",
-      "armor_gilded"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/bakery/init.lua
@@ -50,9 +50,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 6 },
       { name = "flour", amount = 6 }
    },
-   outputs = {
-      "empire_bread"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/empire/barracks/init.lua
@@ -49,9 +49,6 @@ tribes:new_productionsite_type {
       { name = "spear_wooden", amount = 8 },
       { name = "empire_recruit", amount = 8 }
    },
-   outputs = {
-      "empire_soldier",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/brewery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/brewery/init.lua
@@ -44,9 +44,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 7 },
       { name = "wheat", amount = 7 }
    },
-   outputs = {
-      "beer"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/empire/charcoal_kiln/init.lua
@@ -42,9 +42,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "log", amount = 8 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/coalmine/init.lua
@@ -54,9 +54,6 @@ tribes:new_productionsite_type {
       { name = "ration", amount = 6 },
       { name = "beer", amount = 6 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/coalmine_deep/init.lua
@@ -52,9 +52,6 @@ tribes:new_productionsite_type {
       { name = "meal", amount = 6 },
       { name = "beer", amount = 6 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/donkeyfarm/init.lua
+++ b/data/tribes/buildings/productionsites/empire/donkeyfarm/init.lua
@@ -42,9 +42,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 8 },
       { name = "wheat", amount = 8 }
    },
-   outputs = {
-      "empire_donkey"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/farm/init.lua
+++ b/data/tribes/buildings/productionsites/empire/farm/init.lua
@@ -47,10 +47,6 @@ tribes:new_productionsite_type {
       empire_farmer = 1
    },
 
-   outputs = {
-      "wheat"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...

--- a/data/tribes/buildings/productionsites/empire/fishers_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/fishers_house/init.lua
@@ -35,10 +35,6 @@ tribes:new_productionsite_type {
       empire_fisher = 1
    },
 
-   outputs = {
-      "fish"
-   },
-
    indicate_workarea_overlaps = {
       empire_fishers_house = false,
    },

--- a/data/tribes/buildings/productionsites/empire/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/goldmine/init.lua
@@ -54,9 +54,6 @@ tribes:new_productionsite_type {
       { name = "ration", amount = 6 },
       { name = "wine", amount = 6 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/goldmine_deep/init.lua
@@ -52,9 +52,6 @@ tribes:new_productionsite_type {
       { name = "meal", amount = 6 },
       { name = "wine", amount = 6 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/hunters_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/hunters_house/init.lua
@@ -34,10 +34,6 @@ tribes:new_productionsite_type {
       empire_hunter = 1
    },
 
-   outputs = {
-      "meat"
-   },
-
    indicate_workarea_overlaps = {
       empire_hunters_house = false,
    },

--- a/data/tribes/buildings/productionsites/empire/inn/init.lua
+++ b/data/tribes/buildings/productionsites/empire/inn/init.lua
@@ -43,10 +43,6 @@ tribes:new_productionsite_type {
       { name = "meat", amount = 6 },
       { name = "empire_bread", amount = 6 }
    },
-   outputs = {
-      "ration",
-      "meal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/ironmine/init.lua
@@ -54,9 +54,6 @@ tribes:new_productionsite_type {
       { name = "ration", amount = 6 },
       { name = "beer", amount = 6 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/ironmine_deep/init.lua
@@ -52,9 +52,6 @@ tribes:new_productionsite_type {
       { name = "meal", amount = 6 },
       { name = "beer", amount = 6 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/lumberjacks_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/lumberjacks_house/init.lua
@@ -33,10 +33,6 @@ tribes:new_productionsite_type {
       empire_lumberjack = 1
    },
 
-   outputs = {
-      "log"
-   },
-
    indicate_workarea_overlaps = {
       empire_lumberjacks_house = false,
       empire_foresters_house = true,

--- a/data/tribes/buildings/productionsites/empire/marblemine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/marblemine/init.lua
@@ -55,10 +55,6 @@ tribes:new_productionsite_type {
       { name = "ration", amount = 6 },
       { name = "wine", amount = 6 }
    },
-   outputs = {
-      "marble",
-      "granite"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/marblemine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/marblemine_deep/init.lua
@@ -52,10 +52,6 @@ tribes:new_productionsite_type {
       { name = "meal", amount = 6 },
       { name = "wine", amount = 6 }
    },
-   outputs = {
-      "marble",
-      "granite"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/mill/init.lua
+++ b/data/tribes/buildings/productionsites/empire/mill/init.lua
@@ -43,9 +43,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "wheat", amount = 6 }
    },
-   outputs = {
-      "flour"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/piggery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/piggery/init.lua
@@ -44,9 +44,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 7 },
       { name = "wheat", amount = 7 }
    },
-   outputs = {
-      "meat"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/empire/quarry/init.lua
@@ -36,11 +36,6 @@ tribes:new_productionsite_type {
       empire_quarry = false,
    },
 
-   outputs = {
-      "granite",
-      "marble"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...

--- a/data/tribes/buildings/productionsites/empire/sawmill/init.lua
+++ b/data/tribes/buildings/productionsites/empire/sawmill/init.lua
@@ -43,9 +43,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "log", amount = 8 }
    },
-   outputs = {
-      "planks"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/sheepfarm/init.lua
+++ b/data/tribes/buildings/productionsites/empire/sheepfarm/init.lua
@@ -44,9 +44,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 7 },
       { name = "wheat", amount = 7 }
    },
-   outputs = {
-      "wool"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/smelting_works/init.lua
+++ b/data/tribes/buildings/productionsites/empire/smelting_works/init.lua
@@ -50,10 +50,6 @@ tribes:new_productionsite_type {
       { name = "iron_ore", amount = 8 },
       { name = "gold_ore", amount = 8 }
    },
-   outputs = {
-      "iron",
-      "gold"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/stonemasons_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/stonemasons_house/init.lua
@@ -44,9 +44,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "marble", amount = 6 }
    },
-   outputs = {
-      "marble_column"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/tavern/init.lua
+++ b/data/tribes/buildings/productionsites/empire/tavern/init.lua
@@ -46,9 +46,6 @@ tribes:new_productionsite_type {
       { name = "meat", amount = 5 },
       { name = "empire_bread", amount = 5 }
    },
-   outputs = {
-      "ration"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/toolsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/empire/toolsmithy/init.lua
@@ -43,20 +43,6 @@ tribes:new_productionsite_type {
       { name = "log", amount = 8 },
       { name = "iron", amount = 8 },
    },
-   outputs = {
-      "felling_ax",
-      "bread_paddle",
-      "fire_tongs",
-      "fishing_rod",
-      "hammer",
-      "kitchen_tools",
-      "pick",
-      "scythe",
-      "shovel",
-      "hunting_spear",
-      "basket",
-      "saw"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/vineyard/init.lua
+++ b/data/tribes/buildings/productionsites/empire/vineyard/init.lua
@@ -40,10 +40,6 @@ tribes:new_productionsite_type {
       empire_vinefarmer = 1
    },
 
-   outputs = {
-      "grape"
-   },
-
    indicate_workarea_overlaps = {
       empire_vineyard = false,
       empire_farm = false,

--- a/data/tribes/buildings/productionsites/empire/weaponsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/empire/weaponsmithy/init.lua
@@ -52,13 +52,6 @@ tribes:new_productionsite_type {
       { name = "iron", amount = 8 },
       { name = "gold", amount = 8 }
    },
-   outputs = {
-      "spear_wooden",
-      "spear",
-      "spear_advanced",
-      "spear_heavy",
-      "spear_war"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/empire/weaving_mill/init.lua
@@ -50,9 +50,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "wool", amount = 6 }
    },
-   outputs = {
-      "cloth"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/empire/well/init.lua
+++ b/data/tribes/buildings/productionsites/empire/well/init.lua
@@ -38,10 +38,6 @@ tribes:new_productionsite_type {
       empire_carrier = 1
    },
 
-   outputs = {
-      "water"
-   },
-
    indicate_workarea_overlaps = {
       empire_well = false,
    },

--- a/data/tribes/buildings/productionsites/empire/winery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/winery/init.lua
@@ -46,9 +46,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "grape", amount = 8 }
    },
-   outputs = {
-      "wine"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/aqua_farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/aqua_farm/init.lua
@@ -53,10 +53,6 @@ tribes:new_productionsite_type {
       { name = "fruit", amount = 2 },
    },
 
-   outputs = {
-      "fish"
-   },
-
    indicate_workarea_overlaps = {
       frisians_aqua_farm = false,
       frisians_charcoal_burners_house = false,

--- a/data/tribes/buildings/productionsites/frisians/armor_smithy_large/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/armor_smithy_large/init.lua
@@ -62,11 +62,6 @@ tribes:new_productionsite_type {
       { name = "iron", amount = 8 },
       { name = "gold", amount = 8 },
    },
-   outputs = {
-      "sword_broad",
-      "sword_double",
-      "helmet_golden",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/armor_smithy_small/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/armor_smithy_small/init.lua
@@ -62,11 +62,6 @@ tribes:new_productionsite_type {
       { name = "coal", amount = 8 },
       { name = "iron", amount = 8 },
    },
-   outputs = {
-      "sword_short",
-      "sword_long",
-      "helmet",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/bakery/init.lua
@@ -63,9 +63,6 @@ tribes:new_productionsite_type {
       { name = "barley", amount = 7 },
       { name = "water", amount = 7 },
    },
-   outputs = {
-      "bread_frisians"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/barracks/init.lua
@@ -65,9 +65,6 @@ tribes:new_productionsite_type {
       { name = "fur_garment", amount = 8 },
       { name = "frisians_carrier", amount = 8 }
    },
-   outputs = {
-      "frisians_soldier",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/beekeepers_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/beekeepers_house/init.lua
@@ -55,10 +55,6 @@ tribes:new_productionsite_type {
       frisians_beekeeper = 1
    },
 
-   outputs = {
-      "honey"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...

--- a/data/tribes/buildings/productionsites/frisians/blacksmithy/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/blacksmithy/init.lua
@@ -65,20 +65,6 @@ tribes:new_productionsite_type {
       { name = "log", amount = 7 },
       { name = "reed", amount = 4 }
    },
-   outputs = {
-      "felling_ax",
-      "pick",
-      "scythe",
-      "shovel",
-      "basket",
-      "hunting_spear",
-      "fishing_net",
-      "bread_paddle",
-      "kitchen_tools",
-      "hammer",
-      "fire_tongs",
-      "needles",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/brewery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/brewery/init.lua
@@ -62,9 +62,6 @@ tribes:new_productionsite_type {
       { name = "barley", amount = 7 },
       { name = "water", amount = 7 },
    },
-   outputs = {
-      "beer"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/brick_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/brick_kiln/init.lua
@@ -64,9 +64,6 @@ tribes:new_productionsite_type {
       { name = "clay", amount = 6 },
       { name = "coal", amount = 3 },
    },
-   outputs = {
-      "brick"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/charcoal_burners_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/charcoal_burners_house/init.lua
@@ -54,10 +54,6 @@ tribes:new_productionsite_type {
       { name = "log", amount = 6 },
    },
 
-   outputs = {
-      "coal"
-   },
-
    indicate_workarea_overlaps = {
       frisians_aqua_farm = false,
       frisians_charcoal_burners_house = false,

--- a/data/tribes/buildings/productionsites/frisians/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/charcoal_kiln/init.lua
@@ -61,9 +61,6 @@ tribes:new_productionsite_type {
       { name = "log", amount = 8 },
       { name = "clay", amount = 4 },
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/clay_pit/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/clay_pit/init.lua
@@ -70,9 +70,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "water", amount = 4 },
    },
-   outputs = {
-      "clay"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/coalmine/init.lua
@@ -76,9 +76,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 8 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/coalmine_deep/init.lua
@@ -75,9 +75,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "meal", amount = 8 }
    },
-   outputs = {
-      "coal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/collectors_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/collectors_house/init.lua
@@ -53,10 +53,6 @@ tribes:new_productionsite_type {
       frisians_fruit_collector = 1
    },
 
-   outputs = {
-      "fruit"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start gathering berries because ...

--- a/data/tribes/buildings/productionsites/frisians/drinking_hall/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/drinking_hall/init.lua
@@ -64,10 +64,6 @@ tribes:new_productionsite_type {
       { name = "smoked_fish", amount = 4 },
       { name = "smoked_meat", amount = 4 },
    },
-   outputs = {
-      "ration",
-      "meal"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/farm/init.lua
@@ -68,10 +68,6 @@ tribes:new_productionsite_type {
       frisians_farmer = 1
    },
 
-   outputs = {
-      "barley"
-   },
-
    indicate_workarea_overlaps = {
       frisians_clay_pit = false,
       frisians_berry_farm = false,

--- a/data/tribes/buildings/productionsites/frisians/fishers_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/fishers_house/init.lua
@@ -52,10 +52,6 @@ tribes:new_productionsite_type {
       frisians_fisher = 1
    },
 
-   outputs = {
-      "fish"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start fishing because ...

--- a/data/tribes/buildings/productionsites/frisians/furnace/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/furnace/init.lua
@@ -74,10 +74,6 @@ tribes:new_productionsite_type {
       { name = "iron_ore", amount = 8 },
       { name = "gold_ore", amount = 8 },
    },
-   outputs = {
-      "iron",
-      "gold"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/goldmine/init.lua
@@ -77,9 +77,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 8 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/goldmine_deep/init.lua
@@ -75,9 +75,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "meal", amount = 8 }
    },
-   outputs = {
-      "gold_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/honey_bread_bakery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/honey_bread_bakery/init.lua
@@ -62,10 +62,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 8 },
       { name = "honey", amount = 6 },
    },
-   outputs = {
-      "honey_bread",
-      "bread_frisians"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/hunters_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/hunters_house/init.lua
@@ -51,11 +51,6 @@ tribes:new_productionsite_type {
       frisians_hunter = 1
    },
 
-   outputs = {
-      "meat",
-      "fur"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start hunting because ...

--- a/data/tribes/buildings/productionsites/frisians/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/ironmine/init.lua
@@ -77,9 +77,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 8 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/ironmine_deep/init.lua
@@ -75,9 +75,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "meal", amount = 8 }
    },
-   outputs = {
-      "iron_ore"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/mead_brewery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/mead_brewery/init.lua
@@ -60,10 +60,6 @@ tribes:new_productionsite_type {
       { name = "water", amount = 8 },
       { name = "honey", amount = 6 },
    },
-   outputs = {
-      "mead",
-      "beer"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/quarry/init.lua
@@ -50,10 +50,6 @@ tribes:new_productionsite_type {
       frisians_quarry = false,
    },
 
-   outputs = {
-      "granite"
-   },
-
    programs = {
       work = {
          -- TRANSLATORS: Completed/Skipped/Did not start quarrying granite because ...

--- a/data/tribes/buildings/productionsites/frisians/recycling_center/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/recycling_center/init.lua
@@ -75,11 +75,6 @@ tribes:new_productionsite_type {
       { name = "scrap_metal_mixed", amount = 8 },
       { name = "fur_garment_old", amount = 8 },
    },
-   outputs = {
-      "iron",
-      "gold",
-      "fur"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/reed_farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/reed_farm/init.lua
@@ -50,10 +50,6 @@ tribes:new_productionsite_type {
       frisians_reed_farmer = 1
    },
 
-   outputs = {
-      "reed"
-   },
-
    indicate_workarea_overlaps = {
       frisians_clay_pit = false,
       frisians_berry_farm = false,

--- a/data/tribes/buildings/productionsites/frisians/reindeer_farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/reindeer_farm/init.lua
@@ -62,11 +62,6 @@ tribes:new_productionsite_type {
       { name = "barley", amount = 8 },
       { name = "water", amount = 8 }
    },
-   outputs = {
-      "frisians_reindeer",
-      "fur",
-      "meat",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/rockmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/rockmine/init.lua
@@ -77,9 +77,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "ration", amount = 8 }
    },
-   outputs = {
-      "granite"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/rockmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/rockmine_deep/init.lua
@@ -75,9 +75,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "meal", amount = 8 }
    },
-   outputs = {
-      "granite"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/sewing_room/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/sewing_room/init.lua
@@ -60,9 +60,6 @@ tribes:new_productionsite_type {
    inputs = {
       { name = "fur", amount = 8 },
    },
-   outputs = {
-      "fur_garment"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/smokery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/smokery/init.lua
@@ -65,10 +65,6 @@ tribes:new_productionsite_type {
       { name = "fish", amount = 6 },
       { name = "log", amount = 6 },
    },
-   outputs = {
-      "smoked_meat",
-      "smoked_fish",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/tailors_shop/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/tailors_shop/init.lua
@@ -62,10 +62,6 @@ tribes:new_productionsite_type {
       { name = "iron", amount = 8 },
       { name = "gold", amount = 4 },
    },
-   outputs = {
-      "fur_garment_studded",
-      "fur_garment_golden"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/tavern/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/tavern/init.lua
@@ -66,9 +66,6 @@ tribes:new_productionsite_type {
       { name = "smoked_fish", amount = 4 },
       { name = "smoked_meat", amount = 4 },
    },
-   outputs = {
-      "ration"
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/weaving_mill/init.lua
@@ -63,9 +63,6 @@ tribes:new_productionsite_type {
       { name = "fur", amount = 6 },
       { name = "reed", amount = 6 },
    },
-   outputs = {
-      "cloth",
-   },
 
    programs = {
       work = {

--- a/data/tribes/buildings/productionsites/frisians/well/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/well/init.lua
@@ -47,10 +47,6 @@ tribes:new_productionsite_type {
       frisians_carrier = 1
    },
 
-   outputs = {
-      "water"
-   },
-
    indicate_workarea_overlaps = {
       frisians_well = false,
    },

--- a/data/tribes/buildings/productionsites/frisians/woodcutters_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/woodcutters_house/init.lua
@@ -46,10 +46,6 @@ tribes:new_productionsite_type {
       frisians_woodcutter = 1
    },
 
-   outputs = {
-      "log"
-   },
-
    indicate_workarea_overlaps = {
       frisians_foresters_house = true,
       frisians_woodcutters_house = false,

--- a/data/tribes/buildings/trainingsites/atlanteans/dungeon/init.lua
+++ b/data/tribes/buildings/trainingsites/atlanteans/dungeon/init.lua
@@ -131,9 +131,6 @@ tribes:new_trainingsite_type {
       { name = "trident_double", amount = 4 },
       { name = "trident_heavy_double", amount = 4 }
    },
-   outputs = {
-      "atlanteans_soldier",
-   },
 
    ["soldier attack"] = {
       min_level = 0,

--- a/data/tribes/buildings/trainingsites/atlanteans/labyrinth/init.lua
+++ b/data/tribes/buildings/trainingsites/atlanteans/labyrinth/init.lua
@@ -51,9 +51,6 @@ tribes:new_trainingsite_type {
       { name = "shield_steel", amount = 4 },
       { name = "shield_advanced", amount = 4 },
    },
-   outputs = {
-      "atlanteans_soldier",
-   },
 
    ["soldier defense"] = {
       min_level = 0,

--- a/data/tribes/buildings/trainingsites/barbarians/battlearena/init.lua
+++ b/data/tribes/buildings/trainingsites/barbarians/battlearena/init.lua
@@ -62,9 +62,6 @@ tribes:new_trainingsite_type {
       { name = "barbarians_bread", amount = 8 },
       { name = "beer_strong", amount = 8 }
    },
-   outputs = {
-      "barbarians_soldier",
-   },
 
    ["soldier evade"] = {
       min_level = 0,

--- a/data/tribes/buildings/trainingsites/barbarians/trainingcamp/init.lua
+++ b/data/tribes/buildings/trainingsites/barbarians/trainingcamp/init.lua
@@ -62,9 +62,6 @@ tribes:new_trainingsite_type {
       { name = "helmet_mask", amount = 2 },
       { name = "helmet_warhelm", amount = 2 }
    },
-   outputs = {
-      "barbarians_soldier",
-   },
 
    ["soldier attack"] = {
       min_level = 0,

--- a/data/tribes/buildings/trainingsites/empire/arena/init.lua
+++ b/data/tribes/buildings/trainingsites/empire/arena/init.lua
@@ -52,9 +52,6 @@ tribes:new_trainingsite_type {
       { name = "meat", amount = 6 },
       { name = "empire_bread", amount = 10 }
    },
-   outputs = {
-      "empire_soldier",
-   },
 
    ["soldier evade"] = {
       min_level = 0,

--- a/data/tribes/buildings/trainingsites/empire/colosseum/init.lua
+++ b/data/tribes/buildings/trainingsites/empire/colosseum/init.lua
@@ -48,9 +48,6 @@ tribes:new_trainingsite_type {
       { name = "meat", amount = 8 },
       { name = "empire_bread", amount = 8 }
    },
-   outputs = {
-      "empire_soldier",
-   },
 
    ["soldier evade"] = {
       min_level = 0,

--- a/data/tribes/buildings/trainingsites/empire/trainingcamp/init.lua
+++ b/data/tribes/buildings/trainingsites/empire/trainingcamp/init.lua
@@ -56,9 +56,6 @@ tribes:new_trainingsite_type {
       { name = "armor_chain", amount = 2 },
       { name = "armor_gilded", amount = 2 },
    },
-   outputs = {
-      "empire_soldier",
-   },
 
    ["soldier attack"] = {
       min_level = 0,

--- a/data/tribes/buildings/trainingsites/frisians/training_arena/init.lua
+++ b/data/tribes/buildings/trainingsites/frisians/training_arena/init.lua
@@ -74,12 +74,6 @@ tribes:new_trainingsite_type {
       { name = "helmet_golden", amount = 2 },
       { name = "fur_garment_golden", amount = 2 },
    },
-   outputs = {
-      "frisians_soldier",
-      "scrap_iron",
-      "scrap_metal_mixed",
-      "fur_garment_old",
-   },
 
    ["soldier attack"] = {
       min_level = 3,

--- a/data/tribes/buildings/trainingsites/frisians/training_camp/init.lua
+++ b/data/tribes/buildings/trainingsites/frisians/training_camp/init.lua
@@ -73,12 +73,6 @@ tribes:new_trainingsite_type {
       { name = "helmet", amount = 2 },
       { name = "fur_garment_studded", amount = 2 },
    },
-   outputs = {
-      "frisians_soldier",
-      "scrap_metal_mixed",
-      "scrap_iron",
-      "fur_garment_old",
-   },
 
    ["soldier attack"] = {
       min_level = 0,

--- a/data/tribes/scripting/help/building_help.lua
+++ b/data/tribes/scripting/help/building_help.lua
@@ -206,13 +206,13 @@ function building_help_general_string(tribe, building_description)
 -- TODO(GunChleoc) "carrier" for headquarters, "ship" for ports, "scout" for scouts_hut, "shipwright" for shipyard?
 -- TODO(GunChleoc) use aihints for gamekeeper, forester?
    local representative_resource = nil
-   if (building_description.type_name == "productionsite" or
-       building_description.type_name == "trainingsite") then
+   if (building_description.type_name == "productionsite") then
       representative_resource = building_description.output_ware_types[1]
       if(not representative_resource) then
          representative_resource = building_description.output_worker_types[1]
       end
-   elseif (building_description.type_name == "militarysite") then
+   elseif (building_description.type_name == "militarysite" or
+       building_description.type_name == "trainingsite") then
       representative_resource = wl.Game():get_worker_description(tribe.soldier)
 -- TODO(GunChleoc) need a bob_descr for the ship -> port and shipyard
 -- TODO(GunChleoc) create descr objects for flag, portdock, ...

--- a/src/ai/ai_hints.h
+++ b/src/ai/ai_hints.h
@@ -82,7 +82,6 @@ struct BuildingHints {
 	}
 
 	const std::string& collects_ware_from_map() const {
-        // NOCOM deduce this: empty inputs?
 		return collects_ware_from_map_;
 	}
 

--- a/src/ai/ai_hints.h
+++ b/src/ai/ai_hints.h
@@ -82,6 +82,7 @@ struct BuildingHints {
 	}
 
 	const std::string& collects_ware_from_map() const {
+        // NOCOM deduce this: empty inputs?
 		return collects_ware_from_map_;
 	}
 

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -171,7 +171,6 @@ ProductionProgram::parse_ware_type_groups(std::vector<std::string>::const_iterat
 BillOfMaterials
 ProductionProgram::parse_bill_of_materials(const std::vector<std::string>& arguments,
                                            WareWorker ww,
-                                           const ProductionSiteDescr& descr,
                                            const Tribes& tribes) {
 	BillOfMaterials result;
 	for (const std::string& argument : arguments) {
@@ -180,22 +179,6 @@ ProductionProgram::parse_bill_of_materials(const std::vector<std::string>& argum
 		const DescriptionIndex index = ww == WareWorker::wwWARE ?
 		                                  tribes.safe_ware_index(produceme.first) :
 		                                  tribes.safe_worker_index(produceme.first);
-
-		// Verify the building outputs
-		switch (ww) {
-		case WareWorker::wwWARE:
-			if (!descr.is_output_ware_type(index)) {
-				throw GameDataError("Ware '%s' is not listed in the building's 'outputs' table",
-				                    produceme.first.c_str());
-			}
-			break;
-		case WareWorker::wwWORKER:
-			if (!descr.is_output_worker_type(index)) {
-				throw GameDataError("Worker '%s' is not listed in the building's 'outputs' table",
-				                    produceme.first.c_str());
-			}
-			break;
-		}
 
 		result.push_back(std::make_pair(index, read_positive(produceme.second)));
 	}
@@ -637,10 +620,17 @@ ProductionProgram::ActCallWorker::ActCallWorker(const std::vector<std::string>& 
 	const WorkerDescr& main_worker_descr =
 	   *tribes.get_worker_descr(descr->working_positions().front().first);
 
+	WorkerProgram const* workerprogram = main_worker_descr.get_program(program_);
+
 	//  This will fail unless the main worker has a program with the given
 	//  name, so it also validates the parameter.
 	const WorkareaInfo& worker_workarea_info =
-	   main_worker_descr.get_program(program_)->get_workarea_info();
+	   workerprogram->get_workarea_info();
+
+	// Add to building outputs for help and AI
+	for (const DescriptionIndex produced_ware : workerprogram->produced_ware_types()) {
+		descr->add_output_ware_type(produced_ware);
+	}
 
 	for (const auto& area_info : worker_workarea_info) {
 		std::set<std::string>& building_radius_infos = descr->workarea_info_[area_info.first];
@@ -834,12 +824,17 @@ void ProductionProgram::ActConsume::execute(Game& game, ProductionSite& ps) cons
 }
 
 ProductionProgram::ActProduce::ActProduce(const std::vector<std::string>& arguments,
-                                          const ProductionSiteDescr& descr,
+                                          ProductionSiteDescr& descr,
                                           const Tribes& tribes) {
 	if (arguments.empty()) {
 		throw GameDataError("Usage: produce=<ware name>[:<amount>] [<ware name>[:<amount>]...]");
 	}
-	produced_wares_ = parse_bill_of_materials(arguments, WareWorker::wwWARE, descr, tribes);
+	produced_wares_ = parse_bill_of_materials(arguments, WareWorker::wwWARE, tribes);
+
+	// Add to building outputs for help and AI
+	for (auto& produced_ware : produced_wares_) {
+		descr.add_output_ware_type(produced_ware.first);
+	}
 }
 
 void ProductionProgram::ActProduce::execute(Game& game, ProductionSite& ps) const {
@@ -886,12 +881,17 @@ bool ProductionProgram::ActProduce::get_building_work(Game& game,
 }
 
 ProductionProgram::ActRecruit::ActRecruit(const std::vector<std::string>& arguments,
-                                          const ProductionSiteDescr& descr,
+                                          ProductionSiteDescr& descr,
                                           const Tribes& tribes) {
 	if (arguments.empty()) {
 		throw GameDataError("Usage: recruit=<worker name>[:<amount>] [<worker name>[:<amount>]...]");
 	}
-	recruited_workers_ = parse_bill_of_materials(arguments, WareWorker::wwWORKER, descr, tribes);
+	recruited_workers_ = parse_bill_of_materials(arguments, WareWorker::wwWORKER, tribes);
+
+	// Add to building outputs for help and AI
+	for (auto& recruited_worker : recruited_workers_) {
+		descr.add_output_worker_type(recruited_worker.first);
+	}
 }
 
 void ProductionProgram::ActRecruit::execute(Game& game, ProductionSite& ps) const {

--- a/src/logic/map_objects/tribes/production_program.h
+++ b/src/logic/map_objects/tribes/production_program.h
@@ -99,7 +99,6 @@ struct ProductionProgram : public MapObjectProgram {
 	/// match. Example: "fish:2".
 	static BillOfMaterials parse_bill_of_materials(const std::vector<std::string>& arguments,
 	                                               WareWorker ww,
-	                                               const ProductionSiteDescr& descr,
 	                                               const Tribes& tribes);
 
 	/// Returns from the program.
@@ -413,7 +412,7 @@ struct ProductionProgram : public MapObjectProgram {
 	/// wares are handled is defined by the productionsite.
 	struct ActProduce : public Action {
 		ActProduce(const std::vector<std::string>& arguments,
-		           const ProductionSiteDescr&,
+		           ProductionSiteDescr&,
 		           const Tribes& tribes);
 		void execute(Game&, ProductionSite&) const override;
 		bool get_building_work(Game&, ProductionSite&, Worker&) const override;
@@ -436,7 +435,7 @@ struct ProductionProgram : public MapObjectProgram {
 	/// recruited workers are handled is defined by the productionsite.
 	struct ActRecruit : public Action {
 		ActRecruit(const std::vector<std::string>& arguments,
-		           const ProductionSiteDescr&,
+		           ProductionSiteDescr&,
 		           const Tribes& tribes);
 		void execute(Game&, ProductionSite&) const override;
 		bool get_building_work(Game&, ProductionSite&, Worker&) const override;

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -117,29 +117,7 @@ ProductionSiteDescr::ProductionSiteDescr(const std::string& init_descname,
 	}
 
 	if (table.has_key("outputs")) {
-		for (const std::string& output : table.get_table("outputs")->array_entries<std::string>()) {
-			try {
-				DescriptionIndex idx = tribes.ware_index(output);
-				if (tribes.ware_exists(idx)) {
-					if (output_ware_types_.count(idx)) {
-						throw wexception("this ware type has already been declared as an output");
-					}
-					output_ware_types_.insert(idx);
-				} else {
-					idx = tribes.worker_index(output);
-					if (tribes.worker_exists(idx)) {
-						if (output_worker_types_.count(idx)) {
-							throw wexception("this worker type has already been declared as an output");
-						}
-						output_worker_types_.insert(idx);
-					} else {
-						throw wexception("tribes do not define a ware or worker type with this name");
-					}
-				}
-			} catch (const WException& e) {
-				throw wexception("output \"%s\": %s", output.c_str(), e.what());
-			}
-		}
+		log("WARNING: The \"outputs\" table is no longer needed; you can remove it from %s\n", name().c_str());
 	}
 
 	if (table.has_key("inputs")) {

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -49,7 +49,7 @@ enum class FailNotificationType { kDefault, kFull };
  */
 class ProductionSiteDescr : public BuildingDescr {
 public:
-	friend struct ProductionProgram;  // To add animations
+	friend struct ProductionProgram;  // To add animations, outputs etc.
 
 	ProductionSiteDescr(const std::string& init_descname,
 	                    const std::string& msgctxt,
@@ -141,6 +141,14 @@ public:
 
 	const std::map<std::string, bool>& get_highlight_overlapping_workarea_for() const {
 		return highlight_overlapping_workarea_for_;
+	}
+
+protected:
+	void add_output_ware_type(DescriptionIndex index) {
+		output_ware_types_.insert(index);
+	}
+	void add_output_worker_type(DescriptionIndex index) {
+		output_worker_types_.insert(index);
 	}
 
 private:

--- a/src/logic/map_objects/tribes/worker_program.cc
+++ b/src/logic/map_objects/tribes/worker_program.cc
@@ -170,8 +170,11 @@ void WorkerProgram::parse_createware(Worker::Action* act, const std::vector<std:
 		throw wexception("Usage: createware=<ware type>");
 	}
 
+	const DescriptionIndex ware_index = tribes_.safe_ware_index(cmd[0]);
+
 	act->function = &Worker::run_createware;
-	act->iparam1 = tribes_.safe_ware_index(cmd[0]);
+	act->iparam1 = ware_index;
+	produced_ware_types_.insert(ware_index);
 }
 
 /* RST

--- a/src/logic/map_objects/tribes/worker_program.h
+++ b/src/logic/map_objects/tribes/worker_program.h
@@ -56,6 +56,11 @@ struct WorkerProgram : public MapObjectProgram {
 		return workarea_info_;
 	}
 
+	/// Set of ware types produced by this program
+	const std::set<DescriptionIndex>& produced_ware_types() const {
+		return produced_ware_types_;
+	}
+
 private:
 	WorkareaInfo workarea_info_;
 	struct ParseMap {
@@ -87,6 +92,7 @@ private:
 	const Tribes& tribes_;
 	Actions actions_;
 	static ParseMap const parsemap_[];
+	std::set<DescriptionIndex> produced_ware_types_;
 	DISALLOW_COPY_AND_ASSIGN(WorkerProgram);
 };
 }  // namespace Widelands

--- a/src/website/map_object_info.cc
+++ b/src/website/map_object_info.cc
@@ -101,10 +101,15 @@ void write_buildings(const TribeDescr& tribe, EditorGameBase& egbase, FileSystem
 				}
 			}
 			// Produces workers
-			if (productionsite->output_worker_types().size() > 0) {
+			if (productionsite->output_worker_types().size() > 0
+				|| productionsite->type() == Widelands::MapObjectType::TRAININGSITE) {
 				JSON::Array* json_workers_array = json_building->add_array("produced_workers");
 				for (DescriptionIndex worker_index : productionsite->output_worker_types()) {
 					json_workers_array->add_empty(tribe.get_worker_descr(worker_index)->name());
+				}
+				// Trainingsites
+				if (productionsite->type() == Widelands::MapObjectType::TRAININGSITE) {
+					json_workers_array->add_empty(tribe.get_worker_descr(tribe.soldier())->name());
 				}
 			}
 


### PR DESCRIPTION
* The building "outputs" table was originally added for the Encyclopedia, and is now being used by the AI as well. We can now easily get that information from the productionsite programs, uncluttering the Lua configuration.
* 2 separate commits for C++ code and Lua configuration.

@tibor95 There's a difference for the AI here - Trainingsites are no longer classified as having `BuildingAttribute::kBarracks`. Does this fix an AI bug or add one?