### PR TITLE
Fix lua doc for custom buildings

### DIFF
--- a/data/campaigns/emp04.wmf/scripting/tribes/init.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/init.lua
@@ -62,7 +62,7 @@
 --       },
 --       frisians = {
 --          buildings = {
---             "frisians_warehouse1"
+--             { name = "frisians_warehouse1" }
 --          }
 --       }
 --    }


### PR DESCRIPTION
I got an error while working on my own scenario and it took me days to find the culprit. It was a wrong documentation in the lua docs, which i just copied and adopted. This leads to the error:

~~~~
[00:00:07.092 real] WARNING: Unused key "1" in LuaTable. Please report as a bug.
[00:00:07.092 real] INFO: ┗━ took 715ms
[00:00:07.093 real] WARNING: Unused key "animation_directory" in LuaTable. Please report as a bug.
[00:00:07.093 real] WARNING: Unused key "animations" in LuaTable. Please report as a bug.
[00:00:07.093 real] WARNING: Unused key "roads" in LuaTable. Please report as a bug.
[00:00:07.094 real] ERROR: Scenario not started: Game data error: Error while loading tribe 'atlanteans': [/home/kaputtnik/widelands-repo/widelands/src/scripting/lua_errors.cc:22] [/home/kaputtnik/widelands-repo/widelands/src/scripting/lua_errors.cc:22] Could not convert value at the top of the stack to table value.
[00:00:07.094 real] ERROR: stack traceback:
[00:00:07.094 real] ERROR:      [string "tribes/initialization/atlanteans/units.lua"]:265: in main chunk
[00:00:07.104 real] DEBUG: lastserial: 0
[00:00:07.316 real] DEBUG: SoundHandler: Closing 1 time, 22050 Hz, format 32784, 2 channels
[00:00:07.316 real] DEBUG: SoundHandler: SDL_AUDIODRIVER alsa
~~~~

This will fix the documentation. And finally i can work on :)