### PR TITLE
Fix incorrect allows_seafaring detection

### DIFF
--- a/src/logic/map.cc
+++ b/src/logic/map.cc
@@ -2544,7 +2544,7 @@ void Map::recalculate_allows_seafaring() {
 		FCoords fc = get_fcoords(c);
 
 		// Get portdock slots for this port
-		for (const Coords& portdock : find_portdock(fc, false)) {
+		for (const Coords& portdock : find_portdock(fc, true)) {
 			reachable_from_current_port.insert(portdock);
 			positions_to_check.push(portdock);
 		}


### PR DESCRIPTION
The savegame in #1615 is a seafaring map which is not recognized as such. This one-liner PR fixes the allows_seafaring detection in that cornercase.