### PR TITLE
Fix Codecheck <cstdlib> error message

### DIFF
--- a/cmake/codecheck/rules/include_cstdlib.py
+++ b/cmake/codecheck/rules/include_cstdlib.py
@@ -20,7 +20,7 @@ def does_include_cstdlib(lines, fn):
 
         matches = []
         for match in FUNCTION_REGEX.findall(line):
-            matches.append(match[1])
+            matches.append(match[0])
 
         if matches and not includes_cstdlib:
             return [(fn, lineno,

--- a/cmake/codecheck/rules/include_cstdlib.py
+++ b/cmake/codecheck/rules/include_cstdlib.py
@@ -20,7 +20,7 @@ def does_include_cstdlib(lines, fn):
 
         matches = []
         for match in FUNCTION_REGEX.findall(line):
-            matches.append(match[0])
+            matches.append(match[0].strip())
 
         if matches and not includes_cstdlib:
             return [(fn, lineno,

--- a/src/ui_basic/progresswindow.cc
+++ b/src/ui_basic/progresswindow.cc
@@ -19,6 +19,7 @@
 
 #include "ui_basic/progresswindow.h"
 
+#include <cstdlib>
 #include <memory>
 #ifndef _MSC_VER
 #include <sys/time.h>

--- a/src/ui_fsmenu/main.cc
+++ b/src/ui_fsmenu/main.cc
@@ -19,6 +19,8 @@
 
 #include "ui_fsmenu/main.h"
 
+#include <cstdlib>
+
 #include <SDL_timer.h>
 
 #include "base/i18n.h"


### PR DESCRIPTION
- Fix Codecheck <cstdlib> error message - it didn't print the function name correctly.
- Add missing <cstdlib> includes.