### PR TITLE
Add new option: Allow diagonal scrolling with numeric keypad

### DIFF
--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -223,6 +223,7 @@ FullscreenMenuOptions::FullscreenMenuOptions(OptionsCtrl::OptionsStruct opt)
      /** TRANSLATORS: This refers to to zooming with the scrollwheel.*/
      ctrl_zoom_(&box_game_, Vector2i::zero(), _("Zoom only when Ctrl is pressed")),
      game_clock_(&box_game_, Vector2i::zero(), _("Display game time in the top left corner")),
+     numpad_diagonalscrolling_(&box_game_, Vector2i::zero(), _("Allow diagonal scrolling with the numeric keypad")),
      os_(opt) {
 
 	// Buttons
@@ -276,6 +277,7 @@ FullscreenMenuOptions::FullscreenMenuOptions(OptionsCtrl::OptionsStruct opt)
 	box_game_.add(&single_watchwin_);
 	box_game_.add(&ctrl_zoom_);
 	box_game_.add(&game_clock_);
+	box_game_.add(&numpad_diagonalscrolling_);
 
 	// Bind actions
 	language_dropdown_.selected.connect([this]() { update_language_stats(false); });
@@ -342,6 +344,7 @@ FullscreenMenuOptions::FullscreenMenuOptions(OptionsCtrl::OptionsStruct opt)
 	single_watchwin_.set_state(opt.single_watchwin);
 	ctrl_zoom_.set_state(opt.ctrl_zoom);
 	game_clock_.set_state(opt.game_clock);
+	numpad_diagonalscrolling_.set_state(opt.numpad_diagonalscrolling);
 
 	// Language options
 	add_languages_to_list(opt.language);
@@ -417,6 +420,7 @@ void FullscreenMenuOptions::layout() {
 	single_watchwin_.set_desired_size(tab_panel_width, single_watchwin_.get_h());
 	ctrl_zoom_.set_desired_size(tab_panel_width, ctrl_zoom_.get_h());
 	game_clock_.set_desired_size(tab_panel_width, game_clock_.get_h());
+	numpad_diagonalscrolling_.set_desired_size(tab_panel_width, numpad_diagonalscrolling_.get_h());
 }
 
 void FullscreenMenuOptions::add_languages_to_list(const std::string& current_locale) {
@@ -596,6 +600,7 @@ OptionsCtrl::OptionsStruct FullscreenMenuOptions::get_values() {
 	os_.single_watchwin = single_watchwin_.get_state();
 	os_.ctrl_zoom = ctrl_zoom_.get_state();
 	os_.game_clock = game_clock_.get_state();
+	os_.numpad_diagonalscrolling = numpad_diagonalscrolling_.get_state();
 
 	// Last tab for reloading the options menu
 	os_.active_tab = tabs_.active();
@@ -655,6 +660,7 @@ OptionsCtrl::OptionsStruct OptionsCtrl::options_struct(uint32_t active_tab) {
 	opt.single_watchwin = opt_section_.get_bool("single_watchwin", false);
 	opt.ctrl_zoom = opt_section_.get_bool("ctrl_zoom", false);
 	opt.game_clock = opt_section_.get_bool("game_clock", true);
+	opt.numpad_diagonalscrolling = opt_section_.get_bool("numpad_diagonalscrolling", false);
 
 	// Language options
 	opt.language = opt_section_.get_string("language", "");
@@ -694,6 +700,7 @@ void OptionsCtrl::save_options() {
 	opt_section_.set_bool("single_watchwin", opt.single_watchwin);
 	opt_section_.set_bool("ctrl_zoom", opt.ctrl_zoom);
 	opt_section_.set_bool("game_clock", opt.game_clock);
+	opt_section_.set_bool("numpad_diagonalscrolling", opt.numpad_diagonalscrolling);
 
 	// Language options
 	opt_section_.set_string("language", opt.language);

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -223,7 +223,8 @@ FullscreenMenuOptions::FullscreenMenuOptions(OptionsCtrl::OptionsStruct opt)
      /** TRANSLATORS: This refers to to zooming with the scrollwheel.*/
      ctrl_zoom_(&box_game_, Vector2i::zero(), _("Zoom only when Ctrl is pressed")),
      game_clock_(&box_game_, Vector2i::zero(), _("Display game time in the top left corner")),
-     numpad_diagonalscrolling_(&box_game_, Vector2i::zero(), _("Allow diagonal scrolling with the numeric keypad")),
+     numpad_diagonalscrolling_(
+        &box_game_, Vector2i::zero(), _("Allow diagonal scrolling with the numeric keypad")),
      os_(opt) {
 
 	// Buttons

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -67,6 +67,7 @@ public:
 		bool single_watchwin;
 		bool ctrl_zoom;
 		bool game_clock;
+		bool numpad_diagonalscrolling;
 
 		// Language options
 		std::string language;
@@ -156,6 +157,7 @@ private:
 	UI::Checkbox single_watchwin_;
 	UI::Checkbox ctrl_zoom_;
 	UI::Checkbox game_clock_;
+	UI::Checkbox numpad_diagonalscrolling_;
 
 	OptionsCtrl::OptionsStruct os_;
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -825,6 +825,7 @@ bool WLApplication::init_settings() {
 	get_config_bool("single_watchwin", false);
 	get_config_bool("ctrl_zoom", false);
 	get_config_bool("game_clock", true);
+	get_config_bool("numpad_diagonalscrolling", false);
 	get_config_bool("inputgrab", false);
 	get_config_bool("transparent_chat", false);
 	// Undocumented. Unique ID used to allow the metaserver to recognize players

--- a/src/wui/interactive_gamebase.cc
+++ b/src/wui/interactive_gamebase.cc
@@ -32,6 +32,7 @@
 #include "logic/map_objects/tribes/ship.h"
 #include "logic/player.h"
 #include "network/gamehost.h"
+#include "wlapplication_options.h"
 #include "wui/constructionsitewindow.h"
 #include "wui/dismantlesitewindow.h"
 #include "wui/game_chat_menu.h"
@@ -375,10 +376,15 @@ bool InteractiveGameBase::handle_key(bool down, SDL_Keysym code) {
 	if (InteractiveBase::handle_key(down, code)) {
 		return true;
 	}
+	const bool numpad_diagonalscrolling = get_config_bool("numpad_diagonalscrolling", false);
 
 	if (down) {
 		switch (code.sym) {
+		case SDLK_KP_9:
 		case SDLK_PAGEUP:
+			if (code.sym == SDLK_KP_9 && ((code.mod & KMOD_NUM) || numpad_diagonalscrolling)) {
+				break;
+			}
 			increase_gamespeed(
 			   code.mod & KMOD_SHIFT ? kSpeedSlow : code.mod & KMOD_CTRL ? kSpeedFast : kSpeedDefault);
 			return true;
@@ -389,7 +395,11 @@ bool InteractiveGameBase::handle_key(bool down, SDL_Keysym code) {
 				toggle_game_paused();
 			}
 			return true;
+		case SDLK_KP_3:
 		case SDLK_PAGEDOWN:
+			if (code.sym == SDLK_KP_3 && ((code.mod & KMOD_NUM) || numpad_diagonalscrolling)) {
+				break;
+			}
 			decrease_gamespeed(
 			   code.mod & KMOD_SHIFT ? kSpeedSlow : code.mod & KMOD_CTRL ? kSpeedFast : kSpeedDefault);
 			return true;

--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -598,6 +598,7 @@ Widelands::NodeAndTriangle<> MapView::track_sel(const Vector2i& p) {
 }
 
 bool MapView::scroll_map() {
+	const bool numpad_diagonalscrolling = get_config_bool("numpad_diagonalscrolling", false);
 	// arrow keys
 	const bool kUP = get_key_state(SDL_SCANCODE_UP);
 	const bool kDOWN = get_key_state(SDL_SCANCODE_DOWN);
@@ -610,25 +611,25 @@ bool MapView::scroll_map() {
 	kNP(1) kNP(2) kNP(3) kNP(4) kNP(6) kNP(7) kNP(8) kNP(9)
 #undef kNP
 
-	   // set the scrolling distance
-	   const uint8_t denominator =
-	      ((SDL_GetModState() & KMOD_CTRL) ? 4 : (SDL_GetModState() & KMOD_SHIFT) ? 16 : 8);
+	// set the scrolling distance
+	const uint8_t denominator =
+		((SDL_GetModState() & KMOD_CTRL) ? 4 : (SDL_GetModState() & KMOD_SHIFT) ? 16 : 8);
 	const uint16_t scroll_distance_y = g_gr->get_yres() / denominator;
 	const uint16_t scroll_distance_x = g_gr->get_xres() / denominator;
 	int32_t distance_to_scroll_x = 0;
 	int32_t distance_to_scroll_y = 0;
 
 	// check the directions
-	if (kUP || kNP7 || kNP8 || kNP9) {
+	if (kUP || kNP8 || (numpad_diagonalscrolling && (kNP7 || kNP9))) {
 		distance_to_scroll_y -= scroll_distance_y;
 	}
-	if (kDOWN || kNP1 || kNP2 || kNP3) {
+	if (kDOWN || kNP2 || (numpad_diagonalscrolling && (kNP1 || kNP3))) {
 		distance_to_scroll_y += scroll_distance_y;
 	}
-	if (kLEFT || kNP1 || kNP4 || kNP7) {
+	if (kLEFT ||  kNP4 || (numpad_diagonalscrolling && (kNP1 || kNP7))) {
 		distance_to_scroll_x -= scroll_distance_x;
 	}
-	if (kRIGHT || kNP3 || kNP6 || kNP9) {
+	if (kRIGHT || kNP6 || (numpad_diagonalscrolling && (kNP3 || kNP9))) {
 		distance_to_scroll_x += scroll_distance_x;
 	}
 

--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -611,9 +611,9 @@ bool MapView::scroll_map() {
 	kNP(1) kNP(2) kNP(3) kNP(4) kNP(6) kNP(7) kNP(8) kNP(9)
 #undef kNP
 
-	// set the scrolling distance
-	const uint8_t denominator =
-		((SDL_GetModState() & KMOD_CTRL) ? 4 : (SDL_GetModState() & KMOD_SHIFT) ? 16 : 8);
+	   // set the scrolling distance
+	   const uint8_t denominator =
+	      ((SDL_GetModState() & KMOD_CTRL) ? 4 : (SDL_GetModState() & KMOD_SHIFT) ? 16 : 8);
 	const uint16_t scroll_distance_y = g_gr->get_yres() / denominator;
 	const uint16_t scroll_distance_x = g_gr->get_xres() / denominator;
 	int32_t distance_to_scroll_x = 0;
@@ -626,7 +626,7 @@ bool MapView::scroll_map() {
 	if (kDOWN || kNP2 || (numpad_diagonalscrolling && (kNP1 || kNP3))) {
 		distance_to_scroll_y += scroll_distance_y;
 	}
-	if (kLEFT ||  kNP4 || (numpad_diagonalscrolling && (kNP1 || kNP7))) {
+	if (kLEFT || kNP4 || (numpad_diagonalscrolling && (kNP1 || kNP7))) {
 		distance_to_scroll_x -= scroll_distance_x;
 	}
 	if (kRIGHT || kNP6 || (numpad_diagonalscrolling && (kNP3 || kNP9))) {


### PR DESCRIPTION
Page Up/Down on the numeric keypad don't work as expected. They should
speed up/down the game. Unfortunately, they are assigned for diagonal
scrolling.

By this patch we want to revert the old behavior, and at the same time
allow users to use numpad for diagonal scrolling when they explicitly
enable this feature.

Closes widelands/widelands#3986