### PR TITLE
Include <cstdlib> in src/graphic/surface.cc

### DIFF
--- a/src/graphic/surface.cc
+++ b/src/graphic/surface.cc
@@ -19,6 +19,8 @@
 
 #include "graphic/surface.h"
 
+#include <cstdlib>
+
 #include "base/rect.h"
 #include "base/vector.h"
 #include "graphic/gl/coordinate_conversion.h"


### PR DESCRIPTION
Building widelands build21 fails on OS X 10.9 with Apple LLVM version 6.0:

```
widelands-build21-source/src/graphic/surface.cc:114:25: error: call to 'abs' is ambiguous
        const int abs_factor = std::abs(factor);
                               ^~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cmath:660:1: note: candidate function
abs(float __x) _NOEXCEPT {return fabsf(__x);}
^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cmath:664:1: note: candidate function
abs(double __x) _NOEXCEPT {return fabs(__x);}
^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cmath:668:1: note: candidate function
abs(long double __x) _NOEXCEPT {return fabsl(__x);}
^
```

`<cstdlib>` is where integral overloads of `abs` are located.