### PR TITLE
Create directory structure in homedir

### DIFF
--- a/src/editor/ui_menus/main_menu_load_map.cc
+++ b/src/editor/ui_menus/main_menu_load_map.cc
@@ -71,6 +71,8 @@ void MainMenuLoadMap::set_current_directory(const std::string& filename) {
 		boost::replace_first(display_dir, "My_Maps", _("My Maps"));
 	} else if (boost::starts_with(display_dir, "MP_Scenarios")) {
 		boost::replace_first(display_dir, "MP_Scenarios", _("Multiplayer Scenarios"));
+	} else if (boost::starts_with(display_dir, "Downloaded")) {
+		boost::replace_first(display_dir, "Downloaded", _("Downloaded Maps"));
 	}
 	/** TRANSLATORS: The folder that a file will be saved to. */
 	directory_info_.set_text((boost::format(_("Current directory: %s")) % display_dir).str());

--- a/src/editor/ui_menus/main_menu_load_or_save_map.cc
+++ b/src/editor/ui_menus/main_menu_load_or_save_map.cc
@@ -33,11 +33,14 @@ MainMenuLoadOrSaveMap::MainMenuLoadOrSaveMap(EditorInteractive& parent,
                                              Registry& registry,
                                              const std::string& name,
                                              const std::string& title,
+                                             bool show_empty_dirs,
                                              const std::string& basedir)
    : UI::UniqueWindow(&parent, name, &registry, parent.get_w(), parent.get_h(), title),
 
      // Values for alignment and size
      padding_(4),
+
+     show_empty_dirs_(show_empty_dirs),
 
      main_box_(this, padding_, padding_, UI::Box::Vertical, 0, 0, padding_),
 
@@ -184,7 +187,8 @@ void MainMenuLoadOrSaveMap::fill_table() {
 				maps_data_.push_back(MapData(map, mapfilename, maptype, display_type));
 			} catch (const WException&) {
 			}  //  we simply skip illegal entries
-		} else if (g_fs->is_directory(mapfilename)) {
+		} else if (g_fs->is_directory(mapfilename) &&
+		           (show_empty_dirs_ || g_fs->list_directory(mapfilename).size() > 0)) {
 			// Add subdirectory to the list
 			const char* fs_filename = FileSystem::fs_filename(mapfilename.c_str());
 			if (!strcmp(fs_filename, ".") || !strcmp(fs_filename, "..")) {

--- a/src/editor/ui_menus/main_menu_load_or_save_map.h
+++ b/src/editor/ui_menus/main_menu_load_or_save_map.h
@@ -36,6 +36,7 @@ struct MainMenuLoadOrSaveMap : public UI::UniqueWindow {
 	                      UI::UniqueWindow::Registry& registry,
 	                      const std::string& name,
 	                      const std::string& title,
+	                      bool show_empty_dirs = false,
 	                      const std::string& basedir = kMapsDir);
 
 protected:
@@ -54,6 +55,9 @@ protected:
 private:
 	// Common padding between panels
 	int32_t const padding_;
+
+	// Whether to list empty directories
+	bool const show_empty_dirs_;
 
 	// Main vertical container for the UI elements
 	UI::Box main_box_;

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -48,7 +48,7 @@ inline EditorInteractive& MainMenuSaveMap::eia() {
 MainMenuSaveMap::MainMenuSaveMap(EditorInteractive& parent,
                                  UI::UniqueWindow::Registry& registry,
                                  Registry& map_options_registry)
-   : MainMenuLoadOrSaveMap(parent, registry, "save_map_menu", _("Save Map"), "maps/My_Maps"),
+   : MainMenuLoadOrSaveMap(parent, registry, "save_map_menu", _("Save Map"), true, "maps/My_Maps"),
      map_options_registry_(map_options_registry),
      edit_options_(&map_details_box_,
                    "edit_options",

--- a/src/ui_fsmenu/mapselect.cc
+++ b/src/ui_fsmenu/mapselect.cc
@@ -361,7 +361,7 @@ void FullscreenMenuMapSelect::fill_table() {
 			} catch (...) {
 				log_warn("Mapselect: Skip %s due to unknown exception\n", mapfilename.c_str());
 			}
-		} else if (g_fs->is_directory(mapfilename)) {
+		} else if (g_fs->is_directory(mapfilename) && g_fs->list_directory(mapfilename).size() > 0) {
 			// Add subdirectory to the list
 			const char* fs_filename = FileSystem::fs_filename(mapfilename.c_str());
 			if (!strcmp(fs_filename, ".") || !strcmp(fs_filename, "..")) {

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -268,6 +268,12 @@ void WLApplication::setup_homedir() {
 #endif
 		// Homedir is ready, so we can log normally from now on
 		log_info("Set home directory: %s\n", homedir_.c_str());
+
+		// Create directory structure
+		g_fs->ensure_directory_exists("save");
+		g_fs->ensure_directory_exists("replays");
+		g_fs->ensure_directory_exists("maps/My_Maps");
+		g_fs->ensure_directory_exists("maps/Downloaded");
 	}
 
 #ifdef USE_XDG

--- a/src/wui/mapdata.cc
+++ b/src/wui/mapdata.cc
@@ -162,6 +162,9 @@ MapData MapData::create_directory(const std::string& directory) {
 	} else if (boost::equals(directory, "maps/My_Maps")) {
 		/** TRANSLATORS: Directory name for user maps in map selection */
 		localized_name = _("My Maps");
+	} else if (boost::equals(directory, "maps/Downloaded")) {
+		/** TRANSLATORS: Directory name for downloaded maps in map selection */
+		localized_name = _("Downloaded Maps");
 	} else {
 		localized_name = FileSystem::fs_filename(directory.c_str());
 	}


### PR DESCRIPTION
Fixes #581 
Create empty directory structure in homedir to guide new players, where to put downloaded maps, replays or saves.
Empty folders are hidden in map selection to prevent confusion.