### PR TITLE
Fix blurry sprite rendering at 1x zoom

### DIFF
--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -393,7 +393,7 @@ FieldsToDraw* MapView::draw_terrain(const Widelands::EditorGameBase& egbase,
 	// If zoom is 1x align to whole pixels to get pixel-perfect sprite rendering.
 	if (view_.zoom_near(1)) {
 		fields_to_draw_.reset(
-		    egbase, Vector2f(round(view_.viewpoint.x), round(view_.viewpoint.y)), view_.zoom, dst);
+		   egbase, Vector2f(round(view_.viewpoint.x), round(view_.viewpoint.y)), view_.zoom, dst);
 	} else {
 		fields_to_draw_.reset(egbase, view_.viewpoint, view_.zoom, dst);
 	}
@@ -528,8 +528,7 @@ bool MapView::handle_mousewheel(uint32_t which, int32_t /* x */, int32_t y) {
 		return true;
 	}
 	constexpr float kPercentPerMouseWheelTick = 0.02f;
-	float zoom = view_.zoom * static_cast<float>(
-	                             std::pow(1.f - kPercentPerMouseWheelTick, y));
+	float zoom = view_.zoom * static_cast<float>(std::pow(1.f - kPercentPerMouseWheelTick, y));
 	zoom_around(zoom, last_mouse_pos_.cast<float>(), Transition::Jump);
 	return true;
 }

--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -390,7 +390,13 @@ FieldsToDraw* MapView::draw_terrain(const Widelands::EditorGameBase& egbase,
 		break;
 	}
 
-	fields_to_draw_.reset(egbase, view_.viewpoint, view_.zoom, dst);
+	// If zoom is 1x align to whole pixels to get pixel-perfect sprite rendering.
+	if (view_.zoom_near(1)) {
+		fields_to_draw_.reset(
+		    egbase, Vector2f(round(view_.viewpoint.x), round(view_.viewpoint.y)), view_.zoom, dst);
+	} else {
+		fields_to_draw_.reset(egbase, view_.viewpoint, view_.zoom, dst);
+	}
 	const float scale = 1.f / view_.zoom;
 	::draw_terrain(
 	   egbase.get_gametime(), egbase.world(), fields_to_draw_, scale, workarea, grid, player, dst);
@@ -522,8 +528,8 @@ bool MapView::handle_mousewheel(uint32_t which, int32_t /* x */, int32_t y) {
 		return true;
 	}
 	constexpr float kPercentPerMouseWheelTick = 0.02f;
-	float zoom = view_.zoom * static_cast<float>(std::pow(
-	                             1.f - math::sign(y) * kPercentPerMouseWheelTick, std::abs(y)));
+	float zoom = view_.zoom * static_cast<float>(
+	                             std::pow(1.f - kPercentPerMouseWheelTick, y));
 	zoom_around(zoom, last_mouse_pos_.cast<float>(), Transition::Jump);
 	return true;
 }


### PR DESCRIPTION
- Align the sprites to whole pixels when at 1x zoom to get pixel-perfect rendering.
- Tweak mouse wheel zooming formula so when we zoom the same number of steps in and out we end up at the same zoom we started at.

Fixes #4168 

**Before:**
![screenshot without the fix](https://user-images.githubusercontent.com/4470900/91365083-95daa600-e800-11ea-9406-6d946647e802.png)

**After:**
![screenshot with the fix](https://user-images.githubusercontent.com/4470900/91364997-5ad87280-e800-11ea-8f0f-e9fc3005f30f.png)

The HQ sprite was switched for illustration purposes.