### PR TITLE
Include <cstdlib> in src/map_io/coords_profile.cc

### DIFF
--- a/src/map_io/coords_profile.cc
+++ b/src/map_io/coords_profile.cc
@@ -19,6 +19,8 @@
 
 #include "map_io/coords_profile.h"
 
+#include <cstdlib>
+
 #include "base/wexception.h"
 #include "io/profile.h"
 #include "logic/widelands_geometry.h"


### PR DESCRIPTION
Hi, widelands build21 fails on OS X 10.9 with Apple LLVM version 6.0

```
widelands-build21-source/src/map_io/coords_profile.cc:32:21: error: use of undeclared identifier 'strtol'
        const long int x = strtol(endp, &endp, 0);
                           ^
widelands-build21-source/src/map_io/coords_profile.cc:33:21: error: use of undeclared identifier 'strtol'
        const long int y = strtol(endp, &endp, 0);
                           ^
1 warning and 2 errors generated.
```

This was [reported to MacPorts](https://trac.macports.org/ticket/61028).

According to `man 3 strtol`, one must include <stdlib.h> to access this function. (Perhaps on later OS/LLVM versions that happens indirectly.)