### PR TITLE
Fix typos in comments, messages, documentation

### DIFF
--- a/cmake/codecheck/CodeCheck.py
+++ b/cmake/codecheck/CodeCheck.py
@@ -5,9 +5,9 @@
 """Yet another code checker for the widelands project.
 
 This one's intention is to get rid of the ADA whitespace checker (while
-keeping it's functionality or improving on it) and supersede the old
-detect_spurious_indentation.py script (while also keeping it's cases
-around). En plus, we also replace the spurious code checking done with
+keeping its functionality or improving on it) and supersede the old
+detect_spurious_indentation.py script (while also keeping its cases
+around). Additionally, we replace the spurious code checking done with
 grep which is currently also around.
 """
 
@@ -245,9 +245,9 @@ class CodeChecker(object):
         self._color = color
 
         # We keep a cache of file names/error strings
-        # so that (e.g.) a header is requested twice in one
+        # so that (e.g.) if a header is requested twice in one
         # run of the program, we just return the cached errors.
-        # They will not have changed while the program was running
+        # They will not have changed while the program was running.
         self._cache = {}
 
     @property

--- a/cmake/codecheck/rules/correct_include_order.py
+++ b/cmake/codecheck/rules/correct_include_order.py
@@ -58,7 +58,7 @@ class EvalMatches(object):
             if len(blocks[0]) != 1 or not blocks[0][0][2][:-2].endswith(base_file):
                 if os.path.exists(os.path.abspath(fn)[:-3] + '.h'):
                     errors.append(
-                        (fn, blocks[0][0][0], 'In a .cc file, include the corresponding header first in a line of its own it exists.'))
+                        (fn, blocks[0][0][0], 'In a .cc file, include the corresponding header first in a line of its own if it exists.'))
                 return errors
             else:
                 blocks.pop(0)

--- a/doc/sphinx/source/implementation.rst
+++ b/doc/sphinx/source/implementation.rst
@@ -90,13 +90,13 @@ will be the submodule name where this class is registered. For our example,
 Player would return ``"game"`` because it is defined in ``wl.game``.
 
 The class must also define two constructors, one that takes no arguments and
-is only used to create a empty class that is created for unpersisting. And a
+is only used to create an empty class that is created for unpersisting, and a
 second one that takes a ``lua_State *`` that is called when the construction
 is requested from Lua, that is if ``wl.game.Player()`` is called. Some (most?)
 classes can't be constructed from Lua and should then answer with
 ``report_error()``.
 
-En plus, a function ``__persist(lua_State *)`` and a function
+Additionally, a function ``__persist(lua_State *)`` and a function
 ``__unpersist(lua_State *)`` must be defined. They are discussed in the next
 section.
 


### PR DESCRIPTION
Just a few wording fixes in documentation and codecheck messages and comments that shouldn't affect the functionality of the program.