### PR TITLE
Handle GameDataError during preview rendering

### DIFF
--- a/src/ui_fsmenu/mapselect.cc
+++ b/src/ui_fsmenu/mapselect.cc
@@ -192,8 +192,9 @@ void FullscreenMenuMapSelect::think() {
 	if (update_map_details_) {
 		// Call performance heavy draw_minimap function only during think
 		update_map_details_ = false;
-		map_details_.update(
+		bool loadable = map_details_.update(
 		   maps_data_[table_.get_selected()], !cb_dont_localize_mapnames_->get_state());
+		ok_.set_enabled(loadable && maps_data_.at(table_.get_selected()).nrplayers > 0);
 	}
 }
 
@@ -225,6 +226,8 @@ void FullscreenMenuMapSelect::clicked_ok() {
 	if (!mapdata.width) {
 		curdir_ = mapdata.filename;
 		fill_table();
+	} else if (!ok_.enabled()) {
+		return;
 	} else {
 		if (maps_data_[table_.get_selected()].maptype == MapData::MapType::kScenario) {
 			end_modal<FullscreenMenuBase::MenuTarget>(FullscreenMenuBase::MenuTarget::kScenarioGame);
@@ -236,9 +239,9 @@ void FullscreenMenuMapSelect::clicked_ok() {
 
 bool FullscreenMenuMapSelect::set_has_selection() {
 	bool has_selection = table_.has_selection();
-	ok_.set_enabled(has_selection && maps_data_.at(table_.get_selected()).nrplayers > 0);
 
 	if (!has_selection) {
+		ok_.set_enabled(false);
 		map_details_.clear();
 	}
 	return has_selection;

--- a/src/wui/CMakeLists.txt
+++ b/src/wui/CMakeLists.txt
@@ -133,6 +133,7 @@ wl_library(wui_common_mapdetails
     graphic_text_layout
     io_filesystem
     logic
+    logic_exceptions
     logic_game_settings
     logic_map
     map_io_map_loader

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -26,6 +26,7 @@
 #include "graphic/minimap_renderer.h"
 #include "graphic/text_layout.h"
 #include "io/filesystem/layered_filesystem.h"
+#include "logic/game_data_error.h"
 #include "logic/game_settings.h"
 #include "map_io/map_loader.h"
 #include "ui_basic/box.h"
@@ -115,10 +116,11 @@ void MapDetails::layout() {
 	descr_box_.set_size(main_box_.get_w(), main_box_.get_h() - name_label_.get_h() - padding_);
 }
 
-void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
+bool MapDetails::update(const MapData& mapdata, bool localize_mapname) {
 	clear();
 	name_ = mapdata.name;
 	last_map_ = mapdata.filename;
+	bool loadable = true;
 	// Show directory information
 	if (mapdata.maptype == MapData::MapType::kDirectory) {
 		name_label_.set_text(
@@ -190,8 +192,6 @@ void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
 			   (boost::format("%s%s") % description % as_content(mapdata.hint, style_)).str();
 		}
 
-		descr_.set_text(as_richtext(description));
-
 		// Render minimap
 		auto minimap = minimap_cache_.find(last_map_);
 		if (minimap != minimap_cache_.end()) {
@@ -201,14 +201,26 @@ void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
 			egbase_.cleanup_for_load();
 			std::unique_ptr<Widelands::MapLoader> ml(
 			   egbase_.mutable_map()->get_correct_loader(mapdata.filename));
-			if (ml.get() && 0 == ml->load_map_for_render(egbase_)) {
-				minimap_cache_[last_map_] = draw_minimap(
-				   egbase_, nullptr, Rectf(), MiniMapType::kStaticMap,
-				   MiniMapLayer::Terrain | MiniMapLayer::StartingPositions | MiniMapLayer::Owner);
-				minimap_icon_.set_icon(minimap_cache_.at(last_map_).get());
-				minimap_icon_.set_visible(true);
+			try {
+				if (ml.get() && 0 == ml->load_map_for_render(egbase_)) {
+					minimap_cache_[last_map_] = draw_minimap(
+					   egbase_, nullptr, Rectf(), MiniMapType::kStaticMap,
+					   MiniMapLayer::Terrain | MiniMapLayer::StartingPositions | MiniMapLayer::Owner);
+					minimap_icon_.set_icon(minimap_cache_.at(last_map_).get());
+					minimap_icon_.set_visible(true);
+				}
+			} catch (const Widelands::GameDataError& e) {
+				// Put error message on top for better visibility
+				description =
+				   (boost::format("%s%s") % as_content(e.what(), style_) % description).str();
+				description =
+				   (boost::format("%s%s") % as_heading(_("Game data error"), style_) % description)
+				      .str();
+				loadable = false;
 			}
 		}
+
+		descr_.set_text(as_richtext(description));
 
 		// Show / hide suggested teams
 		if (mapdata.suggested_teams.empty()) {
@@ -220,4 +232,5 @@ void MapDetails::update(const MapData& mapdata, bool localize_mapname) {
 		}
 	}
 	layout();
+	return loadable;
 }

--- a/src/wui/mapdetails.h
+++ b/src/wui/mapdetails.h
@@ -37,7 +37,7 @@ public:
 	MapDetails(UI::Panel* parent, int32_t x, int32_t y, int32_t w, int32_t h, UI::PanelStyle style);
 
 	void clear();
-	void update(const MapData& mapdata, bool localize_mapname);
+	bool update(const MapData& mapdata, bool localize_mapname);
 	std::string name() {
 		return name_;
 	}


### PR DESCRIPTION
Fixes #4306 by showing the error message in the map detail section and disabling the Ok button.