### PR TITLE
Fast fix for the drop up menu bug #4341 

### DIFF
--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
@@ -71,12 +71,8 @@ end
 
 function select_item_from_dropdown(name, item)
    local blocker = UserInputDisabler:new()
-
-   wl.ui.MapView().dropdowns[name]:highlight_item(item)
-   sleep(5000)
    wl.ui.MapView().dropdowns[name]:select()
    sleep(3000)
-
    blocker:lift_blocks()
 end
 

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
@@ -84,6 +84,19 @@ function open_item_from_dropdown(name, item)
    wl.ui.MapView().dropdowns[name]:open(item)
 end
 
+function show_item_from_dropdown(name, item)
+   local blocker = UserInputDisabler:new()
+   local ind = wl.ui.MapView().dropdowns[name]:get_no_of_items()
+   wl.ui.MapView().dropdowns[name]:highlight_item(ind)
+   sleep(500)
+   while ind >= item do
+      wl.ui.MapView().dropdowns[name]:highlight_item(ind)
+      ind = ind - 1
+      sleep(300)
+   end
+   blocker:lift_blocks()
+end
+
 -- Make sure the user is in road building mode starting from the given flag
 function enter_road_building_mode(flag)
    local mv = wl.ui.MapView()

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
@@ -82,7 +82,7 @@ end
 
 function show_item_from_dropdown(name, item)
    local blocker = UserInputDisabler:new()
-   local ind = wl.ui.MapView().dropdowns[name]:get_no_of_items()
+   local ind = wl.ui.MapView().dropdowns[name].no_of_items
    wl.ui.MapView().dropdowns[name]:highlight_item(ind)
    sleep(500)
    while ind >= item do

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/helper_functions_demonstration.lua
@@ -80,6 +80,10 @@ function select_item_from_dropdown(name, item)
    blocker:lift_blocks()
 end
 
+function open_item_from_dropdown(name, item)
+   wl.ui.MapView().dropdowns[name]:open(item)
+end
+
 -- Make sure the user is in road building mode starting from the given flag
 function enter_road_building_mode(flag)
    local mv = wl.ui.MapView()

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/mission_thread.lua
@@ -54,8 +54,7 @@ function starting_infos()
 
    -- Teach building spaces
    campaign_message_box(initial_message_02, 200)
-
-   open_item_from_dropdown("dropdown_menu_showhide", 1)
+   show_item_from_dropdown("dropdown_menu_showhide", 1)
    local o = campaign_message_with_objective(initial_message_03, obj_initial_toggle_building_spaces)
 
    -- Wait for buildhelp to come on

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/mission_thread.lua
@@ -151,7 +151,7 @@ function build_lumberjack()
    sleep(3000)
 
    campaign_message_box(lumberjack_message_08)
-   wl.ui.MapView().dropdowns["dropdown_menu_gamespeed"]:open()
+   show_item_from_dropdown("dropdown_menu_gamespeed", 1)
 
    sleep(20*1000) -- let the player experiment a bit with the window
 
@@ -186,6 +186,7 @@ function learn_to_move()
    campaign_message_box(tell_about_minimap_1)
 
    -- Open the minimap
+   show_item_from_dropdown("dropdown_menu_mapview", 1)
    select_item_from_dropdown("dropdown_menu_mapview", 1)
    o = campaign_message_with_objective(tell_about_minimap_2, obj_moving_minimap)
 
@@ -331,6 +332,7 @@ function census_and_statistics()
 
    campaign_message_box(census_and_statistics_00)
 
+   show_item_from_dropdown("dropdown_menu_showhide", 2)
    select_item_from_dropdown("dropdown_menu_showhide", 2)
    sleep(200)
 

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/mission_thread.lua
@@ -54,8 +54,8 @@ function starting_infos()
 
    -- Teach building spaces
    campaign_message_box(initial_message_02, 200)
-   select_item_from_dropdown("dropdown_menu_showhide", 1)
-   select_item_from_dropdown("dropdown_menu_showhide", 1)
+
+   open_item_from_dropdown("dropdown_menu_showhide", 1)
    local o = campaign_message_with_objective(initial_message_03, obj_initial_toggle_building_spaces)
 
    -- Wait for buildhelp to come on

--- a/data/campaigns/tutorial01_basic_control.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial01_basic_control.wmf/scripting/texts.lua
@@ -77,7 +77,7 @@ initial_message_02 = {
          _[[There are four different tribes in Widelands: the Barbarians, the Empire, the Atlanteans and the Frisians. All tribes have a different economy, strength and weaknesses, but the general gameplay is the same for all. We will play the Barbarians for now.]]) ..
       li_object("barbarians_headquarters", _[[You will usually start the game with one headquarters. This is the big building with the blue flag in front of it. The headquarters is a warehouse that stores wares, workers and soldiers. Some wares are needed for building houses, others for making other wares. Obviously, the wares in the headquarters will not last forever, so you must make sure to replace them. The most important wares in the early game are the basic construction wares: logs and granite. Let’s make sure that we do not run out of logs. For this, we need a lumberjack and a hut for him to stay in.]], plr.color) ..
       p(_[[We need to find a nice place for the lumberjack’s hut. To make this easier, we can activate ‘Show Building Spaces’.]]) ..
-      li(_[[Left-click the ‘OK’ button to close this window so that I can show you how.]]) ..
+      li(_[[Left-click the ‘OK’ button to close this window. I'll show you where the menu is and where to show and hide the building spaces.]]) ..
       li_arrow(_[[Note that you cannot close this window by right-clicking on it. I have blocked this so that you will not close it by accident and miss important information.]])
    )
 }
@@ -88,7 +88,7 @@ initial_message_03 = {
    field = sf,
    body = (
       h1(_"Let’s dive right in!") ..
-      li_object("barbarians_lumberjacks_hut", _[[Now that I have shown you how to show and hide the building spaces, please switch them on again so that we can place our first building.]], plr.color)
+      li_object("barbarians_lumberjacks_hut", _[[Now that I have shown you where to show and hide the building spaces, please switch them on so that we can place our first building.]], plr.color)
    )
 }
 

--- a/src/scripting/lua_ui.cc
+++ b/src/scripting/lua_ui.cc
@@ -367,6 +367,7 @@ const MethodType<LuaDropdown> LuaDropdown::Methods[] = {
    METHOD(LuaDropdown, open),
    METHOD(LuaDropdown, highlight_item),
    METHOD(LuaDropdown, select),
+   METHOD(LuaDropdown, get_no_of_items),
    {nullptr, nullptr},
 };
 const PropertyType<LuaDropdown> LuaDropdown::Properties[] = {

--- a/src/scripting/lua_ui.cc
+++ b/src/scripting/lua_ui.cc
@@ -367,7 +367,6 @@ const MethodType<LuaDropdown> LuaDropdown::Methods[] = {
    METHOD(LuaDropdown, open),
    METHOD(LuaDropdown, highlight_item),
    METHOD(LuaDropdown, select),
-   METHOD(LuaDropdown, get_no_of_items),
    {nullptr, nullptr},
 };
 const PropertyType<LuaDropdown> LuaDropdown::Properties[] = {


### PR DESCRIPTION
Here is my first solution for the bug #4341 
I created a new method that shows where the target button is and did minor changed to the texts. There is also an unused method that opens the menu only. It can be removed if needed.

The mouse pointer moves over the menu but not over to the button. Instead of moving the mouse pointer I tried to show the position of target menu item by highlighting the buttons step by step from bottom to up.

This is just a fist draft and I look forward to get some feedback.