### PR TITLE
Fix ImageCache/FontHandler initialization order

### DIFF
--- a/src/graphic/font_handler.cc
+++ b/src/graphic/font_handler.cc
@@ -74,6 +74,7 @@ public:
 	     fontset_(fontsets_.get_fontset(locale)),
 	     rt_renderer_(new RT::Renderer(image_cache, texture_cache_.get(), fontsets_)),
 	     image_cache_(image_cache) {
+		assert(image_cache);
 	}
 	~FontHandler() override {
 	}

--- a/src/graphic/graphic.cc
+++ b/src/graphic/graphic.cc
@@ -69,6 +69,8 @@ void set_icon(SDL_Window* sdl_window) {
 }  // namespace
 
 Graphic::Graphic() {
+	g_image_cache = new ImageCache();
+	g_animation_manager = new AnimationManager();
 }
 
 /**
@@ -136,11 +138,9 @@ void Graphic::initialize(const TraceGl& trace_gl,
 
 	std::map<std::string, std::unique_ptr<Texture>> textures_in_atlas;
 	auto texture_atlases = build_texture_atlas(max_texture_size_, &textures_in_atlas);
-	g_image_cache = new ImageCache();
 	g_image_cache->fill_with_texture_atlases(
 	   std::move(texture_atlases), std::move(textures_in_atlas));
 	g_style_manager = new StyleManager();
-	g_animation_manager = new AnimationManager();
 }
 
 Graphic::~Graphic() {

--- a/src/graphic/text/rt_render.cc
+++ b/src/graphic/text/rt_render.cc
@@ -1790,6 +1790,7 @@ Renderer::Renderer(ImageCache* image_cache,
      texture_cache_(texture_cache),
      fontsets_(fontsets),
      renderer_style_("sans", 16, INFINITE_WIDTH, INFINITE_WIDTH) {
+	assert(image_cache);
 	TextureCache* render(const std::string&, uint16_t, const TagSet&);
 }
 


### PR DESCRIPTION
image_cache=nullptr was being passed when creating FontHandler, causing a crash when viewing the "Expedition Ready" message.

Fix #4210
Fix #4248
Fix #4251

Sorry for the slow fix, I didn't realize it was my fault...