### PR TITLE
Improve UI::Box

### DIFF
--- a/src/editor/ui_menus/main_menu_map_options.cc
+++ b/src/editor/ui_menus/main_menu_map_options.cc
@@ -241,8 +241,13 @@ MainMenuMapOptions::MainMenuMapOptions(EditorInteractive& parent, Registry& regi
      main_box_(&tabs_, padding_, padding_, UI::Box::Vertical, max_w_, get_inner_h(), 0),
      tags_box_(&tabs_, padding_, padding_, UI::Box::Vertical, max_w_, get_inner_h(), 0),
      teams_box_(&tabs_, padding_, padding_, UI::Box::Vertical, max_w_, get_inner_h(), 0),
-     inner_teams_box_(
-        &teams_box_, padding_, padding_, UI::Box::Vertical, max_w_, get_inner_h() / 2),
+     inner_teams_box_(&teams_box_,
+                      padding_,
+                      padding_,
+                      UI::Box::Vertical,
+                      max_w_,
+                      get_inner_h() / 2,
+                      kSuggestedTeamsUnitSize),
 
      name_(&main_box_, 0, 0, max_w_, UI::PanelStyle::kWui),
      author_(&main_box_, 0, 0, max_w_, UI::PanelStyle::kWui),
@@ -349,16 +354,18 @@ MainMenuMapOptions::MainMenuMapOptions(EditorInteractive& parent, Registry& regi
 	teams_box_.add(new UI::Textarea(
 	   &teams_box_, 0, 0, max_w_, labelh_,
 	   (boost::format(ngettext("%u Player", "%u Players", nr_players)) % nr_players).str()));
-	teams_box_.add_space(4);
+	teams_box_.add_space(padding_);
 	teams_box_.add(new UI::Textarea(&teams_box_, 0, 0, max_w_, labelh_, _("Suggested Teams:")));
+	teams_box_.add_space(padding_);
 	teams_box_.add(&inner_teams_box_, UI::Box::Resizing::kFullSize);
+	teams_box_.add_space(padding_);
 	teams_box_.add(&new_suggested_team_, UI::Box::Resizing::kFullSize);
 	new_suggested_team_.sigclicked.connect([this]() {
 		SuggestedTeamsEntry* ste =
 		   new SuggestedTeamsEntry(this, &inner_teams_box_, eia().egbase().map(),
 		                           max_w_ - UI::Scrollbar::kSize, Widelands::SuggestedTeamLineup());
 		inner_teams_box_.add(ste);
-		inner_teams_box_.add_space(kSuggestedTeamsUnitSize);
+		//		inner_teams_box_.add_space(kSuggestedTeamsUnitSize);
 		suggested_teams_entries_.push_back(ste);
 	});
 
@@ -490,22 +497,11 @@ void MainMenuMapOptions::add_tag_checkbox(UI::Box* parent,
 
 void MainMenuMapOptions::delete_suggested_team(SuggestedTeamsEntry* ste) {
 	inner_teams_box_.set_force_scrolling(false);
-	inner_teams_box_.clear();
-	const size_t nr = suggested_teams_entries_.size();
-	for (size_t i = 0; i < nr; ++i) {
-		if (suggested_teams_entries_[i] == ste) {
-			for (size_t j = i + 1; j < nr; ++j) {
-				inner_teams_box_.add(suggested_teams_entries_[j]);
-				inner_teams_box_.add_space(kSuggestedTeamsUnitSize);
-				suggested_teams_entries_[j - 1] = suggested_teams_entries_[j];
-			}
-			suggested_teams_entries_.resize(nr - 1);
-			inner_teams_box_.set_force_scrolling(true);
-			return ste->die();
-		} else {
-			inner_teams_box_.add(suggested_teams_entries_[i]);
-			inner_teams_box_.add_space(kSuggestedTeamsUnitSize);
-		}
-	}
-	NEVER_HERE();
+
+	auto is_deleted_panel = [ste](SuggestedTeamsEntry* i) { return ste == i; };
+	suggested_teams_entries_.erase(std::remove_if(suggested_teams_entries_.begin(),
+	                                              suggested_teams_entries_.end(), is_deleted_panel),
+	                               suggested_teams_entries_.end());
+	ste->die();
+	inner_teams_box_.set_force_scrolling(true);
 }

--- a/src/editor/ui_menus/main_menu_map_options.cc
+++ b/src/editor/ui_menus/main_menu_map_options.cc
@@ -365,7 +365,6 @@ MainMenuMapOptions::MainMenuMapOptions(EditorInteractive& parent, Registry& regi
 		   new SuggestedTeamsEntry(this, &inner_teams_box_, eia().egbase().map(),
 		                           max_w_ - UI::Scrollbar::kSize, Widelands::SuggestedTeamLineup());
 		inner_teams_box_.add(ste);
-		//		inner_teams_box_.add_space(kSuggestedTeamsUnitSize);
 		suggested_teams_entries_.push_back(ste);
 	});
 

--- a/src/ui_basic/box.cc
+++ b/src/ui_basic/box.cc
@@ -33,8 +33,7 @@ Box::Box(Panel* const parent,
          uint32_t const orientation,
          int32_t const max_x,
          int32_t const max_y,
-         uint32_t const inner_spacing,
-         bool const ignore_invisible_items)
+         uint32_t const inner_spacing)
    : Panel(parent, x, y, 0, 0),
 
      max_x_(max_x ? max_x : g_gr->get_xres()),
@@ -46,8 +45,7 @@ Box::Box(Panel* const parent,
      scrollbar_style_(UI::PanelStyle::kFsMenu),
      orientation_(orientation),
      mindesiredbreadth_(0),
-     inner_spacing_(inner_spacing),
-     ignore_invisible_items_(ignore_invisible_items) {
+     inner_spacing_(inner_spacing) {
 }
 
 /**
@@ -363,7 +361,7 @@ void Box::get_item_desired_size(uint32_t const idx, int* depth, int* breadth) {
 
 	switch (it.type) {
 	case Item::ItemPanel:
-		if (ignore_invisible_items_ && !it.u.panel.panel->is_visible()) {
+		if (!it.u.panel.panel->is_visible()) {
 			*depth = 0;
 			*breadth = 0;
 			return;

--- a/src/ui_basic/box.cc
+++ b/src/ui_basic/box.cc
@@ -33,7 +33,8 @@ Box::Box(Panel* const parent,
          uint32_t const orientation,
          int32_t const max_x,
          int32_t const max_y,
-         uint32_t const inner_spacing)
+         uint32_t const inner_spacing,
+         bool const ignore_invisible_items)
    : Panel(parent, x, y, 0, 0),
 
      max_x_(max_x ? max_x : g_gr->get_xres()),
@@ -45,7 +46,8 @@ Box::Box(Panel* const parent,
      scrollbar_style_(UI::PanelStyle::kFsMenu),
      orientation_(orientation),
      mindesiredbreadth_(0),
-     inner_spacing_(inner_spacing) {
+     inner_spacing_(inner_spacing),
+     ignore_invisible_items_(ignore_invisible_items) {
 }
 
 /**
@@ -361,6 +363,11 @@ void Box::get_item_desired_size(uint32_t const idx, int* depth, int* breadth) {
 
 	switch (it.type) {
 	case Item::ItemPanel:
+		if (ignore_invisible_items_ && !it.u.panel.panel->is_visible()) {
+			*depth = 0;
+			*breadth = 0;
+			return;
+		}
 		if (orientation_ == Horizontal) {
 			it.u.panel.panel->get_desired_size(depth, breadth);
 		} else {

--- a/src/ui_basic/box.cc
+++ b/src/ui_basic/box.cc
@@ -450,4 +450,10 @@ void Box::set_item_pos(uint32_t idx, int32_t pos) {
 		break;  //  no need to do anything
 	}
 }
+void Box::on_death(Panel* p) {
+	auto is_deleted_panel = [p](Box::Item i) { return p == i.u.panel.panel; };
+	items_.erase(std::remove_if(items_.begin(), items_.end(), is_deleted_panel));
+
+	update_desired_size();
+}
 }  // namespace UI

--- a/src/ui_basic/box.cc
+++ b/src/ui_basic/box.cc
@@ -457,7 +457,7 @@ void Box::set_item_pos(uint32_t idx, int32_t pos) {
 }
 void Box::on_death(Panel* p) {
 	auto is_deleted_panel = [p](Box::Item i) { return p == i.u.panel.panel; };
-	items_.erase(std::remove_if(items_.begin(), items_.end(), is_deleted_panel));
+	items_.erase(std::remove_if(items_.begin(), items_.end(), is_deleted_panel), items_.end());
 
 	update_desired_size();
 }

--- a/src/ui_basic/box.cc
+++ b/src/ui_basic/box.cc
@@ -463,4 +463,7 @@ void Box::on_death(Panel* p) {
 
 	update_desired_size();
 }
+void Box::on_visibility_changed() {
+	update_desired_size();
+}
 }  // namespace UI

--- a/src/ui_basic/box.h
+++ b/src/ui_basic/box.h
@@ -94,6 +94,7 @@ private:
 	void scrollbar_moved(int32_t);
 	void update_positions();
 	void on_death(Panel* p) override;
+	void on_visibility_changed() override;
 
 	// Don't resize beyond this size
 	int max_x_, max_y_;

--- a/src/ui_basic/box.h
+++ b/src/ui_basic/box.h
@@ -92,6 +92,7 @@ private:
 	void set_item_pos(uint32_t idx, int32_t pos);
 	void scrollbar_moved(int32_t);
 	void update_positions();
+	void on_death(Panel* p) override;
 
 	// Don't resize beyond this size
 	int max_x_, max_y_;

--- a/src/ui_basic/box.h
+++ b/src/ui_basic/box.h
@@ -47,8 +47,7 @@ struct Box : public Panel {
 	    uint32_t orientation,
 	    int32_t max_x = 0,
 	    int32_t max_y = 0,
-	    uint32_t inner_spacing = 0,
-	    bool ignore_invisible_items = false);
+	    uint32_t inner_spacing = 0);
 
 	void set_scrolling(bool scroll);
 	void set_force_scrolling(bool);
@@ -126,7 +125,6 @@ private:
 	uint32_t orientation_;
 	uint32_t mindesiredbreadth_;
 	uint32_t inner_spacing_;
-	bool ignore_invisible_items_;
 
 	std::vector<Item> items_;
 };

--- a/src/ui_basic/box.h
+++ b/src/ui_basic/box.h
@@ -47,7 +47,8 @@ struct Box : public Panel {
 	    uint32_t orientation,
 	    int32_t max_x = 0,
 	    int32_t max_y = 0,
-	    uint32_t inner_spacing = 0);
+	    uint32_t inner_spacing = 0,
+	    bool ignore_invisible_items = false);
 
 	void set_scrolling(bool scroll);
 	void set_force_scrolling(bool);
@@ -124,6 +125,7 @@ private:
 	uint32_t orientation_;
 	uint32_t mindesiredbreadth_;
 	uint32_t inner_spacing_;
+	bool ignore_invisible_items_;
 
 	std::vector<Item> items_;
 };

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -490,7 +490,7 @@ void Panel::draw_overlay(RenderTarget& dst) {
 		}
 		dst.fill_rect(focus_overlay_rect(),
 		              has_toplevel_focus ? g_style_manager->focused_color() :
-                                         g_style_manager->semi_focused_color(),
+		                                   g_style_manager->semi_focused_color(),
 		              BlendMode::Default);
 	}
 }

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -480,7 +480,7 @@ void Panel::draw_overlay(RenderTarget& dst) {
 		}
 		dst.fill_rect(focus_overlay_rect(),
 		              has_toplevel_focus ? g_style_manager->focused_color() :
-		                                   g_style_manager->semi_focused_color(),
+                                         g_style_manager->semi_focused_color(),
 		              BlendMode::Default);
 	}
 }
@@ -797,6 +797,9 @@ void Panel::die() {
 	}
 }
 
+void Panel::on_death(Panel*) {
+}
+
 /**
  * Wrapper around SoundHandler::play_fx() to prevent having to include
  * sound_handler.h in every UI subclass just for playing a 'click'
@@ -825,6 +828,7 @@ void Panel::check_child_death() {
 		next = p->next_;
 
 		if (p->flags_ & pf_die) {
+			p->parent_->on_death(p);
 			delete p;
 			p = nullptr;
 		} else if (p->flags_ & pf_child_die) {

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -446,6 +446,16 @@ void Panel::set_visible(bool const on) {
 	} else if (parent_ && parent_->focus_ == this) {
 		parent_->focus_ = nullptr;
 	}
+	if (parent_) {
+		parent_->on_visibility_changed();
+	}
+}
+
+/**
+ * Called on a child's parent when visibility of child changed
+ * Overridden in UI::Box
+ */
+void Panel::on_visibility_changed() {
 }
 
 /**
@@ -796,7 +806,10 @@ void Panel::die() {
 		}
 	}
 }
-
+/**
+ * Called on a child's parent just before child is deleted.
+ * Overridden in UI::Box
+ */
 void Panel::on_death(Panel*) {
 }
 

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -352,6 +352,7 @@ private:
 	}
 
 	void check_child_death();
+	virtual void on_death(Panel* p);
 
 	friend class Window;
 	void do_draw(RenderTarget&);

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -353,6 +353,7 @@ private:
 
 	void check_child_death();
 	virtual void on_death(Panel* p);
+	virtual void on_visibility_changed();
 
 	friend class Window;
 	void do_draw(RenderTarget&);


### PR DESCRIPTION
Fixes #4062 

Add support for deletion of panels for UI::Box and ignoring invisible panels while layouting.

I also have a solution according to @gunchleoc proposal https://github.com/widelands/widelands/issues/4062#issuecomment-669097595 with publishing notifications, but this of course notifies ALL existing boxes which in turn need to iterate over their `items_` to find the (one) panel which was deleted and then relayout themselves. To me, this looked like much overhead... Opinions?

I provided a boolean switch to enable/disable ignoring of invisible items while layouting. Imho, this should be removed (set to always ignore invisible items) but as I am not sure if there are any spacing hacks (add a invisible panel for enforcing padding or whatever) I included it for now...