### PR TITLE
Reset dropdown list selection when toggled off

### DIFF
--- a/src/ui_basic/dropdown.cc
+++ b/src/ui_basic/dropdown.cc
@@ -416,6 +416,9 @@ void BaseDropdown::set_list_visibility(bool open) {
 }
 
 void BaseDropdown::toggle_list() {
+	if (list_->is_visible()) {
+		list_->select(current_selection_);
+	}
 	if (!is_enabled_) {
 		list_->set_visible(false);
 		return;
@@ -463,7 +466,6 @@ bool BaseDropdown::handle_key(bool down, SDL_Keysym code) {
 			return true;
 		case SDLK_ESCAPE:
 			if (list_->is_visible()) {
-				list_->select(current_selection_);
 				toggle_list();
 				return true;
 			}

--- a/src/ui_basic/dropdown.cc
+++ b/src/ui_basic/dropdown.cc
@@ -394,6 +394,9 @@ void BaseDropdown::toggle() {
 }
 
 void BaseDropdown::set_list_visibility(bool open) {
+	if (!open) {
+		list_->select(current_selection_);
+	}
 	if (!is_enabled_) {
 		list_->set_visible(false);
 		return;


### PR DESCRIPTION
If a dropdown is toggled off without the user confirming the selection by clicking or pressing space/enter, reset the list selection back to the previously selected value.
Fix #4204