### PR TITLE
Fix an #ifdef in wlapplication messages

### DIFF
--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -50,9 +50,9 @@ void show_usage(const std::string& build_id, const std::string& build_type) {
 	          << _(" --homedir=DIRNAME    Use specified directory for widelands config\n"
 	               "                      files, savegames and replays")
 	          << endl
-#ifdef __linux__
+#ifndef _WIN32
 	          << _("                      Default is ~/.widelands") << endl
-#elif _WIN32
+#else
 	          << _("                      Default is %USERPROFILE%\\.widelands") << endl
 #endif
 	          << _(" --localedir=DIRNAME  Use specified directory for the widelands\n"


### PR DESCRIPTION
* Fix compiler warning about `#elif _WIN32`
* Show game data path on MacOS

