### PR TITLE
Clamp textures to fix artifacts at the edges

### DIFF
--- a/src/graphic/texture.cc
+++ b/src/graphic/texture.cc
@@ -191,6 +191,8 @@ void Texture::init(uint16_t w, uint16_t h) {
 	// makes no difference.
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, static_cast<GLint>(GL_LINEAR));
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, static_cast<GLint>(GL_LINEAR));
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, static_cast<GLint>(GL_CLAMP_TO_EDGE));
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, static_cast<GLint>(GL_CLAMP_TO_EDGE));
 }
 
 void Texture::lock() {


### PR DESCRIPTION
At texture edges pixels bleed from the opposite sides of the textures.

**Before:**
![shot0021](https://user-images.githubusercontent.com/4470900/89982343-d6b9b300-dc75-11ea-8085-3797ff2fcf31.png)

**After:**
![shot0020](https://user-images.githubusercontent.com/4470900/89982348-dae5d080-dc75-11ea-9992-783d942476b2.png)

You might want to enlarge the images as the artifacts are pretty subtle.