### PR TITLE
Animation duration units

### DIFF
--- a/data/world/immovables/bush1/init.lua
+++ b/data/world/immovables/bush1/init.lua
@@ -69,7 +69,7 @@ dirname = path.dirname(__file__)
 --        like this::
 --
 --            program = {
---               "animate=idle duration:50s",
+--               "animate=idle duration:1m20s500ms",
 --               "remove=18",
 --               "grow=alder_summer_old",
 --            },

--- a/data/world/immovables/bush1/init.lua
+++ b/data/world/immovables/bush1/init.lua
@@ -69,7 +69,7 @@ dirname = path.dirname(__file__)
 --        like this::
 --
 --            program = {
---               "animate=idle 50000",
+--               "animate=idle duration:50s",
 --               "remove=18",
 --               "grow=alder_summer_old",
 --            },

--- a/data/world/immovables/trees/alder/init.lua
+++ b/data/world/immovables/trees/alder/init.lua
@@ -24,7 +24,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:57500ms",
+         "animate=idle duration:57s500ms",
          "remove=21",
          "grow=alder_summer_pole",
       },
@@ -51,7 +51,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:52500ms",
+         "animate=idle duration:52s500ms",
          "remove=19",
          "grow=alder_summer_mature",
       },
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1550s",
+         "animate=idle duration:25m50s",
          "transform=deadtree4 5",
          "seed=alder_summer_sapling 180",
       },

--- a/data/world/immovables/trees/alder/init.lua
+++ b/data/world/immovables/trees/alder/init.lua
@@ -24,7 +24,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 57500",
+         "animate=idle duration:57500ms",
          "remove=21",
          "grow=alder_summer_pole",
       },
@@ -51,7 +51,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 52500",
+         "animate=idle duration:52500ms",
          "remove=19",
          "grow=alder_summer_mature",
       },
@@ -78,7 +78,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 50000",
+         "animate=idle duration:50s",
          "remove=18",
          "grow=alder_summer_old",
       },
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1550000",
+         "animate=idle duration:1550s",
          "transform=deadtree4 5",
          "seed=alder_summer_sapling 180",
       },

--- a/data/world/immovables/trees/aspen/init.lua
+++ b/data/world/immovables/trees/aspen/init.lua
@@ -102,12 +102,12 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1050s",
+         "animate=idle duration:17m30s",
          "transform=deadtree2 15",
          "seed=aspen_summer_sapling 100",
       },
       fall = {
-         "animate=falling duration:1400ms",
+         "animate=falling duration:1s400ms",
          "transform=fallentree",
       },
    },

--- a/data/world/immovables/trees/aspen/init.lua
+++ b/data/world/immovables/trees/aspen/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 38000",
+         "animate=idle duration:38s",
          "remove=50",
          "grow=aspen_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 38000",
+         "animate=idle duration:38s",
          "remove=47",
          "grow=aspen_summer_mature",
       },
@@ -70,10 +70,10 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 20000",
+         "animate=idle duration:20s",
          "remove=30",
          "seed=aspen_summer_sapling 60",
-         "animate=idle 20000",
+         "animate=idle duration:20s",
          "remove=20",
          "grow=aspen_summer_old",
       },
@@ -102,12 +102,12 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1050000",
+         "animate=idle duration:1050s",
          "transform=deadtree2 15",
          "seed=aspen_summer_sapling 100",
       },
       fall = {
-         "animate=falling 1400",
+         "animate=falling duration:1400ms",
          "transform=fallentree",
       },
    },

--- a/data/world/immovables/trees/beech/init.lua
+++ b/data/world/immovables/trees/beech/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=35",
          "grow=beech_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 65000",
+         "animate=idle duration:65s",
          "remove=24",
          "grow=beech_summer_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 72000",
+         "animate=idle duration:72s",
          "remove=19",
          "grow=beech_summer_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1525000",
+         "animate=idle duration:1525s",
          "transform=deadtree2 20",
          "seed=beech_summer_sapling 250",
       },

--- a/data/world/immovables/trees/beech/init.lua
+++ b/data/world/immovables/trees/beech/init.lua
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:65s",
+         "animate=idle duration:1m5s",
          "remove=24",
          "grow=beech_summer_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:72s",
+         "animate=idle duration:1m12s",
          "remove=19",
          "grow=beech_summer_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1525s",
+         "animate=idle duration:25m25s",
          "transform=deadtree2 20",
          "seed=beech_summer_sapling 250",
       },

--- a/data/world/immovables/trees/birch/init.lua
+++ b/data/world/immovables/trees/birch/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 42000",
+         "animate=idle duration:42s",
          "remove=32",
          "grow=birch_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 40000",
+         "animate=idle duration:40s",
          "remove=25",
          "grow=birch_summer_mature",
       },
@@ -70,10 +70,10 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 25000",
+         "animate=idle duration:25s",
          "remove=10",
          "seed=birch_summer_sapling 200",
-         "animate=idle 30000",
+         "animate=idle duration:30s",
          "remove=10",
          "grow=birch_summer_old",
       },
@@ -102,7 +102,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 800000",
+         "animate=idle duration:800s",
          "transform=deadtree2 27",
          "seed=birch_summer_sapling 60",
       },

--- a/data/world/immovables/trees/birch/init.lua
+++ b/data/world/immovables/trees/birch/init.lua
@@ -102,7 +102,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:800s",
+         "animate=idle duration:13m20s",
          "transform=deadtree2 27",
          "seed=birch_summer_sapling 60",
       },

--- a/data/world/immovables/trees/cirrus/init.lua
+++ b/data/world/immovables/trees/cirrus/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:61s",
+         "animate=idle duration:1m1s",
          "remove=44",
          "grow=cirrus_wasteland_pole",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1455s",
+         "animate=idle duration:24m15s",
          "transform=deadtree3 34",
          "seed=cirrus_wasteland_sapling 100",
       },

--- a/data/world/immovables/trees/cirrus/init.lua
+++ b/data/world/immovables/trees/cirrus/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 61000",
+         "animate=idle duration:61s",
          "remove=44",
          "grow=cirrus_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 59000",
+         "animate=idle duration:59s",
          "remove=34",
          "grow=cirrus_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=24",
          "grow=cirrus_wasteland_old",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1455000",
+         "animate=idle duration:1455s",
          "transform=deadtree3 34",
          "seed=cirrus_wasteland_sapling 100",
       },

--- a/data/world/immovables/trees/deadtree1/init.lua
+++ b/data/world/immovables/trees/deadtree1/init.lua
@@ -8,7 +8,7 @@ world:new_immovable_type{
    attributes = {},
    programs = {
       program = {
-        "animate=idle 20000",
+        "animate=idle duration:20s",
        "remove=16"
       }
    },

--- a/data/world/immovables/trees/deadtree2/init.lua
+++ b/data/world/immovables/trees/deadtree2/init.lua
@@ -8,7 +8,7 @@ world:new_immovable_type{
    attributes = {},
    programs = {
       program = {
-        "animate=idle 20000",
+        "animate=idle duration:20s",
        "remove=12"
       }
    },

--- a/data/world/immovables/trees/deadtree3/init.lua
+++ b/data/world/immovables/trees/deadtree3/init.lua
@@ -8,7 +8,7 @@ world:new_immovable_type{
    attributes = {},
    programs = {
       program = {
-        "animate=idle 20000",
+        "animate=idle duration:20s",
        "remove=16"
       }
    },

--- a/data/world/immovables/trees/deadtree4/init.lua
+++ b/data/world/immovables/trees/deadtree4/init.lua
@@ -8,7 +8,7 @@ world:new_immovable_type{
    attributes = {},
    programs = {
       program = {
-        "animate=idle 20000",
+        "animate=idle duration:20s",
        "remove=18"
       }
    },

--- a/data/world/immovables/trees/deadtree5/init.lua
+++ b/data/world/immovables/trees/deadtree5/init.lua
@@ -8,7 +8,7 @@ world:new_immovable_type{
    attributes = {},
    programs = {
       program = {
-        "animate=idle 20000",
+        "animate=idle duration:20s",
        "remove=12"
       }
    },

--- a/data/world/immovables/trees/deadtree6/init.lua
+++ b/data/world/immovables/trees/deadtree6/init.lua
@@ -8,7 +8,7 @@ world:new_immovable_type{
    attributes = {},
    programs = {
       program = {
-        "animate=idle 20000",
+        "animate=idle duration:20s",
        "remove=16"
       }
    },

--- a/data/world/immovables/trees/fallentree/init.lua
+++ b/data/world/immovables/trees/fallentree/init.lua
@@ -15,7 +15,7 @@ world:new_immovable_type{
    attributes = {},
    programs = {
       program = {
-        "animate=idle 30000",
+        "animate=idle duration:30s",
        "remove="
       }
    },

--- a/data/world/immovables/trees/larch/init.lua
+++ b/data/world/immovables/trees/larch/init.lua
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1455s",
+         "animate=idle duration:24m15s",
          "transform=deadtree3 23",
          "seed=larch_summer_sapling 30",
       },

--- a/data/world/immovables/trees/larch/init.lua
+++ b/data/world/immovables/trees/larch/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 60000",
+         "animate=idle duration:1m",
          "remove=44",
          "grow=larch_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 60000",
+         "animate=idle duration:1m",
          "remove=34",
          "grow=larch_summer_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=24",
          "grow=larch_summer_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1455000",
+         "animate=idle duration:1455s",
          "transform=deadtree3 23",
          "seed=larch_summer_sapling 30",
       },

--- a/data/world/immovables/trees/liana/init.lua
+++ b/data/world/immovables/trees/liana/init.lua
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1455s",
+         "animate=idle duration:24m15s",
          "transform=deadtree4 48",
          "seed=liana_wasteland_sapling 100",
       },

--- a/data/world/immovables/trees/liana/init.lua
+++ b/data/world/immovables/trees/liana/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 60000",
+         "animate=idle duration:1m",
          "remove=40",
          "grow=liana_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=30",
          "grow=liana_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=10",
          "seed=liana_wasteland_sapling 30",
          "animate=idle 30000",
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1455000",
+         "animate=idle duration:1455s",
          "transform=deadtree4 48",
          "seed=liana_wasteland_sapling 100",
       },

--- a/data/world/immovables/trees/maple/init.lua
+++ b/data/world/immovables/trees/maple/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:57500ms",
+         "animate=idle duration:57s500ms",
          "remove=21",
          "grow=maple_winter_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:52500ms",
+         "animate=idle duration:52s500ms",
          "remove=19",
          "grow=maple_winter_mature",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1550s",
+         "animate=idle duration:25m50s",
          "transform=deadtree4 39",
          "seed=maple_winter_sapling 240",
       },

--- a/data/world/immovables/trees/maple/init.lua
+++ b/data/world/immovables/trees/maple/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 57500",
+         "animate=idle duration:57500ms",
          "remove=21",
          "grow=maple_winter_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 52500",
+         "animate=idle duration:52500ms",
          "remove=19",
          "grow=maple_winter_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 50000",
+         "animate=idle duration:50s",
          "remove=18",
          "grow=maple_winter_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1550000",
+         "animate=idle duration:1550s",
          "transform=deadtree4 39",
          "seed=maple_winter_sapling 240",
       },

--- a/data/world/immovables/trees/mushroom_dark/init.lua
+++ b/data/world/immovables/trees/mushroom_dark/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 72500",
+         "animate=idle duration:72500ms",
          "remove=80",
          "grow=mushroom_dark_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 72500",
+         "animate=idle duration:72500ms",
          "remove=70",
          "grow=mushroom_dark_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 75000",
+         "animate=idle duration:75s",
          "remove=40",
          "grow=mushroom_dark_wasteland_old",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1050000",
+         "animate=idle duration:1050s",
          "transform=deadtree2 25",
          "seed=mushroom_dark_wasteland_sapling 200",
       },

--- a/data/world/immovables/trees/mushroom_dark/init.lua
+++ b/data/world/immovables/trees/mushroom_dark/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:72500ms",
+         "animate=idle duration:1m12s500ms",
          "remove=80",
          "grow=mushroom_dark_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:72500ms",
+         "animate=idle duration:1m12s500ms",
          "remove=70",
          "grow=mushroom_dark_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:75s",
+         "animate=idle duration:1m15s",
          "remove=40",
          "grow=mushroom_dark_wasteland_old",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1050s",
+         "animate=idle duration:17m30s",
          "transform=deadtree2 25",
          "seed=mushroom_dark_wasteland_sapling 200",
       },

--- a/data/world/immovables/trees/mushroom_green/init.lua
+++ b/data/world/immovables/trees/mushroom_green/init.lua
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:65s",
+         "animate=idle duration:1m5s",
          "remove=24",
          "grow=mushroom_green_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:72s",
+         "animate=idle duration:1m12s",
          "remove=19",
          "grow=mushroom_green_wasteland_old",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1535s",
+         "animate=idle duration:25m35s",
          "transform=deadtree2 33",
          "seed=mushroom_green_wasteland_sapling 220",
       },

--- a/data/world/immovables/trees/mushroom_green/init.lua
+++ b/data/world/immovables/trees/mushroom_green/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=35",
          "grow=mushroom_green_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 65000",
+         "animate=idle duration:65s",
          "remove=24",
          "grow=mushroom_green_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 72000",
+         "animate=idle duration:72s",
          "remove=19",
          "grow=mushroom_green_wasteland_old",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1535000",
+         "animate=idle duration:1535s",
          "transform=deadtree2 33",
          "seed=mushroom_green_wasteland_sapling 220",
       },

--- a/data/world/immovables/trees/mushroom_red/init.lua
+++ b/data/world/immovables/trees/mushroom_red/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 42000",
+         "animate=idle duration:42s",
          "remove=32",
          "grow=mushroom_red_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 40000",
+         "animate=idle duration:40s",
          "remove=25",
          "grow=mushroom_red_wasteland_mature",
       },
@@ -73,10 +73,10 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 27000",
+         "animate=idle duration:27s",
          "remove=10",
          "seed=mushroom_red_wasteland_sapling 100",
-         "animate=idle 29000",
+         "animate=idle duration:29s",
          "remove=10",
          "grow=mushroom_red_wasteland_old",
       },
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 800000",
+         "animate=idle duration:800s",
          "transform=deadtree2 50",
          "seed=mushroom_red_wasteland_sapling 40",
       },

--- a/data/world/immovables/trees/mushroom_red/init.lua
+++ b/data/world/immovables/trees/mushroom_red/init.lua
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:800s",
+         "animate=idle duration:13m20s",
          "transform=deadtree2 50",
          "seed=mushroom_red_wasteland_sapling 40",
       },

--- a/data/world/immovables/trees/oak/init.lua
+++ b/data/world/immovables/trees/oak/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:72500ms",
+         "animate=idle duration:1m12s500ms",
          "remove=80",
          "grow=oak_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:72500ms",
+         "animate=idle duration:1m12s500ms",
          "remove=70",
          "grow=oak_summer_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:75s",
+         "animate=idle duration:1m15s",
          "remove=40",
          "grow=oak_summer_old",
       },
@@ -99,12 +99,12 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:2250s",
+         "animate=idle duration:37m30s",
          "transform=deadtree2 12",
          "seed=oak_summer_sapling 100",
       },
       fall = {
-         "animate=falling 1400",
+         "animate=falling 1s400ms",
          "transform=fallentree",
       },
    },

--- a/data/world/immovables/trees/oak/init.lua
+++ b/data/world/immovables/trees/oak/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 72500",
+         "animate=idle duration:72500ms",
          "remove=80",
          "grow=oak_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 72500",
+         "animate=idle duration:72500ms",
          "remove=70",
          "grow=oak_summer_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 75000",
+         "animate=idle duration:75s",
          "remove=40",
          "grow=oak_summer_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 2250000",
+         "animate=idle duration:2250s",
          "transform=deadtree2 12",
          "seed=oak_summer_sapling 100",
       },

--- a/data/world/immovables/trees/palm_borassus/init.lua
+++ b/data/world/immovables/trees/palm_borassus/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:70s",
+         "animate=idle duration:1m10s",
          "remove=80",
          "grow=palm_borassus_desert_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:70s",
+         "animate=idle duration:1m10s",
          "remove=70",
          "grow=palm_borassus_desert_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:65s",
+         "animate=idle duration:1m5s",
          "remove=40",
          "grow=palm_borassus_desert_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:2000s",
+         "animate=idle duration:33m20s",
          "transform=deadtree5 25",
          "seed=palm_borassus_desert_sapling 160",
       },

--- a/data/world/immovables/trees/palm_borassus/init.lua
+++ b/data/world/immovables/trees/palm_borassus/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 70000",
+         "animate=idle duration:70s",
          "remove=80",
          "grow=palm_borassus_desert_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 70000",
+         "animate=idle duration:70s",
          "remove=70",
          "grow=palm_borassus_desert_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 65000",
+         "animate=idle duration:65s",
          "remove=40",
          "grow=palm_borassus_desert_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 2000000",
+         "animate=idle duration:2000s",
          "transform=deadtree5 25",
          "seed=palm_borassus_desert_sapling 160",
       },

--- a/data/world/immovables/trees/palm_coconut/init.lua
+++ b/data/world/immovables/trees/palm_coconut/init.lua
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1550s",
+         "animate=idle duration:25m50s",
          "transform=deadtree6 36",
          "seed=palm_coconut_desert_sapling 100",
       },

--- a/data/world/immovables/trees/palm_coconut/init.lua
+++ b/data/world/immovables/trees/palm_coconut/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=42",
          "grow=palm_coconut_desert_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=33",
          "grow=palm_coconut_desert_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 60000",
+         "animate=idle duration:1m",
          "remove=23",
          "grow=palm_coconut_desert_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1550000",
+         "animate=idle duration:1550s",
          "transform=deadtree6 36",
          "seed=palm_coconut_desert_sapling 100",
       },

--- a/data/world/immovables/trees/palm_date/init.lua
+++ b/data/world/immovables/trees/palm_date/init.lua
@@ -102,7 +102,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1050s",
+         "animate=idle duration:17m30s",
          "transform=deadtree5 32",
          "seed=palm_date_desert_sapling 200",
       },

--- a/data/world/immovables/trees/palm_date/init.lua
+++ b/data/world/immovables/trees/palm_date/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 38000",
+         "animate=idle duration:38s",
          "remove=50",
          "grow=palm_date_desert_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 38000",
+         "animate=idle duration:38s",
          "remove=47",
          "grow=palm_date_desert_mature",
       },
@@ -70,10 +70,10 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 20000",
+         "animate=idle duration:20s",
          "remove=30",
          "seed=palm_date_desert_sapling 20",
-         "animate=idle 20000",
+         "animate=idle duration:20s",
          "remove=20",
          "grow=palm_date_desert_old",
       },
@@ -102,7 +102,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1050000",
+         "animate=idle duration:1050s",
          "transform=deadtree5 32",
          "seed=palm_date_desert_sapling 200",
       },

--- a/data/world/immovables/trees/palm_oil/init.lua
+++ b/data/world/immovables/trees/palm_oil/init.lua
@@ -103,14 +103,14 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:800s",
+         "animate=idle duration:13m20s",
          "transform=deadtree5 50",
          "seed=palm_oil_desert_sapling 80",
       },
       fall = {
          "remove=",
       },
-   },
+},
    spritesheets = {
       idle = {
          directory = dirname,

--- a/data/world/immovables/trees/palm_oil/init.lua
+++ b/data/world/immovables/trees/palm_oil/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 42000",
+         "animate=idle duration:42s",
          "remove=32",
          "grow=palm_oil_desert_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 40000",
+         "animate=idle duration:40s",
          "remove=25",
          "grow=palm_oil_desert_mature",
       },
@@ -70,10 +70,10 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 25000",
+         "animate=idle duration:25s",
          "remove=10",
          "seed=palm_oil_desert_sapling 80",
-         "animate=idle 30000",
+         "animate=idle duration:30s",
          "remove=10",
          "grow=palm_oil_desert_old",
 
@@ -103,7 +103,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 800000",
+         "animate=idle duration:800s",
          "transform=deadtree5 50",
          "seed=palm_oil_desert_sapling 80",
       },

--- a/data/world/immovables/trees/palm_oil/init.lua
+++ b/data/world/immovables/trees/palm_oil/init.lua
@@ -110,7 +110,7 @@ world:new_immovable_type{
       fall = {
          "remove=",
       },
-},
+   },
    spritesheets = {
       idle = {
          directory = dirname,

--- a/data/world/immovables/trees/palm_roystonea/init.lua
+++ b/data/world/immovables/trees/palm_roystonea/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:57500ms",
+         "animate=idle duration:57s500ms",
          "remove=21",
          "grow=palm_roystonea_desert_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:52500ms",
+         "animate=idle duration:52s500ms",
          "remove=19",
          "grow=palm_roystonea_desert_mature",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1550s",
+         "animate=idle duration:25m50s",
          "transform=deadtree4 39",
          "seed=palm_roystonea_desert_sapling 30",
       },

--- a/data/world/immovables/trees/palm_roystonea/init.lua
+++ b/data/world/immovables/trees/palm_roystonea/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 57500",
+         "animate=idle duration:57500ms",
          "remove=21",
          "grow=palm_roystonea_desert_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 52500",
+         "animate=idle duration:52500ms",
          "remove=19",
          "grow=palm_roystonea_desert_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 50000",
+         "animate=idle duration:50s",
          "remove=18",
          "grow=palm_roystonea_desert_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1550000",
+         "animate=idle duration:1550s",
          "transform=deadtree4 39",
          "seed=palm_roystonea_desert_sapling 30",
       },

--- a/data/world/immovables/trees/rowan/init.lua
+++ b/data/world/immovables/trees/rowan/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 60000",
+         "animate=idle duration:1m",
          "remove=40",
          "grow=rowan_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=30",
          "grow=rowan_summer_mature",
       },
@@ -70,10 +70,10 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=7",
          "seed=rowan_summer_sapling 40",
-         "animate=idle 30000",
+         "animate=idle duration:30s",
          "remove=10",
          "grow=rowan_summer_old",
       },
@@ -102,7 +102,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1432000",
+         "animate=idle duration:1432s",
          "transform=deadtree4 26",
          "seed=rowan_summer_sapling 180",
       },

--- a/data/world/immovables/trees/rowan/init.lua
+++ b/data/world/immovables/trees/rowan/init.lua
@@ -102,7 +102,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1432s",
+         "animate=idle duration:23m52s",
          "transform=deadtree4 26",
          "seed=rowan_summer_sapling 180",
       },

--- a/data/world/immovables/trees/spruce/init.lua
+++ b/data/world/immovables/trees/spruce/init.lua
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1550s",
+         "animate=idle duration:25m50s",
          "transform=deadtree3 24",
          "seed=spruce_summer_sapling 200",
       },

--- a/data/world/immovables/trees/spruce/init.lua
+++ b/data/world/immovables/trees/spruce/init.lua
@@ -16,7 +16,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle 55s",
          "remove=42",
          "grow=spruce_summer_pole",
       },
@@ -43,7 +43,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=33",
          "grow=spruce_summer_mature",
       },
@@ -70,7 +70,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 60000",
+         "animate=idle duration:1m",
          "remove=23",
          "grow=spruce_summer_old",
       },
@@ -99,7 +99,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1550000",
+         "animate=idle duration:1550s",
          "transform=deadtree3 24",
          "seed=spruce_summer_sapling 200",
       },

--- a/data/world/immovables/trees/twine/init.lua
+++ b/data/world/immovables/trees/twine/init.lua
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1550s",
+         "animate=idle duration:25m50s",
          "transform=deadtree3 36",
          "seed=twine_wasteland_sapling 20",
       },

--- a/data/world/immovables/trees/twine/init.lua
+++ b/data/world/immovables/trees/twine/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=42",
          "grow=twine_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 55000",
+         "animate=idle duration:55s",
          "remove=33",
          "grow=twine_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 60000",
+         "animate=idle duration:1m",
          "remove=23",
          "grow=twine_wasteland_old",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1550000",
+         "animate=idle duration:1550s",
          "transform=deadtree3 36",
          "seed=twine_wasteland_sapling 20",
       },

--- a/data/world/immovables/trees/umbrella_green/init.lua
+++ b/data/world/immovables/trees/umbrella_green/init.lua
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1550s",
+         "animate=idle duration:25m50s",
          "transform=deadtree4 39",
          "seed=umbrella_green_wasteland_sapling 100",
       },

--- a/data/world/immovables/trees/umbrella_green/init.lua
+++ b/data/world/immovables/trees/umbrella_green/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 57000",
+         "animate=idle duration:57s",
          "remove=21",
          "grow=umbrella_green_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 53000",
+         "animate=idle duration:53s",
          "remove=19",
          "grow=umbrella_green_wasteland_mature",
       },
@@ -73,7 +73,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 50000",
+         "animate=idle duration:50s",
          "remove=18",
          "grow=umbrella_green_wasteland_old",
       },
@@ -104,7 +104,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1550000",
+         "animate=idle duration:1550s",
          "transform=deadtree4 39",
          "seed=umbrella_green_wasteland_sapling 100",
       },

--- a/data/world/immovables/trees/umbrella_red/init.lua
+++ b/data/world/immovables/trees/umbrella_red/init.lua
@@ -17,7 +17,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 38000",
+         "animate=idle duration:38s",
          "remove=50",
          "grow=umbrella_red_wasteland_pole",
       },
@@ -45,7 +45,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 38000",
+         "animate=idle duration:38s",
          "remove=47",
          "grow=umbrella_red_wasteland_mature",
       },
@@ -73,10 +73,10 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 20000",
+         "animate=idle duration:20s",
          "remove=30",
          "seed=umbrella_red_wasteland_sapling 50",
-         "animate=idle 20000",
+         "animate=idle duration:20s",
          "remove=20",
          "grow=umbrella_red_wasteland_old",
       },
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle 1050000",
+         "animate=idle duration:1050s",
          "transform=deadtree2 32",
          "seed=umbrella_red_wasteland_sapling 90",
       },

--- a/data/world/immovables/trees/umbrella_red/init.lua
+++ b/data/world/immovables/trees/umbrella_red/init.lua
@@ -107,7 +107,7 @@ world:new_immovable_type{
    terrain_affinity = terrain_affinity,
    programs = {
       program = {
-         "animate=idle duration:1050s",
+         "animate=idle duration:17m30s",
          "transform=deadtree2 32",
          "seed=umbrella_red_wasteland_sapling 90",
       },

--- a/src/logic/map_objects/CMakeLists.txt
+++ b/src/logic/map_objects/CMakeLists.txt
@@ -118,6 +118,7 @@ wl_library(logic_map_objects
     world/terrain_description.h
     world/world.cc
     world/world.h
+  USES_BOOST_REGEX
   DEPENDS
     ai_hints
     base_exceptions

--- a/src/logic/map_objects/map_object_program.cc
+++ b/src/logic/map_objects/map_object_program.cc
@@ -83,7 +83,7 @@ Duration MapObjectProgram::as_ms(Duration number, const std::string& unit) {
 		return number;
 	}
 	if (unit.empty()) {
-		// TODO (GunChleoc): deprecate
+		// TODO(GunChleoc): deprecate
 		return number;
 	}
 	throw GameDataError("has unknown unit '%s'", unit.c_str());

--- a/src/logic/map_objects/map_object_program.cc
+++ b/src/logic/map_objects/map_object_program.cc
@@ -19,6 +19,8 @@
 
 #include "logic/map_objects/map_object_program.h"
 
+#include <boost/regex.hpp>
+
 #include "io/filesystem/layered_filesystem.h"
 #include "logic/game_data_error.h"
 #include "logic/map_objects/map_object.h"
@@ -44,7 +46,8 @@ std::vector<std::string> MapObjectProgram::split_string(const std::string& s,
 	return result;
 }
 
-unsigned int MapObjectProgram::read_int(const std::string& input, int min_value, int max_value) {
+// Using int64_t in input so we can get the full range of unsigned int in the output while still checking for negative integers.
+unsigned int MapObjectProgram::read_int(const std::string& input, int min_value, int64_t max_value) {
 	unsigned int result = 0U;
 	char* endp;
 	long int const value = strtol(input.c_str(), &endp, 0);
@@ -56,13 +59,33 @@ unsigned int MapObjectProgram::read_int(const std::string& input, int min_value,
 		throw GameDataError("Expected a number >= %d but found \"%s\"", min_value, input.c_str());
 	}
 	if (value > max_value) {
-		throw GameDataError("Expected a number <= %d but found \"%s\"", max_value, input.c_str());
+		throw GameDataError("Expected a number <= %ld but found \"%s\"", max_value, input.c_str());
 	}
 	return result;
 }
 
-unsigned int MapObjectProgram::read_positive(const std::string& input, int max_value) {
+// Using int64_t in input so we can get the full range of unsigned int in the output while still checking for negative integers.
+unsigned int MapObjectProgram::read_positive(const std::string& input, int64_t max_value) {
 	return read_int(input, 1, max_value);
+}
+
+Duration MapObjectProgram::read_duration(const std::string& input) {
+	boost::regex with_unit("^(\\d+)(ms|s|m)$");
+	boost::smatch match;
+	if (boost::regex_search(input, match, with_unit)) {
+		Duration result = read_positive(match[1], endless());
+		if (match[2] == 's') {
+			result *= 1000;
+		} else if (match[2] == 'm') {
+			result *= 60000;
+		}
+		return result;
+	}
+	boost::regex without_unit("^(\\d+)$");
+	if (boost::regex_match(input, without_unit)) {
+		return read_positive(input, endless());
+	}
+	throw GameDataError("Illegal duration: %s. Usage: numbers{ms|s|m}", input.c_str());
 }
 
 MapObjectProgram::ProgramParseInput
@@ -96,7 +119,7 @@ MapObjectProgram::read_key_value_pair(const std::string& input,
 MapObjectProgram::AnimationParameters MapObjectProgram::parse_act_animate(
    const std::vector<std::string>& arguments, const MapObjectDescr& descr, bool is_idle_allowed) {
 	if (arguments.size() < 1 || arguments.size() > 2) {
-		throw GameDataError("Usage: animate=<name> [<duration>]");
+		throw GameDataError("Usage: animate=animation_name [duration:numbers{ms|s|m}]");
 	}
 
 	AnimationParameters result;
@@ -111,7 +134,15 @@ MapObjectProgram::AnimationParameters MapObjectProgram::parse_act_animate(
 	result.animation = descr.get_animation(animation_name, nullptr);
 
 	if (arguments.size() == 2) {
-		result.duration = read_positive(arguments.at(1));
+		const std::pair<std::string, std::string> item = read_key_value_pair(arguments.at(1), ':');
+		if (item.first == "duration") {
+			result.duration = read_duration(item.second);
+		} else if (item.second.empty()) {
+			result.duration = read_duration(item.first);
+		} else {
+			throw GameDataError(
+			   "Unknown argument '%s'. Usage: animation_name [duration:numbers{ms|s|m}]", arguments.at(1).c_str());
+		}
 	}
 	return result;
 }

--- a/src/logic/map_objects/map_object_program.cc
+++ b/src/logic/map_objects/map_object_program.cc
@@ -89,11 +89,11 @@ Duration MapObjectProgram::as_ms(Duration number, const std::string& unit) {
 Duration MapObjectProgram::read_duration(const std::string& input) {
 	try {
 		boost::smatch match;
-		boost::regex one_unit("^(\\d+)(ms|s|m)$");
+		boost::regex one_unit("^(\\d+)(s|m|ms)$");
 		if (boost::regex_search(input, match, one_unit)) {
 			return as_ms(read_positive(match[1], endless()), match[2]);
 		}
-		boost::regex two_units("^(\\d+)(s|m)(\\d+)(ms|s)$");
+		boost::regex two_units("^(\\d+)(m|s)(\\d+)(s|ms)$");
 		if (boost::regex_search(input, match, two_units)) {
 			if (match[2] == match[4]) {
 				std::string unit(match[2]);
@@ -171,6 +171,7 @@ MapObjectProgram::AnimationParameters MapObjectProgram::parse_act_animate(
 		if (item.first == "duration") {
 			result.duration = read_duration(item.second);
 		} else if (item.second.empty()) {
+			// TODO(GunChleoc): Deprecate unitless
 			result.duration = read_duration(item.first);
 		} else {
 			throw GameDataError(

--- a/src/logic/map_objects/map_object_program.cc
+++ b/src/logic/map_objects/map_object_program.cc
@@ -46,8 +46,10 @@ std::vector<std::string> MapObjectProgram::split_string(const std::string& s,
 	return result;
 }
 
-// Using int64_t in input so we can get the full range of unsigned int in the output while still checking for negative integers.
-unsigned int MapObjectProgram::read_int(const std::string& input, int min_value, int64_t max_value) {
+// Using int64_t in input so we can get the full range of unsigned int in the output while still
+// checking for negative integers.
+unsigned int
+MapObjectProgram::read_int(const std::string& input, int min_value, int64_t max_value) {
 	unsigned int result = 0U;
 	char* endp;
 	long int const value = strtol(input.c_str(), &endp, 0);
@@ -64,7 +66,8 @@ unsigned int MapObjectProgram::read_int(const std::string& input, int min_value,
 	return result;
 }
 
-// Using int64_t in input so we can get the full range of unsigned int in the output while still checking for negative integers.
+// Using int64_t in input so we can get the full range of unsigned int in the output while still
+// checking for negative integers.
 unsigned int MapObjectProgram::read_positive(const std::string& input, int64_t max_value) {
 	return read_int(input, 1, max_value);
 }
@@ -116,9 +119,13 @@ Duration MapObjectProgram::read_duration(const std::string& input) {
 			return read_positive(input, endless());
 		}
 	} catch (const WException& e) {
-		throw GameDataError("Duration '%s' %s. Usage: <numbers>{m|s|ms}[<numbers>{s|ms}][<numbers>ms]", input.c_str(), e.what());
+		throw GameDataError(
+		   "Duration '%s' %s. Usage: <numbers>{m|s|ms}[<numbers>{s|ms}][<numbers>ms]", input.c_str(),
+		   e.what());
 	}
-	throw GameDataError("Illegal duration: %s. Usage: <numbers>{m|s|ms}[<numbers>{s|ms}][<numbers>ms]", input.c_str());
+	throw GameDataError(
+	   "Illegal duration: %s. Usage: <numbers>{m|s|ms}[<numbers>{s|ms}][<numbers>ms]",
+	   input.c_str());
 }
 
 MapObjectProgram::ProgramParseInput
@@ -174,8 +181,8 @@ MapObjectProgram::AnimationParameters MapObjectProgram::parse_act_animate(
 			// TODO(GunChleoc): Deprecate unitless
 			result.duration = read_duration(item.first);
 		} else {
-			throw GameDataError(
-			   "Unknown argument '%s'. Usage: <animation_name> [duration:<duration>]", arguments.at(1).c_str());
+			throw GameDataError("Unknown argument '%s'. Usage: <animation_name> [duration:<duration>]",
+			                    arguments.at(1).c_str());
 		}
 	}
 	return result;

--- a/src/logic/map_objects/map_object_program.h
+++ b/src/logic/map_objects/map_object_program.h
@@ -73,7 +73,7 @@ protected:
 
 	/**
 	 * @brief Reads time duration with a unit from a string
-	 * @param A positive integer, optionally followed by 'ms' (milliseconds), 's' (seconds) or 'm' (minutes). Default unit is milliseconds.
+	 * @param A positive integer, optionally followed by 'ms' (milliseconds), 's' (seconds) or 'm' (minutes). This can be repeated to form units like '1m20s500ms'.
 	 * @return The duration in SDL ticks (milliseconds)
 	 */
 	static Duration read_duration(const std::string& input);
@@ -114,6 +114,8 @@ protected:
 	                                                uint8_t default_priority);
 
 private:
+	static Widelands::Duration as_ms(Widelands::Duration number, const std::string& unit);
+
 	const std::string name_;
 };
 }  // namespace Widelands

--- a/src/logic/map_objects/map_object_program.h
+++ b/src/logic/map_objects/map_object_program.h
@@ -73,7 +73,8 @@ protected:
 
 	/**
 	 * @brief Reads time duration with a unit from a string
-	 * @param A positive integer, optionally followed by 'ms' (milliseconds), 's' (seconds) or 'm' (minutes). This can be repeated to form units like '1m20s500ms'.
+	 * @param A positive integer, optionally followed by 'ms' (milliseconds), 's' (seconds) or 'm'
+	 * (minutes). This can be repeated to form units like '1m20s500ms'.
 	 * @return The duration in SDL ticks (milliseconds)
 	 */
 	static Duration read_duration(const std::string& input);

--- a/src/logic/map_objects/map_object_program.h
+++ b/src/logic/map_objects/map_object_program.h
@@ -51,10 +51,10 @@ protected:
 	/// exceeded
 	static unsigned int read_int(const std::string& input,
 	                             int min_value,
-	                             int max_value = std::numeric_limits<int32_t>::max());
+	                             int64_t max_value = std::numeric_limits<int32_t>::max());
 	/// Same as 'read_int', with 'min_value' == 1
 	static unsigned int read_positive(const std::string& input,
-	                                  int max_value = std::numeric_limits<int32_t>::max());
+	                                  int64_t max_value = std::numeric_limits<int32_t>::max());
 
 	/**
 	 * @brief Reads a key-value pair from a string using the given separator, e.g. "attrib:tree",
@@ -70,6 +70,13 @@ protected:
 	                    const char separator,
 	                    const std::string& default_value = "",
 	                    const std::string& expected_key = "");
+
+	/**
+	 * @brief Reads time duration with a unit from a string
+	 * @param A positive integer, optionally followed by 'ms' (milliseconds), 's' (seconds) or 'm' (minutes). Default unit is milliseconds.
+	 * @return The duration in SDL ticks (milliseconds)
+	 */
+	static Duration read_duration(const std::string& input);
 
 	/// Left-hand and right-hand elements of a line in a program, e.g. parsed from "return=skipped
 	/// unless economy needs meal"


### PR DESCRIPTION
Implement more human-readable duration units, e.g. `1m20s500ms`.

Notes:

* I had also considered using `1:20.500` as a notation, but then it would not be immediately clear from `1:20` whether that's hours-minutes or minutes-seconds
* The function `read_duration` is protected rather than private because there will me more uses, e.g. for the decay parameter in `construct=`
* I have only changed the trees so far to keep the diff smaller

TODOs for follow-up branches:

* Update tribes' `init.lua` files
* Update documentation
* Add deprecation warning

@hessenfarmer @Noordfrees 