### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/src/editor/ui_menus/tool_place_critter_options_menu.h
+++ b/src/editor/ui_menus/tool_place_critter_options_menu.h
@@ -28,7 +28,7 @@
 
 class EditorInteractive;
 namespace Widelands {
-struct CritterDescr;
+class CritterDescr;
 }
 
 struct EditorToolPlaceCritterOptionsMenu : public EditorToolOptionsMenu {

--- a/src/graphic/text/sdl_ttf_font.cc
+++ b/src/graphic/text/sdl_ttf_font.cc
@@ -53,7 +53,7 @@ void SdlTtfFont::dimensions(const std::string& txt, int style, uint16_t* gw, uin
 	// Getting height from TTF_SizeUTF8() was sometimes causing misaligned text,
 	// so use TTF_FontHeight() to get it instead
 	int w, h;
-	TTF_SizeUTF8(font_, txt.c_str(), &w, NULL);
+	TTF_SizeUTF8(font_, txt.c_str(), &w, nullptr);
 	h = TTF_FontHeight(font_);
 
 	if (style & SHADOW) {

--- a/src/logic/map_objects/map_object.h
+++ b/src/logic/map_objects/map_object.h
@@ -86,8 +86,8 @@ std::string to_string(MapObjectType type);
  * Base class for descriptions of worker, files and so on. This must just
  * link them together
  */
-struct MapObjectDescr {
-
+class MapObjectDescr {
+public:
 	enum class OwnerType { kWorld, kTribe };
 
 	MapObjectDescr(const MapObjectType init_type,

--- a/src/logic/map_objects/map_object_program.h
+++ b/src/logic/map_objects/map_object_program.h
@@ -29,7 +29,7 @@
 
 namespace Widelands {
 
-struct MapObjectDescr;
+class MapObjectDescr;
 
 /// Superclass for Worker, Immovable and Productionsite programs. Includes a program name and
 /// diverse parsing convenience functions. The creation and execution of program actions is left to

--- a/src/logic/map_objects/world/critter.h
+++ b/src/logic/map_objects/world/critter.h
@@ -38,7 +38,8 @@ class World;
 //
 // Description
 //
-struct CritterDescr : BobDescr {
+class CritterDescr : public BobDescr {
+public:
 	CritterDescr(const std::string& init_descname, const LuaTable&, const Widelands::World& world);
 	~CritterDescr() override;
 

--- a/src/logic/map_objects/world/world.h
+++ b/src/logic/map_objects/world/world.h
@@ -29,7 +29,7 @@ class LuaTable;
 
 namespace Widelands {
 
-struct CritterDescr;
+class CritterDescr;
 class EditorCategory;
 class ImmovableDescr;
 class ResourceDescription;


### PR DESCRIPTION
* Replace `struct` with `class` for `MapObjectDescr` and `CritterDescr`
* Replace `NULL` with `nullptr`

Re. https://github.com/widelands/widelands/issues/1558 but does not close it.