### PR TITLE
revert checkbox

### DIFF
--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -46,8 +46,7 @@ Statebox::Statebox(Panel* const parent,
    : Panel(parent, p.x, p.y, kStateboxSize, kStateboxSize, tooltip_text),
      flags_(Is_Enabled),
      pic_graphics_(pic),
-     rendered_text_(nullptr),
-     rendered_width_(0) {
+     rendered_text_(nullptr) {
 	uint16_t w = pic->width();
 	uint16_t h = pic->height();
 	set_desired_size(w, h);
@@ -73,7 +72,7 @@ Statebox::Statebox(Panel* const parent,
 
 void Statebox::layout() {
 	// We only need to relayout if we have text and the available width changed
-	if ((flags_ & Has_Text) && (rendered_width_ != get_w())) {
+	if ((flags_ & Has_Text)) {
 		int w = get_w();
 		int h = kStateboxSize;
 		int pic_width = kStateboxSize;
@@ -84,16 +83,15 @@ void Statebox::layout() {
 		}
 		rendered_text_ =
 		   label_text_.empty() ?
-		      nullptr :
-		      UI::g_fh->render(as_richtext_paragraph(label_text_, UI::FontStyle::kLabel),
+            nullptr :
+            UI::g_fh->render(as_richtext_paragraph(label_text_, UI::FontStyle::kLabel),
 		                       text_width(get_w(), pic_width));
 		if (rendered_text_) {
 			w = std::max(rendered_text_->width() + kPadding + pic_width, w);
 			h = std::max(rendered_text_->height(), h);
 		}
-		rendered_width_ = w;
-		set_desired_size(rendered_width_, h);
-		set_size(rendered_width_, h);
+		set_desired_size(w, h);
+		set_size(w, h);
 	}
 }
 
@@ -113,7 +111,7 @@ void Statebox::set_enabled(bool const enabled) {
 
 	if (!(flags_ & Has_Custom_Picture)) {
 		pic_graphics_ = g_image_cache->get(enabled ? "images/ui_basic/checkbox_light.png" :
-		                                             "images/ui_basic/checkbox.png");
+                                                   "images/ui_basic/checkbox.png");
 		set_flags(Is_Highlighted, (flags_ & Is_Highlighted) && (flags_ & Is_Enabled));
 	}
 }

--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -83,8 +83,8 @@ void Statebox::layout() {
 		}
 		rendered_text_ =
 		   label_text_.empty() ?
-            nullptr :
-            UI::g_fh->render(as_richtext_paragraph(label_text_, UI::FontStyle::kLabel),
+		      nullptr :
+		      UI::g_fh->render(as_richtext_paragraph(label_text_, UI::FontStyle::kLabel),
 		                       text_width(get_w(), pic_width));
 		if (rendered_text_) {
 			w = std::max(rendered_text_->width() + kPadding + pic_width, w);
@@ -110,7 +110,7 @@ void Statebox::set_enabled(bool const enabled) {
 
 	if (!(flags_ & Has_Custom_Picture)) {
 		pic_graphics_ = g_image_cache->get(enabled ? "images/ui_basic/checkbox_light.png" :
-                                                   "images/ui_basic/checkbox.png");
+		                                             "images/ui_basic/checkbox.png");
 		set_flags(Is_Highlighted, (flags_ & Is_Highlighted) && (flags_ & Is_Enabled));
 	}
 }

--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -91,7 +91,6 @@ void Statebox::layout() {
 			h = std::max(rendered_text_->height(), h);
 		}
 		set_desired_size(w, h);
-		set_size(w, h);
 	}
 }
 

--- a/src/ui_basic/checkbox.h
+++ b/src/ui_basic/checkbox.h
@@ -94,7 +94,6 @@ private:
 	const Image* pic_graphics_;
 	std::shared_ptr<const UI::RenderedText> rendered_text_;
 	const std::string label_text_;
-	int32_t rendered_width_;
 };
 
 /**


### PR DESCRIPTION
Remove a check in Checkbox which hinders layouting when needed, see screenshots.
This was introduced with 4e9992f3a36ef5b04395a9ee5d67639d15c4b76f and I do not know/understand why @matthiakl @Noordfrees 

Before:
![grafik](https://user-images.githubusercontent.com/10723431/95021673-b05f3500-0672-11eb-8807-5098a608e998.png)


After:
![grafik](https://user-images.githubusercontent.com/10723431/95021567-f8318c80-0671-11eb-9a62-74e297e8e39c.png)
