### PR TITLE
Only show MultilineTextarea scrollbar when really needed

### DIFF
--- a/src/ui_basic/multilinetextarea.cc
+++ b/src/ui_basic/multilinetextarea.cc
@@ -83,7 +83,9 @@ void MultilineTextarea::set_text(const std::string& text) {
  */
 void MultilineTextarea::recompute() {
 	// We wrap the text twice. We need to do this to account for the presence/absence of the
-	// scollbar.
+	// scrollbar. We first try without the scrollbar (unless it's forced) so it's only enabled
+	// when necessary.
+	scrollbar_.set_steps(1);
 	bool scrollbar_was_enabled = scrollbar_.is_enabled();
 	for (int i = 0; i < 2; ++i) {
 		int height = 0;


### PR DESCRIPTION
Change the code that detects whether the scrollbar is needed to always try without the scrollbar first.
Previously the first try was decided by the previous presence/absence of the scrollbar.

Fixes #4060