### PR TITLE
Rename main productionsite program to 'main'

### DIFF
--- a/data/campaigns/emp04.wmf/scripting/tribes/brewery1.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/brewery1.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          descname = "brewing beer",
          actions = {
             "sleep=30000",

--- a/data/campaigns/emp04.wmf/scripting/tribes/brewery2.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/brewery2.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start brewing beer because ...
          descname = _"brewing beer",
          actions = {

--- a/data/campaigns/emp04.wmf/scripting/tribes/farm1.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/farm1.lua
@@ -26,7 +26,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          descname = "working",
          actions = {
             "call=plant",

--- a/data/campaigns/emp04.wmf/scripting/tribes/farm2.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/farm2.lua
@@ -38,7 +38,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/campaigns/emp04.wmf/scripting/tribes/foresters_house1.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/foresters_house1.lua
@@ -35,7 +35,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          descname = "planting trees",
          actions = {
             "sleep=66000",

--- a/data/campaigns/emp04.wmf/scripting/tribes/lumberjacks_house1.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/lumberjacks_house1.lua
@@ -36,7 +36,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          descname = "felling trees",
          actions = {
             "sleep=400000", -- Barbarian lumberjack sleeps 25000

--- a/data/campaigns/emp04.wmf/scripting/tribes/mill1.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/mill1.lua
@@ -46,7 +46,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          descname = "grinding wheat",
          actions = {
             "sleep=5000",

--- a/data/campaigns/emp04.wmf/scripting/tribes/mill2.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/mill2.lua
@@ -43,7 +43,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start grinding wheat because ...
          descname = _"grinding wheat",
          actions = {

--- a/data/campaigns/emp04.wmf/scripting/tribes/well1.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/well1.lua
@@ -40,7 +40,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          descname = "working",
          actions = {
             "sleep=30000",

--- a/data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/armorsmithy/init.lua
@@ -146,7 +146,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/bakery/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start baking bread because ...
          descname = pgettext("atlanteans_building", "baking bread"),
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/barracks/init.lua
@@ -50,7 +50,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start recruiting soldier because ...
          descname = pgettext("atlanteans_building", "recruiting soldier"),
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/blackroot_farm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/blackroot_farm/init.lua
@@ -39,7 +39,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/charcoal_kiln/init.lua
@@ -43,7 +43,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start producing coal because ...
          descname = _"producing coal",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/coalmine/init.lua
@@ -50,7 +50,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/crystalmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/crystalmine/init.lua
@@ -50,7 +50,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/farm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/farm/init.lua
@@ -43,7 +43,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/ferry_yard/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/ferry_yard/init.lua
@@ -43,7 +43,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/fishbreeders_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/fishbreeders_house/init.lua
@@ -37,7 +37,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start breeding fish because ...
          descname = _"breeding fish",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/fishers_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/fishers_house/init.lua
@@ -38,7 +38,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start fishing because ...
          descname = _"fishing",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/foresters_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/foresters_house/init.lua
@@ -38,7 +38,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start planting trees because ...
          descname = _"planting trees",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/gold_spinning_mill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/gold_spinning_mill/init.lua
@@ -43,7 +43,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start spinning gold because ...
          descname = _"spinning gold",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/goldmine/init.lua
@@ -50,7 +50,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/horsefarm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/horsefarm/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start breeding horses because ...
          descname = pgettext("atlanteans_building", "breeding horses"),
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/hunters_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/hunters_house/init.lua
@@ -35,7 +35,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start hunting because ...
          descname = _"hunting",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/ironmine/init.lua
@@ -50,7 +50,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/mill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/mill/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/quarry/init.lua
@@ -33,7 +33,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start quarrying granite because ...
          descname = _"quarrying granite",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/sawmill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/sawmill/init.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start sawing logs because ...
          descname = _"sawing logs",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/scouts_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/scouts_house/init.lua
@@ -40,7 +40,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start scouting because ...
          descname = _"scouting",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/shipyard/init.lua
@@ -59,7 +59,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/smelting_works/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/smelting_works/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/smokery/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/smokery/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/spiderfarm/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/spiderfarm/init.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/toolsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/toolsmithy/init.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/weaponsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/weaponsmithy/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/weaving_mill/init.lua
@@ -48,7 +48,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/well/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/well/init.lua
@@ -40,7 +40,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/atlanteans/woodcutters_house/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/woodcutters_house/init.lua
@@ -34,7 +34,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start felling trees because ...
          descname = _"felling trees",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/ax_workshop/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ax_workshop/init.lua
@@ -57,7 +57,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/bakery/init.lua
@@ -50,7 +50,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start baking bread because ...
          descname = pgettext("barbarians_building", "baking pitta bread"),
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/barracks/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start recruiting soldier because ...
          descname = pgettext("barbarians_building", "recruiting soldier"),
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/big_inn/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/big_inn/init.lua
@@ -50,7 +50,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/brewery/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/brewery/init.lua
@@ -43,7 +43,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start brewing strong beer because ...
          descname = _"brewing strong beer",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/cattlefarm/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/cattlefarm/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start rearing cattle because ...
          descname = pgettext("barbarians_building", "rearing cattle"),
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/charcoal_kiln/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start producing coal because ...
          descname = _"producing coal",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine/init.lua
@@ -53,7 +53,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine_deep/init.lua
@@ -53,7 +53,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/coalmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine_deeper/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/farm/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/farm/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/ferry_yard/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ferry_yard/init.lua
@@ -42,7 +42,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/fishers_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/fishers_hut/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start fishing because ...
          descname = _"fishing",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/gamekeepers_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/gamekeepers_hut/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine/init.lua
@@ -53,7 +53,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine_deep/init.lua
@@ -53,7 +53,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/goldmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine_deeper/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/granitemine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/granitemine/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining granite because ...
          descname = _"mining granite",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/helmsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/helmsmithy/init.lua
@@ -58,7 +58,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/hunters_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/hunters_hut/init.lua
@@ -46,7 +46,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start hunting because ...
          descname = _"hunting",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/inn/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/inn/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine/init.lua
@@ -53,7 +53,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine_deep/init.lua
@@ -53,7 +53,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/ironmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine_deeper/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/lime_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/lime_kiln/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mixing grout because ...
          descname = _"mixing grout",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/lumberjacks_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/lumberjacks_hut/init.lua
@@ -41,7 +41,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start felling trees because ...
          descname = _"felling trees",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/metal_workshop/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/metal_workshop/init.lua
@@ -60,7 +60,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/micro_brewery/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/micro_brewery/init.lua
@@ -48,7 +48,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start brewing beer because ...
          descname = _"brewing beer",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/quarry/init.lua
@@ -40,7 +40,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start quarrying granite because ...
          descname = _"quarrying granite",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/rangers_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/rangers_hut/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start planting trees because ...
          descname = _"planting trees",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/reed_yard/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/reed_yard/init.lua
@@ -35,7 +35,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/scouts_hut/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/scouts_hut/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start scouting because ...
          descname = _"scouting",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/shipyard/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/smelting_works/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/smelting_works/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/tavern/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/tavern/init.lua
@@ -53,7 +53,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start preparing a ration because ...
          descname = _"preparing a ration",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/warmill/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/warmill/init.lua
@@ -58,7 +58,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/weaving_mill/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start weaving because ...
          descname = _"weaving",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/well/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/well/init.lua
@@ -41,7 +41,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/barbarians/wood_hardener/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/wood_hardener/init.lua
@@ -67,7 +67,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start hardening wood because ...
          descname = _"hardening wood",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/armorsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/empire/armorsmithy/init.lua
@@ -57,7 +57,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/bakery/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start baking bread because ...
          descname = pgettext("empire_building", "baking bread"),
          actions = {

--- a/data/tribes/buildings/productionsites/empire/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/empire/barracks/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start recruiting soldier because ...
          descname = pgettext("empire_building", "recruiting soldier"),
          actions = {

--- a/data/tribes/buildings/productionsites/empire/brewery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/brewery/init.lua
@@ -46,7 +46,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start brewing beer because ...
          descname = _"brewing beer",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/empire/charcoal_kiln/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start producing coal because ...
          descname = _"producing coal",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/coalmine/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/coalmine_deep/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/donkeyfarm/init.lua
+++ b/data/tribes/buildings/productionsites/empire/donkeyfarm/init.lua
@@ -44,7 +44,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start rearing donkeys because ...
          descname = pgettext("empire_building", "rearing donkeys"),
          actions = {

--- a/data/tribes/buildings/productionsites/empire/farm/init.lua
+++ b/data/tribes/buildings/productionsites/empire/farm/init.lua
@@ -42,7 +42,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/ferry_yard/init.lua
+++ b/data/tribes/buildings/productionsites/empire/ferry_yard/init.lua
@@ -42,7 +42,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/fishers_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/fishers_house/init.lua
@@ -36,7 +36,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start fishing because ...
          descname = _"fishing",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/foresters_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/foresters_house/init.lua
@@ -38,7 +38,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start planting trees because ...
          descname = _"planting trees",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/goldmine/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/goldmine_deep/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/hunters_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/hunters_house/init.lua
@@ -35,7 +35,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start hunting because ...
          descname = _"hunting",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/inn/init.lua
+++ b/data/tribes/buildings/productionsites/empire/inn/init.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/ironmine/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/ironmine_deep/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/lumberjacks_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/lumberjacks_house/init.lua
@@ -34,7 +34,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start felling trees because ...
          descname = _"felling trees",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/marblemine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/marblemine/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/marblemine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/marblemine_deep/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining marble because ...
          descname = _"mining marble",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/mill/init.lua
+++ b/data/tribes/buildings/productionsites/empire/mill/init.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start grinding wheat because ...
          descname = _"grinding wheat",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/piggery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/piggery/init.lua
@@ -46,7 +46,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start raising pigs because ...
          descname = _"raising pigs",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/empire/quarry/init.lua
@@ -33,7 +33,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/sawmill/init.lua
+++ b/data/tribes/buildings/productionsites/empire/sawmill/init.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start sawing logs because ...
          descname = _"sawing logs",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/scouts_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/scouts_house/init.lua
@@ -40,7 +40,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start scouting because ...
          descname = _"scouting",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/sheepfarm/init.lua
+++ b/data/tribes/buildings/productionsites/empire/sheepfarm/init.lua
@@ -46,7 +46,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start breeding sheep because ...
          descname = _"breeding sheep",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/empire/shipyard/init.lua
@@ -58,7 +58,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/smelting_works/init.lua
+++ b/data/tribes/buildings/productionsites/empire/smelting_works/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/stonemasons_house/init.lua
+++ b/data/tribes/buildings/productionsites/empire/stonemasons_house/init.lua
@@ -46,7 +46,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start sculpting a marble column because ...
          descname = _"sculpting a marble column",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/tavern/init.lua
+++ b/data/tribes/buildings/productionsites/empire/tavern/init.lua
@@ -48,7 +48,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start preparing a ration because ...
          descname = _"preparing a ration",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/toolsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/empire/toolsmithy/init.lua
@@ -45,7 +45,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/vineyard/init.lua
+++ b/data/tribes/buildings/productionsites/empire/vineyard/init.lua
@@ -41,7 +41,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/weaponsmithy/init.lua
+++ b/data/tribes/buildings/productionsites/empire/weaponsmithy/init.lua
@@ -54,7 +54,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/empire/weaving_mill/init.lua
@@ -52,7 +52,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start weaving because ...
          descname = _"weaving",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/well/init.lua
+++ b/data/tribes/buildings/productionsites/empire/well/init.lua
@@ -39,7 +39,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/empire/winery/init.lua
+++ b/data/tribes/buildings/productionsites/empire/winery/init.lua
@@ -48,7 +48,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start making wine because ...
          descname = _"making wine",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/aqua_farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/aqua_farm/init.lua
@@ -54,7 +54,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/armor_smithy_large/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/armor_smithy_large/init.lua
@@ -64,7 +64,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/armor_smithy_small/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/armor_smithy_small/init.lua
@@ -64,7 +64,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/bakery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/bakery/init.lua
@@ -65,7 +65,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start baking bread because ...
          descname = _"baking bread",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/barracks/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/barracks/init.lua
@@ -67,7 +67,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start recruiting soldier because ...
          descname = pgettext("frisians_building", "recruiting soldier"),
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/beekeepers_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/beekeepers_house/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/berry_farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/berry_farm/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start planting bushes because ...
          descname = _"planting bushes",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/blacksmithy/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/blacksmithy/init.lua
@@ -67,7 +67,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/brewery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/brewery/init.lua
@@ -64,7 +64,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start brewing beer because ...
          descname = _"brewing beer",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/brick_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/brick_kiln/init.lua
@@ -66,7 +66,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start burning bricks because ...
          descname = _"burning bricks",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/charcoal_burners_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/charcoal_burners_house/init.lua
@@ -55,7 +55,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/charcoal_kiln/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/charcoal_kiln/init.lua
@@ -63,7 +63,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start producing coal because ...
          descname = _"producing coal",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/clay_pit/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/clay_pit/init.lua
@@ -62,7 +62,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start making clay because ...
          descname = _"making clay",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/coalmine/init.lua
@@ -73,7 +73,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/coalmine_deep/init.lua
@@ -72,7 +72,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining coal because ...
          descname = _"mining coal",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/collectors_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/collectors_house/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start gathering berries because ...
          descname = _"gathering berries",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/drinking_hall/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/drinking_hall/init.lua
@@ -66,7 +66,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/farm/init.lua
@@ -69,7 +69,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/ferry_yard/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/ferry_yard/init.lua
@@ -54,7 +54,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/fishers_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/fishers_house/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start fishing because ...
          descname = _"fishing",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/foresters_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/foresters_house/init.lua
@@ -48,7 +48,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start planting trees because ...
          descname = _"planting trees",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/furnace/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/furnace/init.lua
@@ -76,7 +76,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/goldmine/init.lua
@@ -74,7 +74,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/goldmine_deep/init.lua
@@ -72,7 +72,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining gold because ...
          descname = _"mining gold",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/honey_bread_bakery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/honey_bread_bakery/init.lua
@@ -64,7 +64,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/hunters_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/hunters_house/init.lua
@@ -48,7 +48,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start hunting because ...
          descname = _"hunting",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/ironmine/init.lua
@@ -74,7 +74,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/ironmine_deep/init.lua
@@ -72,7 +72,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining iron because ...
          descname = _"mining iron",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/mead_brewery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/mead_brewery/init.lua
@@ -62,7 +62,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/quarry/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/quarry/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start quarrying granite because ...
          descname = _"quarrying granite",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/recycling_center/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/recycling_center/init.lua
@@ -77,7 +77,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/reed_farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/reed_farm/init.lua
@@ -51,7 +51,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/reindeer_farm/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/reindeer_farm/init.lua
@@ -64,7 +64,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/rockmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/rockmine/init.lua
@@ -74,7 +74,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining granite because ...
          descname = _"mining granite",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/rockmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/rockmine_deep/init.lua
@@ -72,7 +72,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start mining granite because ...
          descname = _"mining granite",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/scouts_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/scouts_house/init.lua
@@ -49,7 +49,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start scouting because ...
          descname = _"scouting",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/sewing_room/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/sewing_room/init.lua
@@ -62,7 +62,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start sewing fur garment because ...
          descname = _"sewing fur garment",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/shipyard/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/shipyard/init.lua
@@ -59,7 +59,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/smokery/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/smokery/init.lua
@@ -67,7 +67,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/tailors_shop/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/tailors_shop/init.lua
@@ -64,7 +64,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/tavern/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/tavern/init.lua
@@ -68,7 +68,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/weaving_mill/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/weaving_mill/init.lua
@@ -65,7 +65,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start weaving cloth because ...
          descname = _"weaving cloth",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/well/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/well/init.lua
@@ -48,7 +48,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {

--- a/data/tribes/buildings/productionsites/frisians/woodcutters_house/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/woodcutters_house/init.lua
@@ -47,7 +47,7 @@ tribes:new_productionsite_type {
    },
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start felling trees because ...
          descname = _"felling trees",
          actions = {

--- a/src/logic/map_objects/immovable.cc
+++ b/src/logic/map_objects/immovable.cc
@@ -267,7 +267,7 @@ void ImmovableDescr::make_sure_default_program_is_there() {
 		assert(is_animation_known("idle"));
 		std::vector<std::string> arguments{"idle"};
 		programs_[MapObjectProgram::kMainProgram] =
-		   new ImmovableProgram("main", std::unique_ptr<ImmovableProgram::Action>(
+		   new ImmovableProgram(MapObjectProgram::kMainProgram, std::unique_ptr<ImmovableProgram::Action>(
 		                                   new ImmovableProgram::ActAnimate(arguments, *this)));
 	}
 }

--- a/src/logic/map_objects/immovable.cc
+++ b/src/logic/map_objects/immovable.cc
@@ -266,9 +266,9 @@ void ImmovableDescr::make_sure_default_program_is_there() {
 	if (!programs_.count(MapObjectProgram::kMainProgram)) {  //  default program
 		assert(is_animation_known("idle"));
 		std::vector<std::string> arguments{"idle"};
-		programs_[MapObjectProgram::kMainProgram] =
-		   new ImmovableProgram(MapObjectProgram::kMainProgram, std::unique_ptr<ImmovableProgram::Action>(
-		                                   new ImmovableProgram::ActAnimate(arguments, *this)));
+		programs_[MapObjectProgram::kMainProgram] = new ImmovableProgram(
+		   MapObjectProgram::kMainProgram, std::unique_ptr<ImmovableProgram::Action>(
+		                                      new ImmovableProgram::ActAnimate(arguments, *this)));
 	}
 }
 

--- a/src/logic/map_objects/map_object_program.cc
+++ b/src/logic/map_objects/map_object_program.cc
@@ -60,32 +60,47 @@ Map object programs are put in a Lua table, like this:
 .. code-block:: lua
 
    programs = {
-      default_program = {
-         "program_name2",
-         "program_name3",
-      }
-      program_name2 = {
+      main = {
          "action1=parameter1:value1 parameter2:value2",
          "action2=value1",
       },
-      program_name3 = {
+      program_name2 = {
          "action3",
          "action4=value1 value2 value3",
       },
-      program_name4 = {
+      program_name3 = {
          "action5=value1 value2 parameter:value3",
       }
    },
+
+For productionsites, there is a nested ``actions`` table, so that we can give them a descname for
+the tooltips:
+
+.. code-block:: lua
+
+   programs = {
+      main = {
+         -- TRANSLATORS: Completed/Skipped/Did not start doing something because ...
+         descname = _"doing something",
+         actions = {
+            "call=program_name2",
+            "call=program_name3",
+         }
+         ...
+     }
+   }
 
 * Named parameters of the form ``parameter:value`` can be given in any order, but we recommend using
   the order from the documentation for consistency. It will make your code easier to read.
 * Values without parameter name need to be given in the correct order.
 * Some actions combine both named and unnamed values, see ``action5`` in our example.
 
-The first program is the default program that calls all the other programs. For productionsites,
-this is ``"work"``, and for immovables, this is ``"program"``. Workers have no default program,
-because their individual programs are called from their production site.
-
+If there is a program called ``"main"``, this is the default program.
+For :ref:`productionsites <productionsite_programs>`, having a main program is mandatory.
+For :ref:`immovables <immovable_programs>`, having a main program is optional, because their
+programs can also be triggered by a productionsite or by a worker. :ref:`Workers
+<tribes_worker_programs>` have no default program, because their individual programs are always
+called from their production site.
 
 .. _map_object_programs_datatypes:
 

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -1887,8 +1887,7 @@ const Buildcost& ProductionProgram::recruited_workers() const {
 
 void ProductionProgram::validate_calls(const ProductionSiteDescr& descr) const {
 	for (const auto& action : actions_) {
-		const ActCall* act_call = dynamic_cast<const ActCall*>(action.get());
-		if (act_call != nullptr) {
+		if (upcast(const ActCall, act_call, action.get())) {
 			const std::string& program_name = act_call->program_name();
 			if (name() == program_name) {
 				throw GameDataError("Production program '%s' in %s is calling itself",

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -68,9 +68,10 @@ bool match_and_skip(const std::vector<std::string>& args,
 
 Productionsite Programs
 =======================
-Productionsites can have programs that will be executed by the game engine. Each productionsite must
-have a program named ``work``, which will be started automatically when the productionsite is
-created in the game, and then repeated until the productionsite is destroyed.
+Productionsites can have :ref:`programs <map_object_programs>` that will be executed by the game
+engine. Each productionsite must have a program named ``main``, which will be started automatically
+when the productionsite is created in the game, and then repeated until the productionsite is
+destroyed. (Note: the main program used to be called ``work``, which has been deprecated.)
 
 Programs are defined as Lua tables. Each program must be declared as a subtable in the
 productionsite's Lua table called ``programs`` and have a unique table key. The entries in a
@@ -78,7 +79,7 @@ program's subtable are the translatable ``descname`` and the table of ``actions`
 this::
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {
@@ -92,7 +93,7 @@ that you do this whenever workers are referenced, or if your tribes have multipl
 same name::
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start recruiting soldier because ...
          descname = pgettext("atlanteans_building", "recruiting soldier"),
          actions = {
@@ -104,7 +105,7 @@ same name::
 A program can call another program, for example::
 
    programs = {
-      work = {
+      main = {
          -- TRANSLATORS: Completed/Skipped/Did not start working because ...
          descname = _"working",
          actions = {
@@ -131,7 +132,6 @@ A program can call another program, for example::
 
 A program consists of a sequence of actions. An action is written as
 ``<type>=<parameters>``::
-
 
    produce_snack = {
       -- TRANSLATORS: Completed/Skipped/Did not start preparing a snack because ...
@@ -1792,8 +1792,8 @@ ProductionProgram::ProductionProgram(const std::string& init_name,
 				actions_.push_back(std::unique_ptr<ProductionProgram::Action>(
 				   new ActReturn(parseinput.arguments, *building, tribes)));
 			} else if (parseinput.name == "call") {
-				actions_.push_back(std::unique_ptr<ProductionProgram::Action>(
-				   new ActCall(parseinput.arguments)));
+				actions_.push_back(
+				   std::unique_ptr<ProductionProgram::Action>(new ActCall(parseinput.arguments)));
 			} else if (parseinput.name == "sleep") {
 				actions_.push_back(std::unique_ptr<ProductionProgram::Action>(
 				   new ActSleep(parseinput.arguments, *building)));
@@ -1886,19 +1886,19 @@ const Buildcost& ProductionProgram::recruited_workers() const {
 }
 
 void ProductionProgram::validate_calls(const ProductionSiteDescr& descr) const {
-	for (const auto& action: actions_) {
+	for (const auto& action : actions_) {
 		const ActCall* act_call = dynamic_cast<const ActCall*>(action.get());
 		if (act_call != nullptr) {
 			const std::string& program_name = act_call->program_name();
 			if (name() == program_name) {
 				throw GameDataError("Production program '%s' in %s is calling itself",
-									program_name.c_str(), descr.name().c_str());
+				                    program_name.c_str(), descr.name().c_str());
 			}
 			const ProductionSiteDescr::Programs& programs = descr.programs();
 			ProductionSiteDescr::Programs::const_iterator const it = programs.find(program_name);
 			if (it == programs.end()) {
-				throw GameDataError("Trying to call unknown program '%s' in %s",
-									program_name.c_str(), descr.name().c_str());
+				throw GameDataError("Trying to call unknown program '%s' in %s", program_name.c_str(),
+				                    descr.name().c_str());
 			}
 		}
 	}

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -68,7 +68,7 @@ bool match_and_skip(const std::vector<std::string>& args,
 
 Productionsite Programs
 =======================
-Productionsites can have :ref:`programs <map_object_programs>` that will be executed by the game
+Productionsites have :ref:`programs <map_object_programs>` that will be executed by the game
 engine. Each productionsite must have a program named ``main``, which will be started automatically
 when the productionsite is created in the game, and then repeated until the productionsite is
 destroyed. (Note: the main program used to be called ``work``, which has been deprecated.)

--- a/src/logic/map_objects/tribes/production_program.h
+++ b/src/logic/map_objects/tribes/production_program.h
@@ -272,11 +272,15 @@ struct ProductionProgram : public MapObjectProgram {
 	///       * If handling_method is None the called program continues normal,
 	///         but no statistics are calculated
 	struct ActCall : public Action {
-		ActCall(const std::vector<std::string>& arguments, const ProductionSiteDescr&);
+		ActCall(const std::vector<std::string>& arguments);
 		void execute(Game&, ProductionSite&) const override;
 
+		const std::string& program_name() const {
+			return program_name_;
+		}
+
 	private:
-		ProductionProgram* program_;
+		std::string program_name_;
 		ProgramResultHandlingMethod handling_methods_[3];
 	};
 
@@ -542,6 +546,8 @@ struct ProductionProgram : public MapObjectProgram {
 	const ProductionProgram::Groups& consumed_wares_workers() const;
 	const Buildcost& produced_wares() const;
 	const Buildcost& recruited_workers() const;
+	// Throws a GameDataError if we're trying to call an illegal program
+	void validate_calls(const ProductionSiteDescr& descr) const;
 
 private:
 	std::string descname_;

--- a/src/logic/map_objects/tribes/production_program.h
+++ b/src/logic/map_objects/tribes/production_program.h
@@ -546,7 +546,7 @@ struct ProductionProgram : public MapObjectProgram {
 	const ProductionProgram::Groups& consumed_wares_workers() const;
 	const Buildcost& produced_wares() const;
 	const Buildcost& recruited_workers() const;
-	// Throws a GameDataError if we're trying to call an illegal program
+	// Throws a GameDataError if we're trying to call an unknown program
 	void validate_calls(const ProductionSiteDescr& descr) const;
 
 private:

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -178,19 +178,27 @@ ProductionSiteDescr::ProductionSiteDescr(const std::string& init_descname,
 				program_descname = pgettext_expr(msgctxt_char, program_descname_unlocalized.c_str());
 			}
 			if (program_name == "work") {
-				log("WARNING: The main program for the building %s should be renamed from 'work' to 'main'\n", name().c_str());
-				programs_["main"] = std::unique_ptr<ProductionProgram>(
-											  new ProductionProgram("main", program_descname,
-																	program_table->get_table("actions"), tribes, world, this));
+				log("WARNING: The main program for the building %s should be renamed from 'work' to "
+				    "'main'\n",
+				    name().c_str());
+				programs_[MapObjectProgram::kMainProgram] = std::unique_ptr<ProductionProgram>(
+				   new ProductionProgram(MapObjectProgram::kMainProgram, program_descname,
+				                         program_table->get_table("actions"), tribes, world, this));
 			} else {
 				programs_[program_name] = std::unique_ptr<ProductionProgram>(
 				   new ProductionProgram(program_name, program_descname,
-										 program_table->get_table("actions"), tribes, world, this));
+				                         program_table->get_table("actions"), tribes, world, this));
 			}
 		} catch (const std::exception& e) {
 			throw GameDataError("%s: Error in productionsite program %s: %s", name().c_str(),
 			                    program_name.c_str(), e.what());
 		}
+	}
+
+	if (init_type == MapObjectType::PRODUCTIONSITE &&
+	    programs_.count(MapObjectProgram::kMainProgram) == 0) {
+		throw GameDataError(
+		   "%s: Error in productionsite programs: no 'main' program defined", name().c_str());
 	}
 
 	// Check ActCall
@@ -794,7 +802,7 @@ void ProductionSite::act(Game& game, uint32_t const data) {
 }
 
 void ProductionSite::find_and_start_next_program(Game& game) {
-	program_start(game, "main");
+	program_start(game, MapObjectProgram::kMainProgram);
 }
 
 /**

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -177,13 +177,25 @@ ProductionSiteDescr::ProductionSiteDescr(const std::string& init_descname,
 			if (program_descname == program_descname_unlocalized) {
 				program_descname = pgettext_expr(msgctxt_char, program_descname_unlocalized.c_str());
 			}
-			programs_[program_name] = std::unique_ptr<ProductionProgram>(
-			   new ProductionProgram(program_name, program_descname,
-			                         program_table->get_table("actions"), tribes, world, this));
+			if (program_name == "work") {
+				log("WARNING: The main program for the building %s should be renamed from 'work' to 'main'\n", name().c_str());
+				programs_["main"] = std::unique_ptr<ProductionProgram>(
+											  new ProductionProgram("main", program_descname,
+																	program_table->get_table("actions"), tribes, world, this));
+			} else {
+				programs_[program_name] = std::unique_ptr<ProductionProgram>(
+				   new ProductionProgram(program_name, program_descname,
+										 program_table->get_table("actions"), tribes, world, this));
+			}
 		} catch (const std::exception& e) {
 			throw GameDataError("%s: Error in productionsite program %s: %s", name().c_str(),
 			                    program_name.c_str(), e.what());
 		}
+	}
+
+	// Check ActCall
+	for (const auto& caller : programs_) {
+		caller.second->validate_calls(*this);
 	}
 
 	if (table.has_key("indicate_workarea_overlaps")) {
@@ -782,7 +794,7 @@ void ProductionSite::act(Game& game, uint32_t const data) {
 }
 
 void ProductionSite::find_and_start_next_program(Game& game) {
-	program_start(game, "work");
+	program_start(game, "main");
 }
 
 /**

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -401,7 +401,7 @@ protected:
 
 	/**
 	 * Determine the next program to be run when the last program has finished.
-	 * The default implementation starts program "work".
+	 * The default implementation starts program "main".
 	 */
 	virtual void find_and_start_next_program(Game&);
 

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -726,7 +726,7 @@ void MapBuildingdataPacket::read_productionsite(
 				std::transform(program_name.begin(), program_name.end(), program_name.begin(), tolower);
 				if (!pr_descr.programs().count(program_name)) {
 					log(
-					   "WARNING: productionsite has unknown program \"%s\",replacing it with \"main\"\n",
+					   "WARNING: productionsite has unknown program \"%s\", replacing it with \"main\"\n",
 					   program_name.c_str());
 					program_name = "main";
 				}

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -726,9 +726,9 @@ void MapBuildingdataPacket::read_productionsite(
 				std::transform(program_name.begin(), program_name.end(), program_name.begin(), tolower);
 				if (!pr_descr.programs().count(program_name)) {
 					log(
-					   "WARNING: productionsite has unknown program \"%s\",replacing it with \"work\"\n",
+					   "WARNING: productionsite has unknown program \"%s\",replacing it with \"main\"\n",
 					   program_name.c_str());
-					program_name = "work";
+					program_name = "main";
 				}
 
 				productionsite.stack_[i].program = productionsite.descr().get_program(program_name);

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -725,9 +725,9 @@ void MapBuildingdataPacket::read_productionsite(
 				std::string program_name = fr.c_string();
 				std::transform(program_name.begin(), program_name.end(), program_name.begin(), tolower);
 				if (!pr_descr.programs().count(program_name)) {
-					log(
-					   "WARNING: productionsite has unknown program \"%s\", replacing it with \"main\"\n",
-					   program_name.c_str());
+					log("WARNING: productionsite has unknown program \"%s\", replacing it with "
+					    "\"main\"\n",
+					    program_name.c_str());
 					program_name = MapObjectProgram::kMainProgram;
 				}
 

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -728,7 +728,7 @@ void MapBuildingdataPacket::read_productionsite(
 					log(
 					   "WARNING: productionsite has unknown program \"%s\", replacing it with \"main\"\n",
 					   program_name.c_str());
-					program_name = "main";
+					program_name = MapObjectProgram::kMainProgram;
 				}
 
 				productionsite.stack_[i].program = productionsite.descr().get_program(program_name);


### PR DESCRIPTION
Also:

* Shift check for `ActCall` to after all programs are loaded, so we can call them now anything we like.
* Check that productionsites have a `main` program defined.