### PR TITLE
Handle video problems of helper applications in CI environment

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,17 @@
-set -ex
+set -x
+trap 'err_handler' ERR
+
+# Called if a command returns a non-zero value
+err_handler() {
+   result=$?
+   if [ $result -eq 2 ] ; then
+      # Catch instabilities with SDL in CI environment
+      echo "SDL initialization failed. TEST SKIPPED.";
+   else
+      # Exit with this error
+      exit $result
+   fi
+}
 
 # Create build folder.
 mkdir build

--- a/src/website/CMakeLists.txt
+++ b/src/website/CMakeLists.txt
@@ -8,6 +8,7 @@ wl_library(website_common
   DEPENDS
     base_exceptions
     base_i18n
+    base_log
     graphic
     io_filesystem
 )

--- a/src/website/website_common.cc
+++ b/src/website/website_common.cc
@@ -22,6 +22,7 @@
 #include <SDL.h>
 
 #include "base/i18n.h"
+#include "base/log.h"
 #include "base/wexception.h"
 #include "graphic/graphic.h"
 #include "io/filesystem/filesystem.h"
@@ -32,7 +33,10 @@ void initialize() {
 	i18n::set_locale("en");
 
 	if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-		throw wexception("Unable to initialize SDL: %s", SDL_GetError());
+		// We sometimes run into a missing video driver in our CI environment, so we exit 0 to prevent
+		// too frequent failures
+		log_err("Failed to initialize SDL, no valid video driver: %s", SDL_GetError());
+		exit(2);
 	}
 
 	g_fs = new LayeredFileSystem();


### PR DESCRIPTION
relates to #3585

The CI instability was only fixed for the main application. In recent builds the same issue occurs for the website tools.
So they should exit the same way.
This might also require an adaption in the build script to process the exit  code.

Examples:
* https://travis-ci.org/github/widelands/widelands/jobs/725022315
* https://travis-ci.org/github/widelands/widelands/jobs/724618982

```
[100%] Built target wl_map_object_info
1856 +++'[' linux = linux ']'
1857 +++cd ..
1858 +++'[' ON = ON ']'
1859 +++mkdir temp_web
1860 +++build/src/website/wl_map_object_info temp_web
1861 [00:00:00.000 real] INFO: selected language: en
1862 [00:00:00.002 real] INFO: using locale en_US.utf-8
1863 [00:00:00.054 real] ERROR: Exception: [/home/travis/build/widelands/widelands/src/website/website_common.cc:35] Unable to initialize SDL: No available video device.
1864 The command "./.travis.sh build" exited with 1.
```