### PR TITLE
Don't directly initialize accepted/rejected_nodes

### DIFF
--- a/src/logic/map_objects/findnode.cc
+++ b/src/logic/map_objects/findnode.cc
@@ -180,9 +180,9 @@ bool FindNodeShore::accept(const EditorGameBase& egbase, const FCoords& coords) 
 	std::vector<FCoords> nodes_to_process = {coords};
 	// Set of nodes that that are swimmable & and achievable by swimming
 	// We use hashes here
-	std::set<uint32_t> accepted_nodes = {};
+	std::set<uint32_t> accepted_nodes;
 	// just not to check the same node twice
-	std::set<uint32_t> rejected_nodes = {};
+	std::set<uint32_t> rejected_nodes;
 
 	// Continue untill all nodes to process are processed, or we found sufficient number of nodes
 	while (!nodes_to_process.empty() && accepted_nodes.size() < min_fields) {


### PR DESCRIPTION
Building widelands build21 fails on OS X 10.9 with Apple LLVM version 6.0:

```
widelands-build21-source/src/logic/map_objects/findnode.cc:178:21: error: chosen constructor is explicit in copy-initialization
        std::set<uint32_t> accepted_nodes = {};
                           ^                ~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/set:428:14: note: constructor declared here
    explicit set(const value_compare& __comp = value_compare())
             ^
widelands-build21-source/src/logic/map_objects/findnode.cc:180:21: error: chosen constructor is explicit in copy-initialization
        std::set<uint32_t> rejected_nodes = {};
                           ^                ~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/set:428:14: note: constructor declared here
    explicit set(const value_compare& __comp = value_compare())
             ^
```

This appears to be an unintended limitation in the C++ standard, fixed in newer compilers; see http://cplusplus.github.io/LWG/lwg-defects.html#2193

I am not familiar with modern C++ so I am not sure if my fix is correct. But if I read it correctly, I believe the old code was trying to initialize `accepted_nodes` and `rejected_nodes` to be empty sets, and if what I've read about C++ today is accurate, then that should happen automatically with set variables.