### PR TITLE
Fix heap use after free in ShipFleet

### DIFF
--- a/src/economy/ship_fleet.cc
+++ b/src/economy/ship_fleet.cc
@@ -412,8 +412,8 @@ void ShipFleet::remove_ship(EditorGameBase& egbase, Ship* ship) {
 		ships_.pop_back();
 		it = std::find(ships_.begin(), ships_.end(), ship);
 		if (it != ships_.end()) {
-			log_err_time(egbase.get_gametime(),
-			             "Multiple instances of the same ship were in the ship fleet\n");
+			log_err_time(
+			   egbase.get_gametime(), "Multiple instances of the same ship were in the ship fleet\n");
 		}
 	}
 	assert(std::count(ships_.begin(), ships_.end(), ship) == 0);


### PR DESCRIPTION
I can only reproduce the issue by loading this old savegame saved using the Amazons branch and then quitting: [406.wgf.zip](https://github.com/widelands/widelands/files/5198430/406.wgf.zip) It still loads in master though.

The change to `object_still_available()` in 0de9148ec8c1c2598c25c10dff4b6fd9d083797f made the old workaround not work anymore. I investigated what was causing the problem and found out that two instances of the same ship were in one ShipFleet. When cleaning up only one was being removed, the other becoming a dangling pointer.