### PR TITLE
Fix terrain glitches in see_all mode

### DIFF
--- a/src/graphic/gl/dither_program.cc
+++ b/src/graphic/gl/dither_program.cc
@@ -168,23 +168,23 @@ void DitherProgram::draw(
 		if (field.bln_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain_d =
 			   map ? player->fields()[map->get_index(field.fcoords)].terrains.d :
-			            field.fcoords.field->terrain_d();
+			         field.fcoords.field->terrain_d();
 			const Widelands::DescriptionIndex terrain_r =
 			   map ? player->fields()[map->get_index(field.fcoords)].terrains.r :
-			            field.fcoords.field->terrain_r();
+			         field.fcoords.field->terrain_r();
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.brn_index,
 			                             current_index, field.bln_index, terrain_d, terrain_r);
 
 			const Widelands::DescriptionIndex terrain_dd =
 			   map ? player->fields()[map->get_index(map->bl_n(field.fcoords))].terrains.r :
-			            fields_to_draw.at(field.bln_index).fcoords.field->terrain_r();
+			         fields_to_draw.at(field.bln_index).fcoords.field->terrain_r();
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.bln_index,
 			                             field.brn_index, current_index, terrain_d, terrain_dd);
 
 			if (field.ln_index != FieldsToDraw::kInvalidIndex) {
 				const Widelands::DescriptionIndex terrain_l =
 				   map ? player->fields()[map->get_index(map->l_n(field.fcoords))].terrains.r :
-				            fields_to_draw.at(field.ln_index).fcoords.field->terrain_r();
+				         fields_to_draw.at(field.ln_index).fcoords.field->terrain_r();
 				maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, current_index,
 				                             field.bln_index, field.brn_index, terrain_d, terrain_l);
 			}
@@ -194,23 +194,23 @@ void DitherProgram::draw(
 		if (field.rn_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain_r =
 			   map ? player->fields()[map->get_index(field.fcoords)].terrains.r :
-			            field.fcoords.field->terrain_r();
+			         field.fcoords.field->terrain_r();
 			const Widelands::DescriptionIndex terrain_d =
 			   map ? player->fields()[map->get_index(field.fcoords)].terrains.d :
-			            field.fcoords.field->terrain_d();
+			         field.fcoords.field->terrain_d();
 
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, current_index,
 			                             field.brn_index, field.rn_index, terrain_r, terrain_d);
 			const Widelands::DescriptionIndex terrain_rr =
 			   map ? player->fields()[map->get_index(map->r_n(field.fcoords))].terrains.d :
-			            fields_to_draw.at(field.rn_index).fcoords.field->terrain_d();
+			         fields_to_draw.at(field.rn_index).fcoords.field->terrain_d();
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.brn_index,
 			                             field.rn_index, current_index, terrain_r, terrain_rr);
 
 			if (field.trn_index != FieldsToDraw::kInvalidIndex) {
 				const Widelands::DescriptionIndex terrain_u =
 				   map ? player->fields()[map->get_index(map->tr_n(field.fcoords))].terrains.d :
-				            fields_to_draw.at(field.trn_index).fcoords.field->terrain_d();
+				         fields_to_draw.at(field.trn_index).fcoords.field->terrain_d();
 				maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.rn_index,
 				                             current_index, field.brn_index, terrain_r, terrain_u);
 			}

--- a/src/graphic/gl/dither_program.cc
+++ b/src/graphic/gl/dither_program.cc
@@ -163,27 +163,27 @@ void DitherProgram::draw(
 			continue;
 		}
 
-		const Widelands::Map* map = player ? &player->egbase().map() : nullptr;
+		const Widelands::Map* map = player && !player->see_all() ? &player->egbase().map() : nullptr;
 		// Dithering triangles for Down triangle.
 		if (field.bln_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain_d =
-			   player ? player->fields()[map->get_index(field.fcoords)].terrains.d :
+			   map ? player->fields()[map->get_index(field.fcoords)].terrains.d :
 			            field.fcoords.field->terrain_d();
 			const Widelands::DescriptionIndex terrain_r =
-			   player ? player->fields()[map->get_index(field.fcoords)].terrains.r :
+			   map ? player->fields()[map->get_index(field.fcoords)].terrains.r :
 			            field.fcoords.field->terrain_r();
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.brn_index,
 			                             current_index, field.bln_index, terrain_d, terrain_r);
 
 			const Widelands::DescriptionIndex terrain_dd =
-			   player ? player->fields()[map->get_index(map->bl_n(field.fcoords))].terrains.r :
+			   map ? player->fields()[map->get_index(map->bl_n(field.fcoords))].terrains.r :
 			            fields_to_draw.at(field.bln_index).fcoords.field->terrain_r();
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.bln_index,
 			                             field.brn_index, current_index, terrain_d, terrain_dd);
 
 			if (field.ln_index != FieldsToDraw::kInvalidIndex) {
 				const Widelands::DescriptionIndex terrain_l =
-				   player ? player->fields()[map->get_index(map->l_n(field.fcoords))].terrains.r :
+				   map ? player->fields()[map->get_index(map->l_n(field.fcoords))].terrains.r :
 				            fields_to_draw.at(field.ln_index).fcoords.field->terrain_r();
 				maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, current_index,
 				                             field.bln_index, field.brn_index, terrain_d, terrain_l);
@@ -193,23 +193,23 @@ void DitherProgram::draw(
 		// Dithering for right triangle.
 		if (field.rn_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain_r =
-			   player ? player->fields()[map->get_index(field.fcoords)].terrains.r :
+			   map ? player->fields()[map->get_index(field.fcoords)].terrains.r :
 			            field.fcoords.field->terrain_r();
 			const Widelands::DescriptionIndex terrain_d =
-			   player ? player->fields()[map->get_index(field.fcoords)].terrains.d :
+			   map ? player->fields()[map->get_index(field.fcoords)].terrains.d :
 			            field.fcoords.field->terrain_d();
 
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, current_index,
 			                             field.brn_index, field.rn_index, terrain_r, terrain_d);
 			const Widelands::DescriptionIndex terrain_rr =
-			   player ? player->fields()[map->get_index(map->r_n(field.fcoords))].terrains.d :
+			   map ? player->fields()[map->get_index(map->r_n(field.fcoords))].terrains.d :
 			            fields_to_draw.at(field.rn_index).fcoords.field->terrain_d();
 			maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.brn_index,
 			                             field.rn_index, current_index, terrain_r, terrain_rr);
 
 			if (field.trn_index != FieldsToDraw::kInvalidIndex) {
 				const Widelands::DescriptionIndex terrain_u =
-				   player ? player->fields()[map->get_index(map->tr_n(field.fcoords))].terrains.d :
+				   map ? player->fields()[map->get_index(map->tr_n(field.fcoords))].terrains.d :
 				            fields_to_draw.at(field.trn_index).fcoords.field->terrain_d();
 				maybe_add_dithering_triangle(gametime, terrains, fields_to_draw, field.rn_index,
 				                             current_index, field.brn_index, terrain_r, terrain_u);

--- a/src/graphic/gl/terrain_program.cc
+++ b/src/graphic/gl/terrain_program.cc
@@ -108,8 +108,9 @@ void TerrainProgram::draw(
 		// Down triangle.
 		if (field.bln_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain =
-			   player && !player->see_all() ? player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.d :
-			            field.fcoords.field->terrain_d();
+			   player && !player->see_all() ?
+			      player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.d :
+			      field.fcoords.field->terrain_d();
 			const Vector2f texture_offset =
 			   to_gl_texture(terrains.get(terrain).get_texture(gametime).blit_data()).origin();
 			add_vertex(fields_to_draw.at(current_index), texture_offset);
@@ -120,8 +121,9 @@ void TerrainProgram::draw(
 		// Right triangle.
 		if (field.rn_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain =
-			   player && !player->see_all() ? player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.r :
-			            field.fcoords.field->terrain_r();
+			   player && !player->see_all() ?
+			      player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.r :
+			      field.fcoords.field->terrain_r();
 			const Vector2f texture_offset =
 			   to_gl_texture(terrains.get(terrain).get_texture(gametime).blit_data()).origin();
 			add_vertex(fields_to_draw.at(current_index), texture_offset);

--- a/src/graphic/gl/terrain_program.cc
+++ b/src/graphic/gl/terrain_program.cc
@@ -108,7 +108,7 @@ void TerrainProgram::draw(
 		// Down triangle.
 		if (field.bln_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain =
-			   player ? player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.d :
+			   player && !player->see_all() ? player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.d :
 			            field.fcoords.field->terrain_d();
 			const Vector2f texture_offset =
 			   to_gl_texture(terrains.get(terrain).get_texture(gametime).blit_data()).origin();
@@ -120,7 +120,7 @@ void TerrainProgram::draw(
 		// Right triangle.
 		if (field.rn_index != FieldsToDraw::kInvalidIndex) {
 			const Widelands::DescriptionIndex terrain =
-			   player ? player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.r :
+			   player && !player->see_all() ? player->fields()[player->egbase().map().get_index(field.fcoords)].terrains.r :
 			            field.fcoords.field->terrain_r();
 			const Vector2f texture_offset =
 			   to_gl_texture(terrains.get(terrain).get_texture(gametime).blit_data()).origin();


### PR DESCRIPTION
Fixes the wrong terrain being drawn under some circumstances if the interactive player `see`s`_all`