### PR TITLE
Remove unneeded NEVER_HERE in Vision

### DIFF
--- a/src/logic/vision.h
+++ b/src/logic/vision.h
@@ -66,8 +66,6 @@ public:
 			// kVisible initializes to the "visible by teammates" state
 			value_ = 2;
 			break;
-		default:
-			NEVER_HERE();
 		}
 	}
 	Vision& operator=(const VisibleState vs) {
@@ -82,8 +80,6 @@ public:
 			// kVisible initializes to the "visible by teammates" state
 			value_ = 2;
 			break;
-		default:
-			NEVER_HERE();
 		}
 		return *this;
 	}


### PR DESCRIPTION
Apparently these cause compiler warnings: https://github.com/widelands/widelands/issues/4234#issuecomment-713853838