### PR TITLE
Stacked workflows

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,15 +1,8 @@
 name: Clang-Tidy
 
 on:
-  workflow_run:
-    workflows: ["Formatting your code"]
-    push:
-      branches: [ master, stacked-workflows ]
-    pull_request:
-      types: [ opened, synchronize ]
-    types:
-      - completed
-      - requested
+  push:
+    branches: [ master, stacked-workflows ]
 
 jobs:
   check:
@@ -23,12 +16,6 @@ jobs:
       with:
         fetch-depth: 1
     - name: Check
-      run: |
-        export CC=/usr/bin/clang
-        export CXX=/usr/bin/clang++
-        mkdir build && pushd build
-        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-        python ../utils/run-clang-tidy.py -checks=-*,*braces*,cert*,clang-analyzer*,cppcoreguidelines-pro-type-static-cast-downcast,google*,performance* > ../clang-tidy.log
-        popd
+      run: ./clang-tidy.sh
     - name: Report
       run: utils/check_clang_tidy_results.py clang-tidy.log

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -8,6 +8,7 @@ on:
       types: [ opened, synchronize ]
     types:
       - completed
+      - requested
 
 jobs:
   check:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -2,7 +2,7 @@ name: Clang-Tidy
 
 on:
   push:
-    branches: [ master, stacked-workflows ]
+    branches: [ master ]
 
 jobs:
   check:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -1,10 +1,13 @@
 name: Clang-Tidy
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["Formatting your code"]
+    branches: [ master, stacked-workflows ]
+    pull_request:
+      types: [ opened, synchronize ]
+    types:
+      - completed
 
 jobs:
   check:

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -3,7 +3,8 @@ name: Clang-Tidy
 on:
   workflow_run:
     workflows: ["Formatting your code"]
-    branches: [ master, stacked-workflows ]
+    push:
+      branches: [ master, stacked-workflows ]
     pull_request:
       types: [ opened, synchronize ]
     types:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,9 +1,36 @@
 name: Deployment for MS-Windows
-on:
-  pull_request:
-    types: [ opened, synchronize ]
+
 jobs:
+  clang_tidy:
+    on:
+      branches: [ master, stacked-workflows ]
+      pull_request:
+        types: [ opened, synchronize ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Installing dependencies
+      run: |
+        sudo apt install git cmake g++ gcc gettext libboost-dev libboost-regex-dev libboost-system-dev libboost-test-dev libglew-dev libpng-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev python zlib1g-dev clang-tidy -y
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: Check
+      run: |
+        export CC=/usr/bin/clang
+        export CXX=/usr/bin/clang++
+        mkdir build && pushd build
+        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+        python ../utils/run-clang-tidy.py -checks=-*,*braces*,cert*,clang-analyzer*,cppcoreguidelines-pro-type-static-cast-downcast,google*,performance* > ../clang-tidy.log
+        popd
+    - name: Report
+      run: utils/check_clang_tidy_results.py clang-tidy.log
+
   compile:
+    on:
+      branches: [ master, stacked-workflows ]
+      pull_request:
+        types: [ opened, synchronize ]
     strategy:
       matrix:
         config:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -30,6 +30,9 @@ jobs:
 
   compile:
     needs: [clang_tidy]
+    on:
+      pull_request:
+        types: [ opened, synchronize ]
     strategy:
       matrix:
         config:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -18,21 +18,12 @@ jobs:
       with:
         fetch-depth: 1
     - name: Check
-      run: |
-        export CC=/usr/bin/clang
-        export CXX=/usr/bin/clang++
-        mkdir build && pushd build
-        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-        python ../utils/run-clang-tidy.py -checks=-*,*braces*,cert*,clang-analyzer*,cppcoreguidelines-pro-type-static-cast-downcast,google*,performance* > ../clang-tidy.log
-        popd
+      run: ./clang-tidy.sh
     - name: Report
       run: utils/check_clang_tidy_results.py clang-tidy.log
 
   compile:
     needs: [clang_tidy]
-    on:
-      pull_request:
-        types: [ opened, synchronize ]
     strategy:
       matrix:
         config:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,5 +1,4 @@
 name: Deployment for MS-Windows
-
 on:
   pull_request:
     types: [ opened, synchronize ]

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,8 +1,6 @@
 name: Deployment for MS-Windows
 
 on:
-  push:
-    branches: [ master, stacked-workflows ]
   pull_request:
     types: [ opened, synchronize ]
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,7 +1,8 @@
 name: Deployment for MS-Windows
 
 on:
-  branches: [ master, stacked-workflows ]
+  push:
+    branches: [ master, stacked-workflows ]
   pull_request:
     types: [ opened, synchronize ]
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,11 +1,12 @@
 name: Deployment for MS-Windows
 
+on:
+  branches: [ master, stacked-workflows ]
+  pull_request:
+    types: [ opened, synchronize ]
+
 jobs:
   clang_tidy:
-    on:
-      branches: [ master, stacked-workflows ]
-      pull_request:
-        types: [ opened, synchronize ]
     runs-on: ubuntu-latest
     steps:
     - name: Installing dependencies
@@ -27,10 +28,6 @@ jobs:
       run: utils/check_clang_tidy_results.py clang-tidy.log
 
   compile:
-    on:
-      branches: [ master, stacked-workflows ]
-      pull_request:
-        types: [ opened, synchronize ]
     strategy:
       matrix:
         config:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -29,6 +29,7 @@ jobs:
       run: utils/check_clang_tidy_results.py clang-tidy.log
 
   compile:
+    needs: [clang_tidy]
     strategy:
       matrix:
         config:

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Script for running clang-tidy in the CI pipeline
 
@@ -7,7 +7,7 @@ export CXX=/usr/bin/clang++
 
 if ! [ -d build ] ; then
   mkdir build
-end
+fi
 
 pushd build
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Script for running clang-tidy in the CI pipeline
+
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+
+if ! [ -d build ] ; then
+  mkdir build
+end
+
+pushd build
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+python ../utils/run-clang-tidy.py -checks=-*,*braces*,cert*,clang-analyzer*,cppcoreguidelines-pro-type-static-cast-downcast,google*,performance* > ../clang-tidy.log
+popd


### PR DESCRIPTION
Only run Windows builds if clang-tidy succeeds.

Once https://github.com/widelands/widelands/pull/4106 is in, we can consider putting everything into a single YAML file.

Unfortunately, the "on" keyword is only allowed for whole workflows and not for individual jobs. So, we need a separate yaml file for master. Bleh.