### PR TITLE
Fix link to starting conditions for tutorial1

### DIFF
--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/starting_conditions.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/starting_conditions.lua
@@ -5,5 +5,5 @@
 plr:allow_buildings("all")
 
 -- A default headquarters
-include "tribes/scripting/starting_conditions/barbarians/headquarters.lua"
+include "tribes/initialization/barbarians/starting_conditions/headquarters.lua"
 init.func(plr) -- defined in headquarters


### PR DESCRIPTION
Fixes https://github.com/widelands/widelands/issues/4250

This is the only scenario affected by the new location of the staring conditions.