### PR TITLE
Turn some enums into enum classes

### DIFF
--- a/src/editor/map_generator.cc
+++ b/src/editor/map_generator.cc
@@ -441,7 +441,8 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
                                                   RNG& rng,
                                                   MapGenAreaInfo::Terrain& terrType) {
 	uint32_t numLandAreas = map_gen_info_->get_num_areas(MapGenAreaInfo::Area::kLand);
-	uint32_t const numWasteLandAreas = map_gen_info_->get_num_areas(MapGenAreaInfo::Area::kWasteland);
+	uint32_t const numWasteLandAreas =
+	   map_gen_info_->get_num_areas(MapGenAreaInfo::Area::kWasteland);
 
 	bool isDesert = false;
 	bool isDesertOuter = false;
@@ -486,8 +487,10 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 		if (numLandAreas == 1) {
 			landAreaIndex = 0;
 		} else if (numLandAreas == 2) {
-			uint32_t const weight1 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 0).get_weight();
-			uint32_t const weight2 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 1).get_weight();
+			uint32_t const weight1 =
+			   map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 0).get_weight();
+			uint32_t const weight2 =
+			   map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 1).get_weight();
 			uint32_t const sum = map_gen_info_->get_sum_land_weight();
 			if (weight1 * (random2[c0.x + map_info_.w * c0.y] / sum) >=
 			    weight2 * (kAverageElevation / sum)) {
@@ -496,9 +499,12 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 				landAreaIndex = 1;
 			}
 		} else {
-			uint32_t const weight1 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 0).get_weight();
-			uint32_t const weight2 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 1).get_weight();
-			uint32_t const weight3 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 2).get_weight();
+			uint32_t const weight1 =
+			   map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 0).get_weight();
+			uint32_t const weight2 =
+			   map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 1).get_weight();
+			uint32_t const weight3 =
+			   map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 2).get_weight();
 			uint32_t const sum = map_gen_info_->get_sum_land_weight();
 			uint32_t const randomX = (rand2 + rand3) / 2;
 			if (weight1 * (rand2 / sum) > weight2 * (rand3 / sum) &&
@@ -570,8 +576,9 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 		usedLandIndex = 0;
 	} else if (isDesert) {
 		atp = MapGenAreaInfo::Area::kWasteland;
-		ttp = ttp == MapGenAreaInfo::Terrain::kLandCoast || isDesertOuter ? MapGenAreaInfo::Terrain::kWastelandOuter :
-		                                                            MapGenAreaInfo::Terrain::kWastelandInner;
+		ttp = ttp == MapGenAreaInfo::Terrain::kLandCoast || isDesertOuter ?
+		         MapGenAreaInfo::Terrain::kWastelandOuter :
+		         MapGenAreaInfo::Terrain::kWastelandInner;
 	}
 
 	// Return terrain type

--- a/src/editor/map_generator.cc
+++ b/src/editor/map_generator.cc
@@ -51,7 +51,7 @@ MapGenerator::MapGenerator(Map& map, const UniqueRandomMapInfo& mapInfo, EditorG
 void MapGenerator::generate_bobs(std::unique_ptr<uint32_t[]> const* random_bobs,
                                  const Coords& fc,
                                  RNG& rng,
-                                 MapGenAreaInfo::MapGenTerrainType const terrType) {
+                                 MapGenAreaInfo::Terrain const terrType) {
 	//  Figure out which bob area is due here...
 	size_t num = map_gen_info_->get_num_land_resources();
 	size_t found = num;
@@ -439,9 +439,9 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
                                                   uint32_t const h2,
                                                   uint32_t const h3,
                                                   RNG& rng,
-                                                  MapGenAreaInfo::MapGenTerrainType& terrType) {
-	uint32_t numLandAreas = map_gen_info_->get_num_areas(MapGenAreaInfo::atLand);
-	uint32_t const numWasteLandAreas = map_gen_info_->get_num_areas(MapGenAreaInfo::atWasteland);
+                                                  MapGenAreaInfo::Terrain& terrType) {
+	uint32_t numLandAreas = map_gen_info_->get_num_areas(MapGenAreaInfo::Area::kLand);
+	uint32_t const numWasteLandAreas = map_gen_info_->get_num_areas(MapGenAreaInfo::Area::kWasteland);
 
 	bool isDesert = false;
 	bool isDesertOuter = false;
@@ -478,16 +478,16 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 		}
 	}
 
-	MapGenAreaInfo::MapGenAreaType atp = MapGenAreaInfo::atLand;
-	MapGenAreaInfo::MapGenTerrainType ttp = MapGenAreaInfo::ttLandLand;
+	MapGenAreaInfo::Area atp = MapGenAreaInfo::Area::kLand;
+	MapGenAreaInfo::Terrain ttp = MapGenAreaInfo::Terrain::kLandLand;
 
 	if (!isDesert) {  //  see what kind of land it is
 
 		if (numLandAreas == 1) {
 			landAreaIndex = 0;
 		} else if (numLandAreas == 2) {
-			uint32_t const weight1 = map_gen_info_->get_area(MapGenAreaInfo::atLand, 0).get_weight();
-			uint32_t const weight2 = map_gen_info_->get_area(MapGenAreaInfo::atLand, 1).get_weight();
+			uint32_t const weight1 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 0).get_weight();
+			uint32_t const weight2 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 1).get_weight();
 			uint32_t const sum = map_gen_info_->get_sum_land_weight();
 			if (weight1 * (random2[c0.x + map_info_.w * c0.y] / sum) >=
 			    weight2 * (kAverageElevation / sum)) {
@@ -496,9 +496,9 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 				landAreaIndex = 1;
 			}
 		} else {
-			uint32_t const weight1 = map_gen_info_->get_area(MapGenAreaInfo::atLand, 0).get_weight();
-			uint32_t const weight2 = map_gen_info_->get_area(MapGenAreaInfo::atLand, 1).get_weight();
-			uint32_t const weight3 = map_gen_info_->get_area(MapGenAreaInfo::atLand, 2).get_weight();
+			uint32_t const weight1 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 0).get_weight();
+			uint32_t const weight2 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 1).get_weight();
+			uint32_t const weight3 = map_gen_info_->get_area(MapGenAreaInfo::Area::kLand, 2).get_weight();
 			uint32_t const sum = map_gen_info_->get_sum_land_weight();
 			uint32_t const randomX = (rand2 + rand3) / 2;
 			if (weight1 * (rand2 / sum) > weight2 * (rand3 / sum) &&
@@ -512,19 +512,19 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 			}
 		}
 
-		atp = MapGenAreaInfo::atLand;
-		ttp = MapGenAreaInfo::ttLandLand;
+		atp = MapGenAreaInfo::Area::kLand;
+		ttp = MapGenAreaInfo::Terrain::kLandLand;
 	} else {
-		atp = MapGenAreaInfo::atWasteland;
-		ttp = MapGenAreaInfo::ttWastelandInner;
+		atp = MapGenAreaInfo::Area::kWasteland;
+		ttp = MapGenAreaInfo::Terrain::kWastelandInner;
 	}
 
 	//  see whether it is water
 
 	uint32_t const coast_h = map_gen_info_->get_land_coast_height();
 	if (h1 <= coast_h && h2 <= coast_h && h3 <= coast_h) {  //  water or coast...
-		atp = MapGenAreaInfo::atLand;
-		ttp = MapGenAreaInfo::ttLandCoast;
+		atp = MapGenAreaInfo::Area::kLand;
+		ttp = MapGenAreaInfo::Terrain::kLandCoast;
 
 		uint32_t const ocean_h = map_gen_info_->get_water_ocean_height();
 		uint32_t const shelf_h = map_gen_info_->get_water_shelf_height();
@@ -534,14 +534,14 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 		//  there will never be an ocean yet
 
 		if (h1 <= ocean_h && h2 <= ocean_h && h3 <= ocean_h) {
-			atp = MapGenAreaInfo::atWater;
-			ttp = MapGenAreaInfo::ttWaterOcean;
+			atp = MapGenAreaInfo::Area::kWater;
+			ttp = MapGenAreaInfo::Terrain::kWaterOcean;
 		} else if (h1 <= shelf_h && h2 <= shelf_h && h3 <= shelf_h) {
-			atp = MapGenAreaInfo::atWater;
-			ttp = MapGenAreaInfo::ttWaterShelf;
+			atp = MapGenAreaInfo::Area::kWater;
+			ttp = MapGenAreaInfo::Terrain::kWaterShelf;
 		} else if (h1 <= shallow_h && h2 <= shallow_h && h3 <= shallow_h) {
-			atp = MapGenAreaInfo::atWater;
-			ttp = MapGenAreaInfo::ttWaterShallow;
+			atp = MapGenAreaInfo::Area::kWater;
+			ttp = MapGenAreaInfo::Terrain::kWaterShallow;
 		}
 	} else {  //  it is not water
 		uint32_t const upper_h = map_gen_info_->get_land_upper_height();
@@ -549,29 +549,29 @@ DescriptionIndex MapGenerator::figure_out_terrain(uint32_t* const random2,
 		uint32_t const mount_h = map_gen_info_->get_mountain_height();
 		uint32_t const snow_h = map_gen_info_->get_snow_height();
 		if (h1 >= snow_h && h2 >= snow_h && h3 >= snow_h) {
-			atp = MapGenAreaInfo::atMountains;
-			ttp = MapGenAreaInfo::ttMountainsSnow;
+			atp = MapGenAreaInfo::Area::kMountains;
+			ttp = MapGenAreaInfo::Terrain::kMountainsSnow;
 		} else if (h1 >= mount_h && h2 >= mount_h && h3 >= mount_h) {
-			atp = MapGenAreaInfo::atMountains;
-			ttp = MapGenAreaInfo::ttMountainsMountain;
+			atp = MapGenAreaInfo::Area::kMountains;
+			ttp = MapGenAreaInfo::Terrain::kMountainsMountain;
 		} else if (h1 >= foot_h && h2 >= foot_h && h3 >= foot_h) {
-			atp = MapGenAreaInfo::atMountains;
-			ttp = MapGenAreaInfo::ttMountainsFoot;
+			atp = MapGenAreaInfo::Area::kMountains;
+			ttp = MapGenAreaInfo::Terrain::kMountainsFoot;
 		} else if (h1 >= upper_h && h2 >= upper_h && h3 >= upper_h) {
-			atp = MapGenAreaInfo::atLand;
-			ttp = MapGenAreaInfo::ttLandUpper;
+			atp = MapGenAreaInfo::Area::kLand;
+			ttp = MapGenAreaInfo::Terrain::kLandUpper;
 		}
 	}
 
 	//  Aftermath for land/Wasteland.
 
 	uint32_t usedLandIndex = landAreaIndex;
-	if (atp != MapGenAreaInfo::atLand && atp != MapGenAreaInfo::atWasteland) {
+	if (atp != MapGenAreaInfo::Area::kLand && atp != MapGenAreaInfo::Area::kWasteland) {
 		usedLandIndex = 0;
 	} else if (isDesert) {
-		atp = MapGenAreaInfo::atWasteland;
-		ttp = ttp == MapGenAreaInfo::ttLandCoast || isDesertOuter ? MapGenAreaInfo::ttWastelandOuter :
-		                                                            MapGenAreaInfo::ttWastelandInner;
+		atp = MapGenAreaInfo::Area::kWasteland;
+		ttp = ttp == MapGenAreaInfo::Terrain::kLandCoast || isDesertOuter ? MapGenAreaInfo::Terrain::kWastelandOuter :
+		                                                            MapGenAreaInfo::Terrain::kWastelandInner;
 	}
 
 	// Return terrain type
@@ -666,7 +666,7 @@ void MapGenerator::create_random_map() {
 		uint8_t height_x0_y1 = map_[Coords(lower_x, lower_y)].get_height();
 		uint8_t height_x1_y1 = map_[Coords(lower_right_x, lower_y)].get_height();
 
-		MapGenAreaInfo::MapGenTerrainType terrType;
+		MapGenAreaInfo::Terrain terrType;
 
 		fc.field->set_terrain_d(figure_out_terrain(
 		   random2.get(), random3.get(), random4.get(), fc, Coords(lower_x, lower_y),

--- a/src/editor/map_generator.h
+++ b/src/editor/map_generator.h
@@ -79,7 +79,7 @@ private:
 	void generate_bobs(std::unique_ptr<uint32_t[]> const* random_bobs,
 	                   const Coords&,
 	                   RNG&,
-	                   MapGenAreaInfo::MapGenTerrainType terrType);
+	                   MapGenAreaInfo::Terrain terrType);
 
 	void generate_resources(uint32_t const* const random1,
 	                        uint32_t const* const random2,
@@ -101,7 +101,7 @@ private:
 	                                    uint32_t const h2,
 	                                    uint32_t const h3,
 	                                    RNG& rng,
-	                                    MapGenAreaInfo::MapGenTerrainType& terrType);
+	                                    MapGenAreaInfo::Terrain& terrType);
 
 	std::unique_ptr<const MapGenInfo> map_gen_info_;
 	Map& map_;

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -253,7 +253,7 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 
 	set_game_controller(new SinglePlayerGameController(*this, true, 1));
 	try {
-		bool const result = run(NewSPScenario, script_to_run, false, "single_player");
+		bool const result = run(StartGameType::kSinglePlayerScenario, script_to_run, false, "single_player");
 		delete ctrl_;
 		ctrl_ = nullptr;
 		return result;
@@ -415,7 +415,7 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 
 	set_game_controller(new SinglePlayerGameController(*this, true, player_nr));
 	try {
-		bool const result = run(Loaded, script_to_run, false, "single_player");
+		bool const result = run(StartGameType::kSaveGame, script_to_run, false, "single_player");
 		delete ctrl_;
 		ctrl_ = nullptr;
 		return result;
@@ -464,9 +464,9 @@ bool Game::run(StartGameType const start_game_type,
 	replay_ = replay;
 	postload();
 
-	if (start_game_type != Loaded) {
+	if (start_game_type != StartGameType::kSaveGame) {
 		PlayerNumber const nr_players = map().get_nrplayers();
-		if (start_game_type == NewNonScenario) {
+		if (start_game_type == StartGameType::kMap) {
 			step_loader_ui(_("Creating player infrastructure…"));
 			iterate_players_existing(p, nr_players, *this, plr) {
 				plr->create_default_infrastructure();
@@ -513,9 +513,9 @@ bool Game::run(StartGameType const start_game_type,
 		}
 
 		// Run the init script, if the map provides one.
-		if (start_game_type == NewSPScenario) {
+		if (start_game_type == StartGameType::kSinglePlayerScenario) {
 			enqueue_command(new CmdLuaScript(get_gametime(), "map:scripting/init.lua"));
-		} else if (start_game_type == NewMPScenario) {
+		} else if (start_game_type == StartGameType::kMultiPlayerScenario) {
 			enqueue_command(new CmdLuaScript(get_gametime(), "map:scripting/multiplayer_init.lua"));
 		}
 
@@ -523,7 +523,7 @@ bool Game::run(StartGameType const start_game_type,
 		enqueue_command(new CmdCalculateStatistics(get_gametime() + 1));
 	}
 
-	if (!script_to_run.empty() && (start_game_type == NewSPScenario || start_game_type == Loaded)) {
+	if (!script_to_run.empty() && (start_game_type == StartGameType::kSinglePlayerScenario || start_game_type == StartGameType::kSaveGame)) {
 		enqueue_command(new CmdLuaScript(get_gametime() + 1, script_to_run));
 	}
 

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -253,7 +253,8 @@ bool Game::run_splayer_scenario_direct(const std::string& mapname,
 
 	set_game_controller(new SinglePlayerGameController(*this, true, 1));
 	try {
-		bool const result = run(StartGameType::kSinglePlayerScenario, script_to_run, false, "single_player");
+		bool const result =
+		   run(StartGameType::kSinglePlayerScenario, script_to_run, false, "single_player");
 		delete ctrl_;
 		ctrl_ = nullptr;
 		return result;
@@ -523,7 +524,8 @@ bool Game::run(StartGameType const start_game_type,
 		enqueue_command(new CmdCalculateStatistics(get_gametime() + 1));
 	}
 
-	if (!script_to_run.empty() && (start_game_type == StartGameType::kSinglePlayerScenario || start_game_type == StartGameType::kSaveGame)) {
+	if (!script_to_run.empty() && (start_game_type == StartGameType::kSinglePlayerScenario ||
+	                               start_game_type == StartGameType::kSaveGame)) {
 		enqueue_command(new CmdLuaScript(get_gametime() + 1, script_to_run));
 	}
 

--- a/src/logic/game.h
+++ b/src/logic/game.h
@@ -172,7 +172,7 @@ public:
 	void init_newgame(const GameSettings&);
 	void init_savegame(const GameSettings&);
 
-	enum StartGameType { NewSPScenario, NewNonScenario, Loaded, NewMPScenario };
+	enum class StartGameType { kMap, kSinglePlayerScenario, kMultiPlayerScenario, kSaveGame };
 
 	bool run(StartGameType,
 	         const std::string& script_to_run,

--- a/src/logic/map_objects/world/map_gen.cc
+++ b/src/logic/map_objects/world/map_gen.cc
@@ -34,24 +34,24 @@ MapGenBobCategory::MapGenBobCategory(const LuaTable& table)
 }
 
 const MapGenBobCategory*
-MapGenLandResource::get_bob_category(MapGenAreaInfo::MapGenTerrainType terrain_type) const {
+MapGenLandResource::get_bob_category(MapGenAreaInfo::Terrain terrain_type) const {
 	switch (terrain_type) {
-	case MapGenAreaInfo::ttLandCoast:
+	case MapGenAreaInfo::Terrain::kLandCoast:
 		return land_coast_bob_category_;
-	case MapGenAreaInfo::ttLandLand:
+	case MapGenAreaInfo::Terrain::kLandLand:
 		return land_inner_bob_category_;
-	case MapGenAreaInfo::ttLandUpper:
+	case MapGenAreaInfo::Terrain::kLandUpper:
 		return land_upper_bob_category_;
-	case MapGenAreaInfo::ttWastelandInner:
+	case MapGenAreaInfo::Terrain::kWastelandInner:
 		return wasteland_inner_bob_category_;
-	case MapGenAreaInfo::ttWastelandOuter:
+	case MapGenAreaInfo::Terrain::kWastelandOuter:
 		return wasteland_outer_bob_category_;
-	case MapGenAreaInfo::ttWaterOcean:
-	case MapGenAreaInfo::ttWaterShelf:
-	case MapGenAreaInfo::ttWaterShallow:
-	case MapGenAreaInfo::ttMountainsFoot:
-	case MapGenAreaInfo::ttMountainsMountain:
-	case MapGenAreaInfo::ttMountainsSnow:
+	case MapGenAreaInfo::Terrain::kWaterOcean:
+	case MapGenAreaInfo::Terrain::kWaterShelf:
+	case MapGenAreaInfo::Terrain::kWaterShallow:
+	case MapGenAreaInfo::Terrain::kMountainsFoot:
+	case MapGenAreaInfo::Terrain::kMountainsMountain:
+	case MapGenAreaInfo::Terrain::kMountainsSnow:
 		return nullptr;
 	}
 	NEVER_HERE();
@@ -82,7 +82,7 @@ MapGenLandResource::MapGenLandResource(const LuaTable& table, MapGenInfo& map_ge
 
 MapGenAreaInfo::MapGenAreaInfo(const LuaTable& table,
                                const World& world,
-                               MapGenAreaType const area_type) {
+                               Area const area_type) {
 	weight_ = get_positive_int(table, "weight");
 
 	const auto read_terrains = [&table, &world](
@@ -96,86 +96,86 @@ MapGenAreaInfo::MapGenAreaInfo(const LuaTable& table,
 	};
 
 	switch (area_type) {
-	case atWater:
+	case MapGenAreaInfo::Area::kWater:
 		read_terrains("ocean_terrains", &terrains1_);
 		read_terrains("shelf_terrains", &terrains2_);
 		read_terrains("shallow_terrains", &terrains3_);
 		break;
-	case atLand:
+	case MapGenAreaInfo::Area::kLand:
 		read_terrains("coast_terrains", &terrains1_);
 		read_terrains("land_terrains", &terrains2_);
 		read_terrains("upper_terrains", &terrains3_);
 		break;
-	case atMountains:
+	case MapGenAreaInfo::Area::kMountains:
 		read_terrains("mountainfoot_terrains", &terrains1_);
 		read_terrains("mountain_terrains", &terrains2_);
 		read_terrains("snow_terrains", &terrains3_);
 		break;
-	case atWasteland:
+	case MapGenAreaInfo::Area::kWasteland:
 		read_terrains("inner_terrains", &terrains1_);
 		read_terrains("outer_terrains", &terrains2_);
 		break;
 	}
 }
 
-size_t MapGenAreaInfo::get_num_terrains(MapGenTerrainType const terrain_type) const {
+size_t MapGenAreaInfo::get_num_terrains(Terrain const terrain_type) const {
 	switch (terrain_type) {
-	case ttWaterOcean:
+	case MapGenAreaInfo::Terrain::kWaterOcean:
 		return terrains1_.size();
-	case ttWaterShelf:
+	case MapGenAreaInfo::Terrain::kWaterShelf:
 		return terrains2_.size();
-	case ttWaterShallow:
+	case MapGenAreaInfo::Terrain::kWaterShallow:
 		return terrains3_.size();
 
-	case ttLandCoast:
+	case MapGenAreaInfo::Terrain::kLandCoast:
 		return terrains1_.size();
-	case ttLandLand:
+	case MapGenAreaInfo::Terrain::kLandLand:
 		return terrains2_.size();
-	case ttLandUpper:
+	case MapGenAreaInfo::Terrain::kLandUpper:
 		return terrains3_.size();
 
-	case ttWastelandInner:
+	case MapGenAreaInfo::Terrain::kWastelandInner:
 		return terrains1_.size();
-	case ttWastelandOuter:
+	case MapGenAreaInfo::Terrain::kWastelandOuter:
 		return terrains2_.size();
 
-	case ttMountainsFoot:
+	case MapGenAreaInfo::Terrain::kMountainsFoot:
 		return terrains1_.size();
-	case ttMountainsMountain:
+	case MapGenAreaInfo::Terrain::kMountainsMountain:
 		return terrains2_.size();
-	case ttMountainsSnow:
+	case MapGenAreaInfo::Terrain::kMountainsSnow:
 		return terrains3_.size();
 	}
 	NEVER_HERE();
 }
 
-DescriptionIndex MapGenAreaInfo::get_terrain(MapGenTerrainType const terrain_type,
+DescriptionIndex MapGenAreaInfo::get_terrain(Terrain const terrain_type,
                                              uint32_t const index) const {
 	switch (terrain_type) {
-	case ttWaterOcean:
+	case MapGenAreaInfo::Terrain::kWaterOcean:
 		return terrains1_[index];
-	case ttWaterShelf:
+	case MapGenAreaInfo::Terrain::kWaterShelf:
 		return terrains2_[index];
-	case ttWaterShallow:
+	case MapGenAreaInfo::Terrain::kWaterShallow:
 		return terrains3_[index];
 
-	case ttLandCoast:
+	case MapGenAreaInfo::Terrain::kLandCoast:
 		return terrains1_[index];
-	case ttLandLand:
+	case MapGenAreaInfo::Terrain::kLandLand:
 		return terrains2_[index];
-	case ttLandUpper:
+	case MapGenAreaInfo::Terrain::kLandUpper:
 		return terrains3_[index];
 
-	case ttWastelandInner:
+	case MapGenAreaInfo::Terrain::kWastelandInner:
 		return terrains1_[index];
-	case ttWastelandOuter:
+	case MapGenAreaInfo::Terrain::kWastelandOuter:
 		return terrains2_[index];
 
-	case ttMountainsFoot:
+	case MapGenAreaInfo::Terrain::kMountainsFoot:
 		return terrains1_[index];
-	case ttMountainsMountain:
+	case MapGenAreaInfo::Terrain::kMountainsMountain:
 		return terrains2_[index];
-	case ttMountainsSnow:
+	case MapGenAreaInfo::Terrain::kMountainsSnow:
 		return terrains3_[index];
 	}
 	NEVER_HERE();
@@ -187,8 +187,8 @@ uint32_t MapGenInfo::get_sum_land_weight() const {
 	}
 
 	uint32_t sum = 0;
-	for (uint32_t ix = 0; ix < get_num_areas(MapGenAreaInfo::atLand); ++ix) {
-		sum += get_area(MapGenAreaInfo::atLand, ix).get_weight();
+	for (uint32_t ix = 0; ix < get_num_areas(MapGenAreaInfo::Area::kLand); ++ix) {
+		sum += get_area(MapGenAreaInfo::Area::kLand, ix).get_weight();
 	}
 	land_weight_ = sum;
 	land_weight_valid_ = true;
@@ -219,30 +219,30 @@ uint32_t MapGenInfo::get_sum_land_resource_weight() const {
 	return sum_bob_area_weights_;
 }
 
-size_t MapGenInfo::get_num_areas(MapGenAreaInfo::MapGenAreaType const area_type) const {
+size_t MapGenInfo::get_num_areas(MapGenAreaInfo::Area const area_type) const {
 	switch (area_type) {
-	case MapGenAreaInfo::atWater:
+	case MapGenAreaInfo::Area::kWater:
 		return water_areas_.size();
-	case MapGenAreaInfo::atLand:
+	case MapGenAreaInfo::Area::kLand:
 		return land_areas_.size();
-	case MapGenAreaInfo::atMountains:
+	case MapGenAreaInfo::Area::kMountains:
 		return mountain_areas_.size();
-	case MapGenAreaInfo::atWasteland:
+	case MapGenAreaInfo::Area::kWasteland:
 		return wasteland_areas_.size();
 	}
 	NEVER_HERE();
 }
 
-const MapGenAreaInfo& MapGenInfo::get_area(MapGenAreaInfo::MapGenAreaType const area_type,
+const MapGenAreaInfo& MapGenInfo::get_area(MapGenAreaInfo::Area const area_type,
                                            uint32_t const index) const {
 	switch (area_type) {
-	case MapGenAreaInfo::atWater:
+	case MapGenAreaInfo::Area::kWater:
 		return water_areas_.at(index);
-	case MapGenAreaInfo::atLand:
+	case MapGenAreaInfo::Area::kLand:
 		return land_areas_.at(index);
-	case MapGenAreaInfo::atMountains:
+	case MapGenAreaInfo::Area::kMountains:
 		return mountain_areas_.at(index);
-	case MapGenAreaInfo::atWasteland:
+	case MapGenAreaInfo::Area::kWasteland:
 		return wasteland_areas_.at(index);
 	}
 	NEVER_HERE();
@@ -279,7 +279,7 @@ MapGenInfo::MapGenInfo(const LuaTable& table, const World& world) {
 		std::unique_ptr<LuaTable> areas(table.get_table("areas"));
 
 		const auto read_area = [&world, &areas](const std::string& area_name,
-		                                        const MapGenAreaInfo::MapGenAreaType area_type,
+		                                        const MapGenAreaInfo::Area area_type,
 		                                        std::vector<MapGenAreaInfo>* area_vector) {
 			std::unique_ptr<LuaTable> area(areas->get_table(area_name));
 			std::vector<std::unique_ptr<LuaTable>> entries =
@@ -291,10 +291,10 @@ MapGenInfo::MapGenInfo(const LuaTable& table, const World& world) {
 			}
 		};
 
-		read_area("water", MapGenAreaInfo::atWater, &water_areas_);
-		read_area("land", MapGenAreaInfo::atLand, &land_areas_);
-		read_area("wasteland", MapGenAreaInfo::atWasteland, &wasteland_areas_);
-		read_area("mountains", MapGenAreaInfo::atMountains, &mountain_areas_);
+		read_area("water", MapGenAreaInfo::Area::kWater, &water_areas_);
+		read_area("land", MapGenAreaInfo::Area::kLand, &land_areas_);
+		read_area("wasteland", MapGenAreaInfo::Area::kWasteland, &wasteland_areas_);
+		read_area("mountains", MapGenAreaInfo::Area::kMountains, &mountain_areas_);
 	}
 
 	// read the bobs.
@@ -333,62 +333,62 @@ MapGenInfo::MapGenInfo(const LuaTable& table, const World& world) {
 		}
 	}
 
-	if (get_num_areas(MapGenAreaInfo::atWater) < 1) {
+	if (get_num_areas(MapGenAreaInfo::Area::kWater) < 1) {
 		throw GameDataError("missing a water area");
 	}
-	if (get_num_areas(MapGenAreaInfo::atWater) > 3) {
+	if (get_num_areas(MapGenAreaInfo::Area::kWater) > 3) {
 		throw GameDataError("too many water areas (>3)");
 	}
-	if (get_num_areas(MapGenAreaInfo::atLand) < 1) {
+	if (get_num_areas(MapGenAreaInfo::Area::kLand) < 1) {
 		throw GameDataError("missing a land area");
 	}
-	if (get_num_areas(MapGenAreaInfo::atLand) > 3) {
+	if (get_num_areas(MapGenAreaInfo::Area::kLand) > 3) {
 		throw GameDataError("too many land areas (>3)");
 	}
-	if (get_num_areas(MapGenAreaInfo::atWasteland) < 1) {
+	if (get_num_areas(MapGenAreaInfo::Area::kWasteland) < 1) {
 		throw GameDataError("missing a wasteland area");
 	}
-	if (get_num_areas(MapGenAreaInfo::atWasteland) > 2) {
+	if (get_num_areas(MapGenAreaInfo::Area::kWasteland) > 2) {
 		throw GameDataError("too many wasteland areas (>2)");
 	}
-	if (get_num_areas(MapGenAreaInfo::atMountains) < 1) {
+	if (get_num_areas(MapGenAreaInfo::Area::kMountains) < 1) {
 		throw GameDataError("missing a mountain area");
 	}
-	if (get_num_areas(MapGenAreaInfo::atMountains) > 1) {
+	if (get_num_areas(MapGenAreaInfo::Area::kMountains) > 1) {
 		throw GameDataError("too many mountain areas (>1)");
 	}
-	if (get_area(MapGenAreaInfo::atWater, 0).get_num_terrains(MapGenAreaInfo::ttWaterOcean) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kWater, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWaterOcean) < 1) {
 		throw GameDataError("missing a water/ocean terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atWater, 0).get_num_terrains(MapGenAreaInfo::ttWaterShelf) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kWater, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWaterShelf) < 1) {
 		throw GameDataError("missing a water/shelf terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atWater, 0).get_num_terrains(MapGenAreaInfo::ttWaterShallow) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kWater, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWaterShallow) < 1) {
 		throw GameDataError("is missing a water/shallow terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atLand, 0).get_num_terrains(MapGenAreaInfo::ttLandCoast) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kLand, 0).get_num_terrains(MapGenAreaInfo::Terrain::kLandCoast) < 1) {
 		throw GameDataError("missing a land/coast terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atLand, 0).get_num_terrains(MapGenAreaInfo::ttLandLand) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kLand, 0).get_num_terrains(MapGenAreaInfo::Terrain::kLandLand) < 1) {
 		throw GameDataError("missing a land/land terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atMountains, 0).get_num_terrains(MapGenAreaInfo::ttMountainsFoot) <
+	if (get_area(MapGenAreaInfo::Area::kMountains, 0).get_num_terrains(MapGenAreaInfo::Terrain::kMountainsFoot) <
 	    1) {
 		throw GameDataError("missing a mountain/foot terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atMountains, 0)
-	       .get_num_terrains(MapGenAreaInfo::ttMountainsMountain) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kMountains, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kMountainsMountain) < 1) {
 		throw GameDataError("missing a monutain/mountain terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atMountains, 0).get_num_terrains(MapGenAreaInfo::ttMountainsSnow) <
+	if (get_area(MapGenAreaInfo::Area::kMountains, 0).get_num_terrains(MapGenAreaInfo::Terrain::kMountainsSnow) <
 	    1) {
 		throw GameDataError("missing a mountain/snow terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atWasteland, 0).get_num_terrains(MapGenAreaInfo::ttWastelandInner) <
+	if (get_area(MapGenAreaInfo::Area::kWasteland, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWastelandInner) <
 	    1) {
 		throw GameDataError("missing a land/coast terrain type");
 	}
-	if (get_area(MapGenAreaInfo::atWasteland, 0).get_num_terrains(MapGenAreaInfo::ttWastelandOuter) <
+	if (get_area(MapGenAreaInfo::Area::kWasteland, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWastelandOuter) <
 	    1) {
 		throw GameDataError("missing a land/land terrain type");
 	}

--- a/src/logic/map_objects/world/map_gen.cc
+++ b/src/logic/map_objects/world/map_gen.cc
@@ -80,9 +80,7 @@ MapGenLandResource::MapGenLandResource(const LuaTable& table, MapGenInfo& map_ge
 	do_assign("wasteland_outer_bobs", &wasteland_outer_bob_category_);
 }
 
-MapGenAreaInfo::MapGenAreaInfo(const LuaTable& table,
-                               const World& world,
-                               Area const area_type) {
+MapGenAreaInfo::MapGenAreaInfo(const LuaTable& table, const World& world, Area const area_type) {
 	weight_ = get_positive_int(table, "weight");
 
 	const auto read_terrains = [&table, &world](
@@ -357,39 +355,44 @@ MapGenInfo::MapGenInfo(const LuaTable& table, const World& world) {
 	if (get_num_areas(MapGenAreaInfo::Area::kMountains) > 1) {
 		throw GameDataError("too many mountain areas (>1)");
 	}
-	if (get_area(MapGenAreaInfo::Area::kWater, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWaterOcean) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kWater, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kWaterOcean) < 1) {
 		throw GameDataError("missing a water/ocean terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kWater, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWaterShelf) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kWater, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kWaterShelf) < 1) {
 		throw GameDataError("missing a water/shelf terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kWater, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWaterShallow) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kWater, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kWaterShallow) < 1) {
 		throw GameDataError("is missing a water/shallow terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kLand, 0).get_num_terrains(MapGenAreaInfo::Terrain::kLandCoast) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kLand, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kLandCoast) < 1) {
 		throw GameDataError("missing a land/coast terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kLand, 0).get_num_terrains(MapGenAreaInfo::Terrain::kLandLand) < 1) {
+	if (get_area(MapGenAreaInfo::Area::kLand, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kLandLand) < 1) {
 		throw GameDataError("missing a land/land terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kMountains, 0).get_num_terrains(MapGenAreaInfo::Terrain::kMountainsFoot) <
-	    1) {
+	if (get_area(MapGenAreaInfo::Area::kMountains, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kMountainsFoot) < 1) {
 		throw GameDataError("missing a mountain/foot terrain type");
 	}
 	if (get_area(MapGenAreaInfo::Area::kMountains, 0)
 	       .get_num_terrains(MapGenAreaInfo::Terrain::kMountainsMountain) < 1) {
 		throw GameDataError("missing a monutain/mountain terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kMountains, 0).get_num_terrains(MapGenAreaInfo::Terrain::kMountainsSnow) <
-	    1) {
+	if (get_area(MapGenAreaInfo::Area::kMountains, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kMountainsSnow) < 1) {
 		throw GameDataError("missing a mountain/snow terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kWasteland, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWastelandInner) <
-	    1) {
+	if (get_area(MapGenAreaInfo::Area::kWasteland, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kWastelandInner) < 1) {
 		throw GameDataError("missing a land/coast terrain type");
 	}
-	if (get_area(MapGenAreaInfo::Area::kWasteland, 0).get_num_terrains(MapGenAreaInfo::Terrain::kWastelandOuter) <
-	    1) {
+	if (get_area(MapGenAreaInfo::Area::kWasteland, 0)
+	       .get_num_terrains(MapGenAreaInfo::Terrain::kWastelandOuter) < 1) {
 		throw GameDataError("missing a land/land terrain type");
 	}
 }

--- a/src/logic/map_objects/world/map_gen.h
+++ b/src/logic/map_objects/world/map_gen.h
@@ -31,29 +31,29 @@ struct MapGenInfo;
 /// Holds world and area specific information for the map generator.
 /// Areas are: Water, Land, Wasteland and Mountains.
 struct MapGenAreaInfo {
-	enum MapGenAreaType { atWater, atLand, atWasteland, atMountains };
+	enum class Area { kWater, kLand, kWasteland, kMountains };
 
-	enum MapGenTerrainType {
-		ttWaterOcean,
-		ttWaterShelf,
-		ttWaterShallow,
+	enum class Terrain {
+		kWaterOcean,
+		kWaterShelf,
+		kWaterShallow,
 
-		ttLandCoast,
-		ttLandLand,
-		ttLandUpper,
+		kLandCoast,
+		kLandLand,
+		kLandUpper,
 
-		ttWastelandInner,
-		ttWastelandOuter,
+		kWastelandInner,
+		kWastelandOuter,
 
-		ttMountainsFoot,
-		ttMountainsMountain,
-		ttMountainsSnow
+		kMountainsFoot,
+		kMountainsMountain,
+		kMountainsSnow
 	};
 
-	MapGenAreaInfo(const LuaTable& table, const World& world, MapGenAreaType area_type);
+	MapGenAreaInfo(const LuaTable& table, const World& world, Area area_type);
 
-	size_t get_num_terrains(MapGenTerrainType) const;
-	DescriptionIndex get_terrain(MapGenTerrainType terrain_type, uint32_t index) const;
+	size_t get_num_terrains(Terrain) const;
+	DescriptionIndex get_terrain(Terrain terrain_type, uint32_t index) const;
 	uint32_t get_weight() const {
 		return weight_;
 	}
@@ -94,7 +94,7 @@ struct MapGenLandResource {
 	uint32_t get_weight() const {
 		return weight_;
 	}
-	const MapGenBobCategory* get_bob_category(MapGenAreaInfo::MapGenTerrainType terrain_type) const;
+	const MapGenBobCategory* get_bob_category(MapGenAreaInfo::Terrain terrain_type) const;
 
 	uint8_t get_immovable_density() const {
 		return immovable_density_;
@@ -122,8 +122,8 @@ private:
 struct MapGenInfo {
 	MapGenInfo(const LuaTable& table, const World& world);
 
-	size_t get_num_areas(MapGenAreaInfo::MapGenAreaType area_type) const;
-	const MapGenAreaInfo& get_area(MapGenAreaInfo::MapGenAreaType area_type, uint32_t index) const;
+	size_t get_num_areas(MapGenAreaInfo::Area area_type) const;
+	const MapGenAreaInfo& get_area(MapGenAreaInfo::Area area_type, uint32_t index) const;
 	const MapGenBobCategory* get_bob_category(const std::string& bob_category) const;
 
 	uint8_t get_water_ocean_height() const {

--- a/src/map_io/map_loader.h
+++ b/src/map_io/map_loader.h
@@ -36,7 +36,7 @@ class MapLoader {
 public:
 	enum class LoadType { kGame, kScenario, kEditor };
 
-	MapLoader(const std::string& filename, Map& M) : map_(M), state_(STATE_INIT) {
+	MapLoader(const std::string& filename, Map& M) : map_(M), state_(State::kInit) {
 		map_.set_filename(filename);
 	}
 	virtual ~MapLoader() {
@@ -50,7 +50,7 @@ public:
 	}
 
 protected:
-	enum State { STATE_INIT, STATE_PRELOADED, STATE_LOADED };
+	enum class State { kInit, kPreLoaded, kLoaded };
 	void set_state(State const s) {
 		state_ = s;
 	}

--- a/src/map_io/s2map.cc
+++ b/src/map_io/s2map.cc
@@ -370,7 +370,7 @@ S2MapLoader::S2MapLoader(const std::string& filename, Widelands::Map& M)
 /// Load the header. The map will then return valid information when
 /// get_width(), get_nrplayers(), get_author() and so on are called.
 int32_t S2MapLoader::preload_map(bool const scenario) {
-	assert(get_state() != STATE_LOADED);
+	assert(get_state() != State::kLoaded);
 
 	map_.cleanup();
 
@@ -397,7 +397,7 @@ int32_t S2MapLoader::preload_map(bool const scenario) {
 		}
 	}
 
-	set_state(STATE_PRELOADED);
+	set_state(State::kPreLoaded);
 
 	return 0;
 }
@@ -418,7 +418,7 @@ int32_t S2MapLoader::load_map_complete(Widelands::EditorGameBase& egbase, MapLoa
 
 	postload_set_port_spaces(egbase);
 
-	set_state(STATE_LOADED);
+	set_state(State::kLoaded);
 
 	return 0;
 }

--- a/src/map_io/widelands_map_loader.cc
+++ b/src/map_io/widelands_map_loader.cc
@@ -75,7 +75,7 @@ WidelandsMapLoader::~WidelandsMapLoader() {
  * get_info() functions (width, nrplayers..)
  */
 int32_t WidelandsMapLoader::preload_map(bool const scenario) {
-	assert(get_state() != STATE_LOADED);
+	assert(get_state() != State::kLoaded);
 
 	map_.cleanup();
 
@@ -103,7 +103,7 @@ int32_t WidelandsMapLoader::preload_map(bool const scenario) {
 	}
 	map_.set_scenario_types(m);
 
-	set_state(STATE_PRELOADED);
+	set_state(State::kPreLoaded);
 
 	return 0;
 }
@@ -408,7 +408,7 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 
 	map_.ensure_resource_consistency(egbase.world());
 
-	set_state(STATE_LOADED);
+	set_state(State::kLoaded);
 
 	return 0;
 }

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -180,9 +180,10 @@ void GameClientImpl::run_game(InteractiveGameBase* igb) {
 
 	modal = igb;
 
-	game->run(settings.savegame ? Widelands::Game::StartGameType::kSaveGame :
-	                              settings.scenario ? Widelands::Game::StartGameType::kMultiPlayerScenario :
-	                                                  Widelands::Game::StartGameType::kMap,
+	game->run(settings.savegame ?
+	             Widelands::Game::StartGameType::kSaveGame :
+	             settings.scenario ? Widelands::Game::StartGameType::kMultiPlayerScenario :
+	                                 Widelands::Game::StartGameType::kMap,
 	          "", false, (boost::format("netclient_%d") % static_cast<int>(settings.usernum)).str());
 
 	// if this is an internet game, tell the metaserver that the game is done.

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -180,9 +180,9 @@ void GameClientImpl::run_game(InteractiveGameBase* igb) {
 
 	modal = igb;
 
-	game->run(settings.savegame ? Widelands::Game::Loaded :
-	                              settings.scenario ? Widelands::Game::NewMPScenario :
-	                                                  Widelands::Game::NewNonScenario,
+	game->run(settings.savegame ? Widelands::Game::StartGameType::kSaveGame :
+	                              settings.scenario ? Widelands::Game::StartGameType::kMultiPlayerScenario :
+	                                                  Widelands::Game::StartGameType::kMap,
 	          "", false, (boost::format("netclient_%d") % static_cast<int>(settings.usernum)).str());
 
 	// if this is an internet game, tell the metaserver that the game is done.

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -705,9 +705,10 @@ void GameHost::run() {
 		// wait mode when there are no clients
 		check_hung_clients();
 		init_computer_players();
-		game.run(d->settings.savegame ? Widelands::Game::StartGameType::kSaveGame :
-		                                d->settings.scenario ? Widelands::Game::StartGameType::kMultiPlayerScenario :
-		                                                       Widelands::Game::StartGameType::kMap,
+		game.run(d->settings.savegame ?
+		            Widelands::Game::StartGameType::kSaveGame :
+		            d->settings.scenario ? Widelands::Game::StartGameType::kMultiPlayerScenario :
+		                                   Widelands::Game::StartGameType::kMap,
 		         "", false, "nethost");
 
 		// if this is an internet game, tell the metaserver that the game is done.

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -705,9 +705,9 @@ void GameHost::run() {
 		// wait mode when there are no clients
 		check_hung_clients();
 		init_computer_players();
-		game.run(d->settings.savegame ? Widelands::Game::Loaded :
-		                                d->settings.scenario ? Widelands::Game::NewMPScenario :
-		                                                       Widelands::Game::NewNonScenario,
+		game.run(d->settings.savegame ? Widelands::Game::StartGameType::kSaveGame :
+		                                d->settings.scenario ? Widelands::Game::StartGameType::kMultiPlayerScenario :
+		                                                       Widelands::Game::StartGameType::kMap,
 		         "", false, "nethost");
 
 		// if this is an internet game, tell the metaserver that the game is done.

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1411,7 +1411,7 @@ bool WLApplication::new_game() {
 
 			game.set_game_controller(ctrl.get());
 			game.init_newgame(sp.settings());
-			game.run(Widelands::Game::NewNonScenario, "", false, "single_player");
+			game.run(Widelands::Game::StartGameType::kMap, "", false, "single_player");
 		} catch (const std::exception& e) {
 			log("Fatal exception: %s\n", e.what());
 			std::unique_ptr<GameController> ctrl(new SinglePlayerGameController(game, true, pn));
@@ -1529,7 +1529,7 @@ void WLApplication::replay() {
 
 		game.save_handler().set_allow_saving(false);
 
-		game.run(Widelands::Game::Loaded, "", true, "replay");
+		game.run(Widelands::Game::StartGameType::kSaveGame, "", true, "replay");
 	} catch (const std::exception& e) {
 		log("Fatal Exception: %s\n", e.what());
 		emergency_save(game);

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -317,7 +317,7 @@ WLApplication* WLApplication::get(int const argc, char const** argv) {
  */
 WLApplication::WLApplication(int const argc, char const* const* const argv)
    : commandline_(std::map<std::string, std::string>()),
-     game_type_(NONE),
+     game_type_(GameType::kNone),
      mouse_swapped_(false),
      faking_middle_mouse_button_(false),
      mouse_position_(Vector2i::zero()),
@@ -454,12 +454,12 @@ void WLApplication::run() {
 	// This also grabs the mouse cursor if so desired.
 	refresh_graphics();
 
-	if (game_type_ == EDITOR) {
+	if (game_type_ == GameType::kEditor) {
 		g_sh->change_music("ingame");
 		EditorInteractive::run_editor(filename_, script_to_run_);
-	} else if (game_type_ == REPLAY) {
+	} else if (game_type_ == GameType::kReplay) {
 		replay();
-	} else if (game_type_ == LOADGAME) {
+	} else if (game_type_ == GameType::kLoadGame) {
 		Widelands::Game game;
 		game.set_ai_training_mode(get_config_bool("ai_training", false));
 		try {
@@ -471,7 +471,7 @@ void WLApplication::run() {
 			emergency_save(game);
 			throw;
 		}
-	} else if (game_type_ == SCENARIO) {
+	} else if (game_type_ == GameType::kScenario) {
 		Widelands::Game game;
 		try {
 			game.run_splayer_scenario_direct(filename_.c_str(), script_to_run_);
@@ -1045,24 +1045,24 @@ void WLApplication::handle_commandline_parameters() {
 		if (filename_.size() && *filename_.rbegin() == '/') {
 			filename_.erase(filename_.size() - 1);
 		}
-		game_type_ = EDITOR;
+		game_type_ = GameType::kEditor;
 		commandline_.erase("editor");
 	}
 
 	if (commandline_.count("replay")) {
-		if (game_type_ != NONE) {
+		if (game_type_ != GameType::kNone) {
 			throw wexception("replay can not be combined with other actions");
 		}
 		filename_ = commandline_["replay"];
 		if (filename_.size() && *filename_.rbegin() == '/') {
 			filename_.erase(filename_.size() - 1);
 		}
-		game_type_ = REPLAY;
+		game_type_ = GameType::kReplay;
 		commandline_.erase("replay");
 	}
 
 	if (commandline_.count("loadgame")) {
-		if (game_type_ != NONE) {
+		if (game_type_ != GameType::kNone) {
 			throw wexception("loadgame can not be combined with other actions");
 		}
 		filename_ = commandline_["loadgame"];
@@ -1072,12 +1072,12 @@ void WLApplication::handle_commandline_parameters() {
 		if (*filename_.rbegin() == '/') {
 			filename_.erase(filename_.size() - 1);
 		}
-		game_type_ = LOADGAME;
+		game_type_ = GameType::kLoadGame;
 		commandline_.erase("loadgame");
 	}
 
 	if (commandline_.count("scenario")) {
-		if (game_type_ != NONE) {
+		if (game_type_ != GameType::kNone) {
 			throw wexception("scenario can not be combined with other actions");
 		}
 		filename_ = commandline_["scenario"];
@@ -1087,7 +1087,7 @@ void WLApplication::handle_commandline_parameters() {
 		if (*filename_.rbegin() == '/') {
 			filename_.erase(filename_.size() - 1);
 		}
-		game_type_ = SCENARIO;
+		game_type_ = GameType::kScenario;
 		commandline_.erase("scenario");
 	}
 	if (commandline_.count("script")) {

--- a/src/wlapplication.h
+++ b/src/wlapplication.h
@@ -131,8 +131,6 @@ struct WLApplication {
 	static WLApplication* get(int const argc = 0, char const** argv = nullptr);
 	~WLApplication();
 
-	enum GameType { NONE, EDITOR, REPLAY, SCENARIO, LOADGAME, NETWORK };
-
 	void run();
 
 	/// \warning true if an external entity wants us to quit
@@ -226,6 +224,7 @@ private:
 	/// --scenario or --loadgame.
 	std::string script_to_run_;
 
+	enum class GameType { kNone, kEditor, kReplay, kScenario, kLoadGame };
 	GameType game_type_;
 
 	/// True if left and right mouse button should be swapped

--- a/src/wui/game_message_menu.cc
+++ b/src/wui/game_message_menu.cc
@@ -56,7 +56,7 @@ GameMessageMenu::GameMessageMenu(InteractivePlayer& plr, UI::UniqueWindow::Regis
                   "",
                   UI::Align::kLeft,
                   UI::MultilineTextarea::ScrollMode::kScrollNormalForced),
-     mode(Inbox) {
+     mode(Mode::Inbox) {
 
 	list = new UI::Table<uintptr_t>(this, kPadding, kButtonSize + 2 * kPadding,
 	                                kWindowWidth - 2 * kPadding, kTableHeight, UI::PanelStyle::kWui,
@@ -224,7 +224,7 @@ bool GameMessageMenu::compare_time_sent(uint32_t a, uint32_t b) {
 
 bool GameMessageMenu::should_be_hidden(const Widelands::Message& message) {
 	// Wrong box
-	return ((mode == Archive) != (message.status() == Message::Status::kArchived)) ||
+	return ((mode == Mode::Archive) != (message.status() == Message::Status::kArchived)) ||
 	       // Filtered out
 	       (message_filter_ != Message::Type::kAllMessages &&
 	        message.message_type_category() != message_filter_);
@@ -243,7 +243,7 @@ void GameMessageMenu::show_new_message(MessageId const id, const Widelands::Mess
 	assert(iplayer().player().messages()[id] == &message);
 	assert(!list->find(id.value()));
 	Message::Status const status = message.status();
-	if ((mode == Archive) != (status == Message::Status::kArchived)) {
+	if ((mode == Mode::Archive) != (status == Message::Status::kArchived)) {
 		toggle_mode();
 	}
 	UI::Table<uintptr_t>::EntryRecord& te = list->add(id.value());
@@ -481,12 +481,12 @@ void GameMessageMenu::archive_or_restore() {
 	for (const uint32_t index : selections) {
 		const uintptr_t selected_record = list->get(list->get_record(index));
 		switch (mode) {
-		case Inbox:
+		case Mode::Inbox:
 			// Archive highlighted message
 			game.send_player_command(new Widelands::CmdMessageSetStatusArchived(
 			   game.get_gametime(), plnum, MessageId(selected_record)));
 			break;
-		case Archive:
+		case Mode::Archive:
 			// Restore highlighted message
 			game.send_player_command(new Widelands::CmdMessageSetStatusRead(
 			   game.get_gametime(), plnum, MessageId(selected_record)));
@@ -626,15 +626,15 @@ std::string GameMessageMenu::display_message_type_icon(const Widelands::Message&
 void GameMessageMenu::toggle_mode() {
 	list->clear();
 	switch (mode) {
-	case Inbox:
-		mode = Archive;
+	case Mode::Inbox:
+		mode = Mode::Archive;
 		set_title(_("Messages: Archive"));
 		archivebtn_->set_pic(g_gr->images().get("images/wui/messages/message_restore.png"));
 		togglemodebtn_->set_pic(g_gr->images().get("images/wui/messages/message_new.png"));
 		togglemodebtn_->set_tooltip(_("Show Inbox"));
 		break;
-	case Archive:
-		mode = Inbox;
+	case Mode::Archive:
+		mode = Mode::Inbox;
 		set_title(_("Messages: Inbox"));
 		archivebtn_->set_pic(g_gr->images().get("images/wui/messages/message_archive.png"));
 		togglemodebtn_->set_pic(g_gr->images().get("images/wui/messages/message_archived.png"));
@@ -654,7 +654,7 @@ void GameMessageMenu::update_archive_button_tooltip() {
 	std::string button_tooltip;
 	size_t no_selections = list->selections().size();
 	switch (mode) {
-	case Archive:
+	case Mode::Archive:
 		if (no_selections > 1) {
 			button_tooltip =
 			   /** TRANSLATORS: Tooltip in the messages window. There is a separate string for 1
@@ -670,7 +670,7 @@ void GameMessageMenu::update_archive_button_tooltip() {
 			button_tooltip = _("Restore selected message");
 		}
 		break;
-	case Inbox:
+	case Mode::Inbox:
 		if (no_selections > 1) {
 			button_tooltip =
 			   /** TRANSLATORS: Tooltip in the messages window. There is a separate string for 1

--- a/src/wui/game_message_menu.cc
+++ b/src/wui/game_message_menu.cc
@@ -56,7 +56,7 @@ GameMessageMenu::GameMessageMenu(InteractivePlayer& plr, UI::UniqueWindow::Regis
                   "",
                   UI::Align::kLeft,
                   UI::MultilineTextarea::ScrollMode::kScrollNormalForced),
-     mode(Mode::Inbox) {
+     mode(Mode::kInbox) {
 
 	list = new UI::Table<uintptr_t>(this, kPadding, kButtonSize + 2 * kPadding,
 	                                kWindowWidth - 2 * kPadding, kTableHeight, UI::PanelStyle::kWui,
@@ -224,7 +224,7 @@ bool GameMessageMenu::compare_time_sent(uint32_t a, uint32_t b) {
 
 bool GameMessageMenu::should_be_hidden(const Widelands::Message& message) {
 	// Wrong box
-	return ((mode == Mode::Archive) != (message.status() == Message::Status::kArchived)) ||
+	return ((mode == Mode::kArchive) != (message.status() == Message::Status::kArchived)) ||
 	       // Filtered out
 	       (message_filter_ != Message::Type::kAllMessages &&
 	        message.message_type_category() != message_filter_);
@@ -243,7 +243,7 @@ void GameMessageMenu::show_new_message(MessageId const id, const Widelands::Mess
 	assert(iplayer().player().messages()[id] == &message);
 	assert(!list->find(id.value()));
 	Message::Status const status = message.status();
-	if ((mode == Mode::Archive) != (status == Message::Status::kArchived)) {
+	if ((mode == Mode::kArchive) != (status == Message::Status::kArchived)) {
 		toggle_mode();
 	}
 	UI::Table<uintptr_t>::EntryRecord& te = list->add(id.value());
@@ -481,12 +481,12 @@ void GameMessageMenu::archive_or_restore() {
 	for (const uint32_t index : selections) {
 		const uintptr_t selected_record = list->get(list->get_record(index));
 		switch (mode) {
-		case Mode::Inbox:
+		case Mode::kInbox:
 			// Archive highlighted message
 			game.send_player_command(new Widelands::CmdMessageSetStatusArchived(
 			   game.get_gametime(), plnum, MessageId(selected_record)));
 			break;
-		case Mode::Archive:
+		case Mode::kArchive:
 			// Restore highlighted message
 			game.send_player_command(new Widelands::CmdMessageSetStatusRead(
 			   game.get_gametime(), plnum, MessageId(selected_record)));
@@ -626,15 +626,15 @@ std::string GameMessageMenu::display_message_type_icon(const Widelands::Message&
 void GameMessageMenu::toggle_mode() {
 	list->clear();
 	switch (mode) {
-	case Mode::Inbox:
-		mode = Mode::Archive;
+	case Mode::kInbox:
+		mode = Mode::kArchive;
 		set_title(_("Messages: Archive"));
 		archivebtn_->set_pic(g_gr->images().get("images/wui/messages/message_restore.png"));
 		togglemodebtn_->set_pic(g_gr->images().get("images/wui/messages/message_new.png"));
 		togglemodebtn_->set_tooltip(_("Show Inbox"));
 		break;
-	case Mode::Archive:
-		mode = Mode::Inbox;
+	case Mode::kArchive:
+		mode = Mode::kInbox;
 		set_title(_("Messages: Inbox"));
 		archivebtn_->set_pic(g_gr->images().get("images/wui/messages/message_archive.png"));
 		togglemodebtn_->set_pic(g_gr->images().get("images/wui/messages/message_archived.png"));
@@ -654,7 +654,7 @@ void GameMessageMenu::update_archive_button_tooltip() {
 	std::string button_tooltip;
 	size_t no_selections = list->selections().size();
 	switch (mode) {
-	case Mode::Archive:
+	case Mode::kArchive:
 		if (no_selections > 1) {
 			button_tooltip =
 			   /** TRANSLATORS: Tooltip in the messages window. There is a separate string for 1
@@ -670,7 +670,7 @@ void GameMessageMenu::update_archive_button_tooltip() {
 			button_tooltip = _("Restore selected message");
 		}
 		break;
-	case Mode::Inbox:
+	case Mode::kInbox:
 		if (no_selections > 1) {
 			button_tooltip =
 			   /** TRANSLATORS: Tooltip in the messages window. There is a separate string for 1

--- a/src/wui/game_message_menu.h
+++ b/src/wui/game_message_menu.h
@@ -43,7 +43,7 @@ struct GameMessageMenu : public UI::UniqueWindow {
 	/// is currently multiselecting messages.
 	void show_new_message(Widelands::MessageId, const Widelands::Message&);
 
-	enum class Mode { Inbox, Archive };
+	enum class Mode { kInbox, kArchive };
 	void think() override;
 	bool handle_key(bool down, SDL_Keysym code) override;
 

--- a/src/wui/game_message_menu.h
+++ b/src/wui/game_message_menu.h
@@ -43,7 +43,7 @@ struct GameMessageMenu : public UI::UniqueWindow {
 	/// is currently multiselecting messages.
 	void show_new_message(Widelands::MessageId, const Widelands::Message&);
 
-	enum Mode { Inbox, Archive };
+	enum class Mode { Inbox, Archive };
 	void think() override;
 	bool handle_key(bool down, SDL_Keysym code) override;
 

--- a/src/wui/interactive_gamebase.cc
+++ b/src/wui/interactive_gamebase.cc
@@ -65,13 +65,11 @@ constexpr uint16_t kSpeedFast = 10000;
 
 InteractiveGameBase::InteractiveGameBase(Widelands::Game& g,
                                          Section& global_s,
-                                         PlayerType pt,
                                          bool const multiplayer,
                                          ChatProvider* chat_provider)
    : InteractiveBase(g, global_s),
      chat_provider_(chat_provider),
      multiplayer_(multiplayer),
-     playertype_(pt),
      showhidemenu_(toolbar(),
                    "dropdown_menu_showhide",
                    0,

--- a/src/wui/interactive_gamebase.h
+++ b/src/wui/interactive_gamebase.h
@@ -31,13 +31,10 @@
 
 struct ChatProvider;
 
-enum PlayerType { NONE, OBSERVER, PLAYING, VICTORIOUS, DEFEATED };
-
 class InteractiveGameBase : public InteractiveBase {
 public:
 	InteractiveGameBase(Widelands::Game&,
 	                    Section& global_s,
-	                    PlayerType pt,
 	                    bool multiplayer,
 	                    ChatProvider* chat_provider);
 	~InteractiveGameBase() override {
@@ -58,13 +55,6 @@ public:
 	void set_sel_pos(Widelands::NodeAndTriangle<> const center) override;
 
 	virtual void node_action(const Widelands::NodeAndTriangle<>& node_and_triangle) = 0;
-	const PlayerType& get_playertype() const {
-		return playertype_;
-	}
-	void set_playertype(const PlayerType& pt) {
-		playertype_ = pt;
-	}
-
 	void add_wanted_building_window(const Widelands::Coords& coords,
 	                                const Vector2i point,
 	                                bool was_minimal,
@@ -130,7 +120,6 @@ protected:
 	ChatProvider* chat_provider_;
 	UI::UniqueWindow::Registry chat_;
 	bool multiplayer_;
-	PlayerType playertype_;
 
 	// Show / Hide menu on the toolbar
 	UI::Dropdown<ShowHideEntry> showhidemenu_;

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -161,7 +161,7 @@ InteractivePlayer::InteractivePlayer(Widelands::Game& g,
                                      Widelands::PlayerNumber const plyn,
                                      bool const multiplayer,
                                      ChatProvider* chat_provider)
-   : InteractiveGameBase(g, global_s, NONE, multiplayer, chat_provider),
+   : InteractiveGameBase(g, global_s, multiplayer, chat_provider),
      auto_roadbuild_mode_(global_s.get_bool("auto_roadbuild_mode", true)),
      flag_to_connect_(Widelands::Coords::null()),
      statisticsmenu_(toolbar(),

--- a/src/wui/interactive_spectator.cc
+++ b/src/wui/interactive_spectator.cc
@@ -39,7 +39,7 @@ InteractiveSpectator::InteractiveSpectator(Widelands::Game& g,
                                            Section& global_s,
                                            bool const multiplayer,
                                            ChatProvider* chat_provider)
-   : InteractiveGameBase(g, global_s, OBSERVER, multiplayer, chat_provider) {
+   : InteractiveGameBase(g, global_s, multiplayer, chat_provider) {
 	add_main_menu();
 
 	add_toolbar_button("wui/menus/statistics_general", "general_stats", _("Statistics"),


### PR DESCRIPTION
Remove enum `PlayerType` - nobody was using it.

Turn some `enum` types into `enum class`:

- Messages `Mode`
- `GameType`, make it private too
- Map loader `State`
- `MapGenAreaInfo` s members
- ` Game::StartGameType`