### PR TITLE
Only show .wgf files in load/save menu

### DIFF
--- a/src/wui/savegameloader.cc
+++ b/src/wui/savegameloader.cc
@@ -61,7 +61,7 @@ void SavegameLoader::load_savegame_from_file(const std::string& gamefilename,
                                              std::vector<SavegameData>& loaded_games) const {
 	std::string savename = get_savename(gamefilename);
 
-	if (!g_fs->file_exists(savename.c_str())) {
+	if (!g_fs->file_exists(savename.c_str()) || !boost::ends_with(savename, kSavegameExtension)) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #3902 
Only show .wgf files in load/save menu to remove incompatibility warnings for files, which clearly are no save games.
Also works for loading replays, where a .wrpl file has to have a corresponding .wgf file.