### PR TITLE
Draw window frames with a different colour when focused

### DIFF
--- a/data/templates/default/init.lua
+++ b/data/templates/default/init.lua
@@ -66,7 +66,7 @@ return {
    minimum_font_size = 10,
    minimap_icon_frame = fs_font_color,
 
-   -- These need a fourth color argument for the alpha
+   -- red, green, blue, alpha
    window_border_focused = {220, 220, 250, 40},
    window_border_unfocused = {50, 0, 0, 40},
 

--- a/data/templates/default/init.lua
+++ b/data/templates/default/init.lua
@@ -66,6 +66,10 @@ return {
    minimum_font_size = 10,
    minimap_icon_frame = fs_font_color,
 
+   -- These need a fourth color argument for the alpha
+   window_border_focused = {220, 220, 250, 40},
+   window_border_unfocused = {50, 0, 0, 40},
+
    -- Buttons
    buttons = {
       -- Buttons used in Fullscreen menus

--- a/src/graphic/style_manager.cc
+++ b/src/graphic/style_manager.cc
@@ -27,13 +27,20 @@
 #include "scripting/lua_interface.h"
 
 namespace {
-// Read RGB color from LuaTable
+// Read RGB(A) color from LuaTable
 RGBColor read_rgb_color(const LuaTable& table) {
 	std::vector<int> rgbcolor = table.array_entries<int>();
 	if (rgbcolor.size() != 3) {
 		throw wexception("Expected 3 entries for RGB color, but got %" PRIuS ".", rgbcolor.size());
 	}
 	return RGBColor(rgbcolor[0], rgbcolor[1], rgbcolor[2]);
+}
+RGBAColor read_rgba_color(const LuaTable& table) {
+	std::vector<int> rgbacolor = table.array_entries<int>();
+	if (rgbacolor.size() != 4) {
+		throw wexception("Expected 4 entries for RGBA color, but got %" PRIuS ".", rgbacolor.size());
+	}
+	return RGBAColor(rgbacolor[0], rgbacolor[1], rgbacolor[2], rgbacolor[3]);
 }
 
 // Read font style from LuaTable
@@ -187,6 +194,8 @@ void StyleManager::init() {
 		throw wexception("Font size too small for minimum_font_size, must be at least 1!");
 	}
 	minimap_icon_frame_ = read_rgb_color(*table->get_table("minimap_icon_frame"));
+	window_border_focused_ = read_rgba_color(*table->get_table("window_border_focused"));
+	window_border_unfocused_ = read_rgba_color(*table->get_table("window_border_unfocused"));
 
 	// Fonts
 	element_table = table->get_table("fonts");

--- a/src/graphic/style_manager.h
+++ b/src/graphic/style_manager.h
@@ -60,6 +60,12 @@ public:
 	// Special elements
 	int minimum_font_size() const;
 	const RGBColor& minimap_icon_frame() const;
+	const RGBAColor& window_border_focused() const {
+		return window_border_focused_;
+	}
+	const RGBAColor& window_border_unfocused() const {
+		return window_border_unfocused_;
+	}
 	static std::string color_tag(const std::string& text, const RGBColor& color);
 
 private:
@@ -85,6 +91,8 @@ private:
 
 	int minimum_font_size_;
 	RGBColor minimap_icon_frame_;
+	RGBAColor window_border_focused_;
+	RGBAColor window_border_unfocused_;
 	std::map<UI::FontStyle, std::unique_ptr<const UI::FontStyleInfo>> fontstyles_;
 	std::unique_ptr<const UI::BuildingStatisticsStyleInfo> building_statistics_style_;
 	std::map<UI::PanelStyle, std::unique_ptr<const UI::ProgressbarStyleInfo>> progressbar_styles_;

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -263,6 +263,9 @@ public:
 		return (get_can_focus() && parent_->focus_ == this);
 	}
 	virtual void focus(bool topcaller = true);
+	Panel* focused_child() const {
+		return focus_;
+	}
 
 	void set_top_on_click(bool const on) {
 		if (on)

--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -500,8 +500,8 @@ void Window::draw_border(RenderTarget& dst) {
 		              focus_color, BlendMode::Default);
 		// Right
 		dst.fill_rect(
-		   Recti(get_w() - kVerticalBorderThickness, kTopBorderThickness,
-		         kVerticalBorderThickness, get_h() - kTopBorderThickness - kBottomBorderThickness),
+		   Recti(get_w() - kVerticalBorderThickness, kTopBorderThickness, kVerticalBorderThickness,
+		         get_h() - kTopBorderThickness - kBottomBorderThickness),
 		   focus_color, BlendMode::Default);
 	}
 

--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -368,9 +368,9 @@ void Window::draw_border(RenderTarget& dst) {
 	const int32_t hz_bar_end = get_w() - kCornerWidth;
 	const int32_t hz_bar_end_minus_middle = hz_bar_end - kHorizontalBorderMiddleLength;
 
-	const RGBAColor& focus_color =
-	   get_parent() && get_parent()->focused_child() == this ?
-	   g_gr->styles().window_border_focused() : g_gr->styles().window_border_unfocused();
+	const RGBAColor& focus_color = get_parent() && get_parent()->focused_child() == this ?
+	                                  g_gr->styles().window_border_focused() :
+	                                  g_gr->styles().window_border_unfocused();
 
 	{  //  Top border.
 		int32_t pos = kCornerWidth;

--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -357,6 +357,9 @@ void Window::draw(RenderTarget& dst) {
 	}
 }
 
+static const RGBAColor kColorFocused(200, 200, 255, 40);
+static const RGBAColor kColorUnfocused(50, 0, 0, 40);
+
 /**
  * Redraw the window frame
  */
@@ -367,6 +370,8 @@ void Window::draw_border(RenderTarget& dst) {
 
 	const int32_t hz_bar_end = get_w() - kCornerWidth;
 	const int32_t hz_bar_end_minus_middle = hz_bar_end - kHorizontalBorderMiddleLength;
+
+	const RGBAColor& focus_color = get_parent() && get_parent()->focused_child() == this ? kColorFocused : kColorUnfocused;
 
 	{  //  Top border.
 		int32_t pos = kCornerWidth;
@@ -388,6 +393,8 @@ void Window::draw_border(RenderTarget& dst) {
 		dst.blitrect(
 		   Vector2i(pos, 0), pic_top_,
 		   Recti(Vector2i(kHorizonalBorderTotalLength - width, 0), width, kTopBorderThickness));
+
+		dst.fill_rect(Recti(0, 0, get_w(), kTopBorderThickness), focus_color, BlendMode::Default);
 	}
 
 	// draw the title if we have one
@@ -480,6 +487,13 @@ void Window::draw_border(RenderTarget& dst) {
 			   Vector2i(pos, get_h() - kBottomBorderThickness), pic_bottom_,
 			   Recti(Vector2i(kHorizonalBorderTotalLength - width, 0), width, kBottomBorderThickness));
 		}
+
+		// Bottom
+		dst.fill_rect(Recti(0, get_h() - kBottomBorderThickness, get_w(), kBottomBorderThickness), focus_color, BlendMode::Default);
+		// Left
+		dst.fill_rect(Recti(0, kTopBorderThickness, kVerticalBorderThickness, get_h() - kTopBorderThickness - kBottomBorderThickness), focus_color, BlendMode::Default);
+		// Right
+		dst.fill_rect(Recti(get_w() - 2 * kVerticalBorderThickness, kTopBorderThickness, kVerticalBorderThickness, get_h() - kTopBorderThickness - kBottomBorderThickness), focus_color, BlendMode::Default);
 	}
 
 	// draw them again so they aren't hidden by the border

--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -371,7 +371,8 @@ void Window::draw_border(RenderTarget& dst) {
 	const int32_t hz_bar_end = get_w() - kCornerWidth;
 	const int32_t hz_bar_end_minus_middle = hz_bar_end - kHorizontalBorderMiddleLength;
 
-	const RGBAColor& focus_color = get_parent() && get_parent()->focused_child() == this ? kColorFocused : kColorUnfocused;
+	const RGBAColor& focus_color =
+	   get_parent() && get_parent()->focused_child() == this ? kColorFocused : kColorUnfocused;
 
 	{  //  Top border.
 		int32_t pos = kCornerWidth;
@@ -489,11 +490,17 @@ void Window::draw_border(RenderTarget& dst) {
 		}
 
 		// Bottom
-		dst.fill_rect(Recti(0, get_h() - kBottomBorderThickness, get_w(), kBottomBorderThickness), focus_color, BlendMode::Default);
+		dst.fill_rect(Recti(0, get_h() - kBottomBorderThickness, get_w(), kBottomBorderThickness),
+		              focus_color, BlendMode::Default);
 		// Left
-		dst.fill_rect(Recti(0, kTopBorderThickness, kVerticalBorderThickness, get_h() - kTopBorderThickness - kBottomBorderThickness), focus_color, BlendMode::Default);
+		dst.fill_rect(Recti(0, kTopBorderThickness, kVerticalBorderThickness,
+		                    get_h() - kTopBorderThickness - kBottomBorderThickness),
+		              focus_color, BlendMode::Default);
 		// Right
-		dst.fill_rect(Recti(get_w() - 2 * kVerticalBorderThickness, kTopBorderThickness, kVerticalBorderThickness, get_h() - kTopBorderThickness - kBottomBorderThickness), focus_color, BlendMode::Default);
+		dst.fill_rect(
+		   Recti(get_w() - 2 * kVerticalBorderThickness, kTopBorderThickness,
+		         kVerticalBorderThickness, get_h() - kTopBorderThickness - kBottomBorderThickness),
+		   focus_color, BlendMode::Default);
 	}
 
 	// draw them again so they aren't hidden by the border

--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -395,6 +395,7 @@ void Window::draw_border(RenderTarget& dst) {
 		   Vector2i(pos, 0), pic_top_,
 		   Recti(Vector2i(kHorizonalBorderTotalLength - width, 0), width, kTopBorderThickness));
 
+		// Focus overlay
 		dst.fill_rect(Recti(0, 0, get_w(), kTopBorderThickness), focus_color, BlendMode::Default);
 	}
 
@@ -489,6 +490,7 @@ void Window::draw_border(RenderTarget& dst) {
 			   Recti(Vector2i(kHorizonalBorderTotalLength - width, 0), width, kBottomBorderThickness));
 		}
 
+		// Focus overlays
 		// Bottom
 		dst.fill_rect(Recti(0, get_h() - kBottomBorderThickness, get_w(), kBottomBorderThickness),
 		              focus_color, BlendMode::Default);
@@ -498,7 +500,7 @@ void Window::draw_border(RenderTarget& dst) {
 		              focus_color, BlendMode::Default);
 		// Right
 		dst.fill_rect(
-		   Recti(get_w() - 2 * kVerticalBorderThickness, kTopBorderThickness,
+		   Recti(get_w() - kVerticalBorderThickness, kTopBorderThickness,
 		         kVerticalBorderThickness, get_h() - kTopBorderThickness - kBottomBorderThickness),
 		   focus_color, BlendMode::Default);
 	}

--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -357,9 +357,6 @@ void Window::draw(RenderTarget& dst) {
 	}
 }
 
-static const RGBAColor kColorFocused(200, 200, 255, 40);
-static const RGBAColor kColorUnfocused(50, 0, 0, 40);
-
 /**
  * Redraw the window frame
  */
@@ -372,7 +369,8 @@ void Window::draw_border(RenderTarget& dst) {
 	const int32_t hz_bar_end_minus_middle = hz_bar_end - kHorizontalBorderMiddleLength;
 
 	const RGBAColor& focus_color =
-	   get_parent() && get_parent()->focused_child() == this ? kColorFocused : kColorUnfocused;
+	   get_parent() && get_parent()->focused_child() == this ?
+	   g_gr->styles().window_border_focused() : g_gr->styles().window_border_unfocused();
 
 	{  //  Top border.
 		int32_t pos = kCornerWidth;


### PR DESCRIPTION
Fixes #3852 
Note that this branch visualises some issues where the transferring of the focus between windows is not intuitive.

![shot0007](https://user-images.githubusercontent.com/48293446/89667669-d5d2fb00-d8dc-11ea-86a3-2ba6b5ff6b67.png)

The colours can be discussed of course.