### PR TITLE
Fix memset compiler warning

### DIFF
--- a/src/logic/map.cc
+++ b/src/logic/map.cc
@@ -531,12 +531,6 @@ void Map::create_empty_map(const EditorGameBase& egbase,
 	filesystem_.reset(nullptr);
 }
 
-// Made this a separate function to reduce compiler warnings
-template <typename T = Field>
-static inline void clear_array(std::unique_ptr<T[]>* array, uint32_t size) {
-	memset(array->get(), 0, sizeof(T) * size);
-}
-
 void Map::set_origin(const Coords& new_origin) {
 	assert(0 <= new_origin.x);
 	assert(new_origin.x < width_);
@@ -549,8 +543,7 @@ void Map::set_origin(const Coords& new_origin) {
 		starting_pos_[--i].reorigin(new_origin, extent());
 	}
 
-	std::unique_ptr<Field[]> new_field_order(new Field[field_size]);
-	clear_array<>(&new_field_order, field_size);
+	std::unique_ptr<Field[]> new_field_order(new Field[field_size]());
 
 	// Rearrange The fields
 	// NOTE because of the triangle design, we have to take special care of cases
@@ -643,12 +636,9 @@ void Map::resize(EditorGameBase& egbase, const Coords split, const int32_t w, co
 
 	// Generate the new fields. Does not modify the actual map yet.
 
-	std::unique_ptr<Field[]> new_fields(new Field[w * h]);
-	clear_array<>(&new_fields, w * h);
-	std::unique_ptr<bool[]> was_preserved(new bool[width_ * height_]);
-	std::unique_ptr<bool[]> was_created(new bool[w * h]);
-	clear_array<bool>(&was_preserved, width_ * height_);
-	clear_array<bool>(&was_created, w * h);
+	std::unique_ptr<Field[]> new_fields(new Field[w * h]());
+	std::unique_ptr<bool[]> was_preserved(new bool[width_ * height_]());
+	std::unique_ptr<bool[]> was_created(new bool[w * h]());
 
 	for (int16_t x = 0; x < width_; ++x) {
 		for (int16_t y = 0; y < height_; ++y) {
@@ -838,8 +828,7 @@ void Map::set_size(const uint32_t w, const uint32_t h) {
 
 	const uint32_t field_size = w * h;
 
-	fields_.reset(new Field[field_size]);
-	clear_array<>(&fields_, field_size);
+	fields_.reset(new Field[field_size]());
 
 	pathfieldmgr_->set_size(field_size);
 }


### PR DESCRIPTION
Fix one of the warnings from https://github.com/widelands/widelands/issues/4234#issuecomment-688375120:
```
[1246/1565] Building CXX object src/logic/CMakeFiles/logic_map.dir/map.cc.o
../src/logic/map.cc: In instantiation of ‘void Widelands::clear_array(std::unique_ptr<T []>*, uint32_t) [with T = Widelands::Field; uint32_t = unsigned int]’:
../src/logic/map.cc:525:44:   required from here
../src/logic/map.cc:509:8: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct Widelands::Field’; use assignment or value-initialization instead [-Wclass-memaccess]
  509 |  memset(array->get(), 0, sizeof(T) * size);
      |  ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../src/logic/map.h:30,
                 from ../src/logic/map.cc:20:
../src/logic/field.h:58:8: note: ‘struct Widelands::Field’ declared here
   58 | struct Field {
      |        ^~~~~
```
I'm looking into the other memset warning too.