### PR TITLE
Faster minimap previews

### DIFF
--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -193,14 +193,14 @@ const World& EditorGameBase::world() const {
 	return *const_cast<EditorGameBase*>(this)->mutable_world();
 }
 
-World* EditorGameBase::mutable_world() {
+World* EditorGameBase::mutable_world(bool render_only) {
 	if (!world_) {
 		// Lazy initialization of World. We need to create the pointer to the
 		// world immediately though, because the lua scripts need to have access
 		// to world through this method already.
 		ScopedTimer timer("Registering the world took %ums");
 		Notifications::publish(UI::NoteLoadingMessage(_("Loading world…")));
-		world_.reset(new World(description_manager_.get()));
+		world_.reset(new World(description_manager_.get(), render_only));
 	}
 	return world_.get();
 }

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -210,7 +210,8 @@ public:
 	const World& world() const;
 
 	// Returns the world that can be modified. Prefer world() whenever possible.
-	World* mutable_world();
+	// Use render_only to speed up registering during world initialization
+	World* mutable_world(bool render_only = false);
 
 	// Returns the tribes.
 	const Tribes& tribes() const;

--- a/src/logic/map_objects/world/world.cc
+++ b/src/logic/map_objects/world/world.cc
@@ -34,7 +34,7 @@
 
 namespace Widelands {
 
-World::World(DescriptionManager* description_manager)
+World::World(DescriptionManager* description_manager, bool render_only)
    : critters_(new DescriptionMaintainer<CritterDescr>()),
      immovables_(new DescriptionMaintainer<ImmovableDescr>()),
      terrains_(new DescriptionMaintainer<TerrainDescription>()),
@@ -42,8 +42,14 @@ World::World(DescriptionManager* description_manager)
 
      description_manager_(description_manager) {
 
-	// Walk world directory and register objects
-	description_manager_->register_directory("world", g_fs, false);
+	if (render_only) {
+		// Only register objects required for rendering
+		description_manager_->register_directory("world/terrains", g_fs, false);
+		description_manager_->register_directory("world/resources", g_fs, false);
+	} else {
+		// Walk world directory and register objects
+		description_manager_->register_directory("world", g_fs, false);
+	}
 }
 
 void World::add_world_object_type(const LuaTable& table, MapObjectType type) {

--- a/src/logic/map_objects/world/world.h
+++ b/src/logic/map_objects/world/world.h
@@ -39,7 +39,7 @@ class TerrainDescription;
 /// terrains, immovables and resources.
 class World {
 public:
-	World(DescriptionManager* description_manager);
+	World(DescriptionManager* description_manager, bool render_only = false);
 	~World() = default;
 
 	/// Add a world object type to the world.

--- a/src/ui_fsmenu/loadgame.cc
+++ b/src/ui_fsmenu/loadgame.cc
@@ -53,6 +53,7 @@ FullscreenMenuLoadGame::FullscreenMenuLoadGame(Widelands::Game& g,
                    true),
 
      is_replay_(is_replay),
+     update_game_details_(false),
      showing_filenames_(false) {
 
 	// Make sure that we have some space to work with.
@@ -80,7 +81,6 @@ FullscreenMenuLoadGame::FullscreenMenuLoadGame(Widelands::Game& g,
 	layout();
 
 	ok_.set_enabled(false);
-	set_thinks(false);
 
 	if (is_replay_) {
 		back_.set_tooltip(_("Return to the main menu"));
@@ -107,6 +107,14 @@ FullscreenMenuLoadGame::FullscreenMenuLoadGame(Widelands::Game& g,
 	}
 
 	load_or_save_.table().cancel.connect([this]() { clicked_back(); });
+}
+
+void FullscreenMenuLoadGame::think() {
+	if (update_game_details_) {
+		// Call performance heavy draw_minimap function only during think
+		update_game_details_ = false;
+		load_or_save_.entry_selected();
+	}
 }
 
 void FullscreenMenuLoadGame::layout() {
@@ -158,7 +166,8 @@ void FullscreenMenuLoadGame::entry_selected() {
 	ok_.set_enabled(load_or_save_.table().selections().size() == 1);
 	load_or_save_.delete_button()->set_enabled(load_or_save_.has_selection());
 	if (load_or_save_.has_selection()) {
-		load_or_save_.entry_selected();
+		// Update during think() instead of every keypress
+		update_game_details_ = true;
 	}
 }
 

--- a/src/ui_fsmenu/loadgame.cc
+++ b/src/ui_fsmenu/loadgame.cc
@@ -110,6 +110,8 @@ FullscreenMenuLoadGame::FullscreenMenuLoadGame(Widelands::Game& g,
 }
 
 void FullscreenMenuLoadGame::think() {
+	FullscreenMenuLoadMapOrGame::think();
+
 	if (update_game_details_) {
 		// Call performance heavy draw_minimap function only during think
 		update_game_details_ = false;

--- a/src/ui_fsmenu/loadgame.cc
+++ b/src/ui_fsmenu/loadgame.cc
@@ -166,10 +166,11 @@ void FullscreenMenuLoadGame::clicked_ok() {
 
 void FullscreenMenuLoadGame::entry_selected() {
 	ok_.set_enabled(load_or_save_.table().selections().size() == 1);
-	load_or_save_.delete_button()->set_enabled(load_or_save_.has_selection());
 	if (load_or_save_.has_selection()) {
 		// Update during think() instead of every keypress
 		update_game_details_ = true;
+	} else {
+		load_or_save_.delete_button()->set_enabled(false);
 	}
 }
 

--- a/src/ui_fsmenu/loadgame.h
+++ b/src/ui_fsmenu/loadgame.h
@@ -38,6 +38,7 @@ public:
 	const std::string& filename() const;
 
 	bool handle_key(bool down, SDL_Keysym code) override;
+	void think() override;
 
 protected:
 	/// Sets the current selected filename and ends the modal screen with 'Ok' status.
@@ -64,6 +65,7 @@ private:
 	std::string filename_;
 
 	bool is_replay_;
+	bool update_game_details_;
 
 	UI::Checkbox* show_filenames_;
 	bool showing_filenames_;

--- a/src/ui_fsmenu/mapselect.cc
+++ b/src/ui_fsmenu/mapselect.cc
@@ -183,6 +183,8 @@ void FullscreenMenuMapSelect::layout() {
 }
 
 void FullscreenMenuMapSelect::think() {
+	FullscreenMenuLoadMapOrGame::think();
+
 	if (ctrl_) {
 		ctrl_->think();
 	}

--- a/src/ui_fsmenu/mapselect.cc
+++ b/src/ui_fsmenu/mapselect.cc
@@ -66,7 +66,8 @@ FullscreenMenuMapSelect::FullscreenMenuMapSelect(GameSettingsProvider* const set
      settings_(settings),
      ctrl_(ctrl),
      has_translated_mapname_(false),
-     unspecified_balancing_found_(false) {
+     unspecified_balancing_found_(false),
+     update_map_details_(false) {
 	curdir_ = basedir_;
 	if (settings_->settings().multiplayer) {
 		back_.set_tooltip(_("Return to the multiplayer game setup"));
@@ -185,6 +186,13 @@ void FullscreenMenuMapSelect::think() {
 	if (ctrl_) {
 		ctrl_->think();
 	}
+
+	if (update_map_details_) {
+		// Call performance heavy draw_minimap function only during think
+		update_map_details_ = false;
+		map_details_.update(
+		   maps_data_[table_.get_selected()], !cb_dont_localize_mapnames_->get_state());
+	}
 }
 
 bool FullscreenMenuMapSelect::compare_players(uint32_t rowa, uint32_t rowb) {
@@ -236,8 +244,8 @@ bool FullscreenMenuMapSelect::set_has_selection() {
 
 void FullscreenMenuMapSelect::entry_selected() {
 	if (set_has_selection()) {
-		map_details_.update(
-		   maps_data_[table_.get_selected()], !cb_dont_localize_mapnames_->get_state());
+		// Update during think() instead of every keypress
+		update_map_details_ = true;
 	}
 }
 

--- a/src/ui_fsmenu/mapselect.h
+++ b/src/ui_fsmenu/mapselect.h
@@ -96,6 +96,8 @@ private:
 	std::set<uint32_t> req_tags_;
 
 	std::vector<MapData> maps_data_;
+
+	bool update_map_details_;
 };
 
 #endif  // end of include guard: WL_UI_FSMENU_MAPSELECT_H

--- a/src/wui/gamedetails.cc
+++ b/src/wui/gamedetails.cc
@@ -202,7 +202,7 @@ void GameDetails::show_minimap(const SavegameData& gamedata) {
 			   minimap_path,
 			   std::unique_ptr<FileSystem>(g_fs->make_sub_file_system(gamedata.filename)).get());
 			minimap_icon_.set_visible(true);
-			minimap_icon_.set_icon(minimap_cache_[gamedata.filename].get());
+			minimap_icon_.set_icon(minimap_cache_.at(gamedata.filename).get());
 		} catch (const std::exception& e) {
 			log_err("Failed to load the minimap image : %s\n", e.what());
 		}
@@ -222,7 +222,7 @@ void GameDetails::show_minimap(const SavegameData& gamedata) {
 				minimap_cache_[gamedata.filename] =
 				   draw_minimap(egbase_, nullptr, Rectf(), MiniMapType::kStaticMap,
 				                MiniMapLayer::Terrain | MiniMapLayer::StartingPositions);
-				minimap_icon_.set_icon(minimap_cache_[gamedata.filename].get());
+				minimap_icon_.set_icon(minimap_cache_.at(gamedata.filename).get());
 				minimap_icon_.set_visible(true);
 			}
 		}
@@ -246,11 +246,11 @@ void GameDetails::layout() {
 		   get_h() - name_label_.get_h() - descr_.get_h() - button_box_->get_h() - 4 * padding_;
 
 		const float scale =
-		   std::min(1.f, std::min<float>(available_width / minimap_cache_[last_game_]->width(),
-		                                 available_height / minimap_cache_[last_game_]->height()));
+		   std::min(1.f, std::min<float>(available_width / minimap_cache_.at(last_game_)->width(),
+		                                 available_height / minimap_cache_.at(last_game_)->height()));
 
-		const int w = scale * minimap_cache_[last_game_]->width();
-		const int h = scale * minimap_cache_[last_game_]->height();
+		const int w = scale * minimap_cache_.at(last_game_)->width();
+		const int h = scale * minimap_cache_.at(last_game_)->height();
 
 		// Center the minimap in the available space
 		const int xpos = (get_w() - w) / 2;

--- a/src/wui/gamedetails.cc
+++ b/src/wui/gamedetails.cc
@@ -132,10 +132,6 @@ void GameDetails::show(const std::vector<SavegameData>& gamedata) {
 }
 
 void GameDetails::show(const SavegameData& gamedata) {
-	if (last_game_ == gamedata.filename) {
-		return;
-	}
-
 	clear();
 	last_game_ = gamedata.filename;
 	if (gamedata.is_directory()) {

--- a/src/wui/gamedetails.cc
+++ b/src/wui/gamedetails.cc
@@ -60,6 +60,7 @@ GameDetails::GameDetails(Panel* parent, UI::PanelStyle style, Mode mode)
             UI::MultilineTextarea::ScrollMode::kNoScrolling),
      minimap_icon_(this, 0, 0, 0, 0, nullptr),
      button_box_(new UI::Box(this, 0, 0, UI::Box::Vertical)),
+     last_game_(""),
      egbase_(nullptr) {
 
 	add(&name_label_, UI::Box::Resizing::kFullSize);
@@ -72,6 +73,9 @@ GameDetails::GameDetails(Panel* parent, UI::PanelStyle style, Mode mode)
 
 	minimap_icon_.set_visible(false);
 	minimap_icon_.set_frame(g_style_manager->minimap_icon_frame());
+
+	// Fast initialize world now
+	egbase_.mutable_world(true);
 }
 
 void GameDetails::clear() {
@@ -129,8 +133,12 @@ void GameDetails::show(const std::vector<SavegameData>& gamedata) {
 }
 
 void GameDetails::show(const SavegameData& gamedata) {
-	clear();
+	if (last_game_ == gamedata.filename) {
+		return;
+	}
 
+	clear();
+	last_game_ = gamedata.filename;
 	if (gamedata.is_directory()) {
 		name_label_.set_text(as_richtext(
 		   as_heading_with_content(_("Directory Name:"), gamedata.filename, style_, true)));

--- a/src/wui/gamedetails.h
+++ b/src/wui/gamedetails.h
@@ -68,6 +68,7 @@ private:
 	UI::Icon minimap_icon_;
 	std::unique_ptr<const Texture> minimap_image_;
 	UI::Box* button_box_;
+	std::string last_game_;
 
 	// Used to render map preview
 	Widelands::EditorGameBase egbase_;

--- a/src/wui/gamedetails.h
+++ b/src/wui/gamedetails.h
@@ -66,11 +66,11 @@ private:
 	UI::MultilineTextarea name_label_;
 	UI::MultilineTextarea descr_;
 	UI::Icon minimap_icon_;
-	std::unique_ptr<const Texture> minimap_image_;
 	UI::Box* button_box_;
-	std::string last_game_;
 
 	// Used to render map preview
+	std::string last_game_;
+	std::unordered_map<std::string, std::unique_ptr<const Texture>> minimap_cache_;
 	Widelands::EditorGameBase egbase_;
 };
 

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -105,9 +105,9 @@ void MapDetails::layout() {
 	} else {
 		// Fit minimap to width
 		const int width = std::min<int>(main_box_.get_w() - UI::Scrollbar::kSize - 2 * padding_,
-		                                minimap_cache_[last_map_]->width());
-		const float scale = static_cast<float>(width) / minimap_cache_[last_map_]->width();
-		const int height = scale * minimap_cache_[last_map_]->height();
+		                                minimap_cache_.at(last_map_)->width());
+		const float scale = static_cast<float>(width) / minimap_cache_.at(last_map_)->width();
+		const int height = scale * minimap_cache_.at(last_map_)->height();
 
 		minimap_icon_.set_desired_size(width, height);
 	}
@@ -205,7 +205,7 @@ void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
 				minimap_cache_[last_map_] = draw_minimap(
 				   egbase_, nullptr, Rectf(), MiniMapType::kStaticMap,
 				   MiniMapLayer::Terrain | MiniMapLayer::StartingPositions | MiniMapLayer::Owner);
-				minimap_icon_.set_icon(minimap_cache_[last_map_].get());
+				minimap_icon_.set_icon(minimap_cache_.at(last_map_).get());
 				minimap_icon_.set_visible(true);
 			}
 		}

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -61,6 +61,7 @@ MapDetails::MapDetails(
             UI::MultilineTextarea::ScrollMode::kNoScrolling),
      minimap_icon_(&descr_box_, 0, 0, 0, 0, nullptr),
      suggested_teams_box_(new UI::SuggestedTeamsBox(this, 0, 0, UI::Box::Vertical, padding_, 0)),
+     last_map_(nullptr),
      egbase_(nullptr) {
 
 	minimap_icon_.set_frame(g_style_manager->minimap_icon_frame());
@@ -74,6 +75,9 @@ MapDetails::MapDetails(
 	main_box_.add(&name_label_, UI::Box::Resizing::kFullSize);
 	main_box_.add_space(padding_);
 	main_box_.add(&descr_box_, UI::Box::Resizing::kExpandBoth);
+
+	// Fast initialize world now
+	egbase_.mutable_world(true);
 
 	layout();
 }
@@ -113,8 +117,13 @@ void MapDetails::layout() {
 }
 
 void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
+	if (last_map_ == &mapdata) {
+		return;
+	}
+
 	clear();
 	name_ = mapdata.name;
+	last_map_ = &mapdata;
 	// Show directory information
 	if (mapdata.maptype == MapData::MapType::kDirectory) {
 		name_label_.set_text(

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -116,10 +116,6 @@ void MapDetails::layout() {
 }
 
 void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
-	if (last_map_ == mapdata.filename) {
-		return;
-	}
-
 	clear();
 	name_ = mapdata.name;
 	last_map_ = mapdata.filename;

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -61,7 +61,7 @@ MapDetails::MapDetails(
             UI::MultilineTextarea::ScrollMode::kNoScrolling),
      minimap_icon_(&descr_box_, 0, 0, 0, 0, nullptr),
      suggested_teams_box_(new UI::SuggestedTeamsBox(this, 0, 0, UI::Box::Vertical, padding_, 0)),
-     last_map_(nullptr),
+     last_map_(""),
      egbase_(nullptr) {
 
 	minimap_icon_.set_frame(g_style_manager->minimap_icon_frame());
@@ -88,7 +88,6 @@ void MapDetails::clear() {
 	minimap_icon_.set_icon(nullptr);
 	minimap_icon_.set_visible(false);
 	minimap_icon_.set_size(0, 0);
-	minimap_image_.reset();
 	suggested_teams_box_->hide();
 }
 
@@ -105,10 +104,10 @@ void MapDetails::layout() {
 		minimap_icon_.set_desired_size(0, 0);
 	} else {
 		// Fit minimap to width
-		const int width = std::min<int>(
-		   main_box_.get_w() - UI::Scrollbar::kSize - 2 * padding_, minimap_image_->width());
-		const float scale = static_cast<float>(width) / minimap_image_->width();
-		const int height = scale * minimap_image_->height();
+		const int width = std::min<int>(main_box_.get_w() - UI::Scrollbar::kSize - 2 * padding_,
+		                                minimap_cache_[last_map_]->width());
+		const float scale = static_cast<float>(width) / minimap_cache_[last_map_]->width();
+		const int height = scale * minimap_cache_[last_map_]->height();
 
 		minimap_icon_.set_desired_size(width, height);
 	}
@@ -117,13 +116,13 @@ void MapDetails::layout() {
 }
 
 void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
-	if (last_map_ == &mapdata) {
+	if (last_map_ == mapdata.filename) {
 		return;
 	}
 
 	clear();
 	name_ = mapdata.name;
-	last_map_ = &mapdata;
+	last_map_ = mapdata.filename;
 	// Show directory information
 	if (mapdata.maptype == MapData::MapType::kDirectory) {
 		name_label_.set_text(
@@ -198,15 +197,21 @@ void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
 		descr_.set_text(as_richtext(description));
 
 		// Render minimap
-		egbase_.cleanup_for_load();
-		std::unique_ptr<Widelands::MapLoader> ml(
-		   egbase_.mutable_map()->get_correct_loader(mapdata.filename));
-		if (ml.get() && 0 == ml->load_map_for_render(egbase_)) {
-			minimap_image_ = draw_minimap(
-			   egbase_, nullptr, Rectf(), MiniMapType::kStaticMap,
-			   MiniMapLayer::Terrain | MiniMapLayer::StartingPositions | MiniMapLayer::Owner);
-			minimap_icon_.set_icon(minimap_image_.get());
+		auto minimap = minimap_cache_.find(last_map_);
+		if (minimap != minimap_cache_.end()) {
+			minimap_icon_.set_icon(minimap->second.get());
 			minimap_icon_.set_visible(true);
+		} else {
+			egbase_.cleanup_for_load();
+			std::unique_ptr<Widelands::MapLoader> ml(
+			   egbase_.mutable_map()->get_correct_loader(mapdata.filename));
+			if (ml.get() && 0 == ml->load_map_for_render(egbase_)) {
+				minimap_cache_[last_map_] = draw_minimap(
+				   egbase_, nullptr, Rectf(), MiniMapType::kStaticMap,
+				   MiniMapLayer::Terrain | MiniMapLayer::StartingPositions | MiniMapLayer::Owner);
+				minimap_icon_.set_icon(minimap_cache_[last_map_].get());
+				minimap_icon_.set_visible(true);
+			}
 		}
 
 		// Show / hide suggested teams

--- a/src/wui/mapdetails.h
+++ b/src/wui/mapdetails.h
@@ -54,6 +54,7 @@ private:
 	UI::MultilineTextarea descr_;
 	UI::Icon minimap_icon_;
 	UI::SuggestedTeamsBox* suggested_teams_box_;
+	const MapData* last_map_;
 
 	// Used to render map preview
 	std::unique_ptr<const Texture> minimap_image_;

--- a/src/wui/mapdetails.h
+++ b/src/wui/mapdetails.h
@@ -54,10 +54,10 @@ private:
 	UI::MultilineTextarea descr_;
 	UI::Icon minimap_icon_;
 	UI::SuggestedTeamsBox* suggested_teams_box_;
-	const MapData* last_map_;
 
 	// Used to render map preview
-	std::unique_ptr<const Texture> minimap_image_;
+	std::string last_map_;
+	std::unordered_map<std::string, std::unique_ptr<const Texture>> minimap_cache_;
 	Widelands::EditorGameBase egbase_;
 };
 


### PR DESCRIPTION
Fixes #4295 for map and save/replay selection.
Speeds up world registering by only loading terrain and resource data.
Stores rendered maps in a cache (unordered_map).
Maps are rendered during think() to keep UI responsive when scrolling through the list using arrow keys.