### PR TITLE
Refactor PartiallyFinishedBuildingDetails

### DIFF
--- a/src/logic/map_objects/tribes/constructionsite.cc
+++ b/src/logic/map_objects/tribes/constructionsite.cc
@@ -116,7 +116,7 @@ void ConstructionsiteInformation::draw(const Vector2f& point_on_dst,
 	}
 	if (time.is_valid()) {
 		dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale, animation_id, time,
-	                    player_color_to_draw, opacity);
+		                    player_color_to_draw, opacity);
 	}
 
 	// Now blit a segment of the current construction phase from the bottom.

--- a/src/logic/map_objects/tribes/constructionsite.cc
+++ b/src/logic/map_objects/tribes/constructionsite.cc
@@ -96,26 +96,27 @@ void ConstructionsiteInformation::draw(const Vector2f& point_on_dst,
 		opacity = kBuildingSilhouetteOpacity;
 	}
 
+	uint32_t animation_id;
+	Time time = Time();
 	if (frame_index > 0) {
 		// Not the first pic within this animation – draw the previous one
-		dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale,
-		                    animations[animation_index].first, anim_time - Duration(kFrameLength),
-		                    player_color_to_draw, opacity);
+		animation_id = animations[animation_index].first;
+		time = anim_time - Duration(kFrameLength);
 	} else if (animation_index > 0) {
 		// The first pic, but not the first series of animations – draw the last pic of the previous
 		// series
-		dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale,
-		                    animations[animation_index - 1].first,
-		                    Time(kFrameLength * (animations[animation_index - 1].second - 1)),
-		                    player_color_to_draw, opacity);
+		animation_id = animations[animation_index - 1].first;
+		time = Time(kFrameLength * (animations[animation_index - 1].second - 1));
 	} else if (was) {
 		//  First pic in first series, but there was another building here before –
 		//  get its most fitting picture and draw it instead
-		const uint32_t unocc = was->get_unoccupied_animation();
-		dst->blit_animation(
-		   point_on_dst, Widelands::Coords::null(), scale, unocc,
-		   Time(kFrameLength * (g_animation_manager->get_animation(unocc).nr_frames() - 1)),
-		   player_color_to_draw, opacity);
+		animation_id = was->get_unoccupied_animation();
+		time =
+		   Time(kFrameLength * (g_animation_manager->get_animation(animation_id).nr_frames() - 1));
+	}
+	if (time.is_valid()) {
+		dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale, animation_id, time,
+	                    player_color_to_draw, opacity);
 	}
 
 	// Now blit a segment of the current construction phase from the bottom.

--- a/src/logic/map_objects/tribes/constructionsite.cc
+++ b/src/logic/map_objects/tribes/constructionsite.cc
@@ -86,46 +86,38 @@ void ConstructionsiteInformation::draw(const Vector2f& point_on_dst,
 	}
 	const Time anim_time(frame_index * kFrameLength);
 
+	const RGBColor* player_color_to_draw;
+	float opacity;
+	if (visible) {
+		player_color_to_draw = &player_color;
+		opacity = 1.0f;
+	} else {
+		player_color_to_draw = nullptr;
+		opacity = kBuildingSilhouetteOpacity;
+	}
+
 	if (frame_index > 0) {
 		// Not the first pic within this animation – draw the previous one
-		if (visible) {
-			dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale,
-			                    animations[animation_index].first, anim_time - Duration(kFrameLength),
-			                    &player_color);
-		} else {
-			dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale,
-			                    animations[animation_index].first, anim_time - Duration(kFrameLength),
-			                    nullptr, kBuildingSilhouetteOpacity);
-		}
+		dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale,
+		                    animations[animation_index].first, anim_time - Duration(kFrameLength),
+		                    player_color_to_draw, opacity);
 	} else if (animation_index > 0) {
 		// The first pic, but not the first series of animations – draw the last pic of the previous
 		// series
-		if (visible) {
-			dst->blit_animation(
-			   point_on_dst, Widelands::Coords::null(), scale, animations[animation_index - 1].first,
-			   Time(kFrameLength * (animations[animation_index - 1].second - 1)), &player_color);
-		} else {
-			dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale,
-			                    animations[animation_index - 1].first,
-			                    Time(kFrameLength * (animations[animation_index - 1].second - 1)),
-			                    nullptr, kBuildingSilhouetteOpacity);
-		}
+		dst->blit_animation(point_on_dst, Widelands::Coords::null(), scale,
+		                    animations[animation_index - 1].first,
+		                    Time(kFrameLength * (animations[animation_index - 1].second - 1)),
+		                    player_color_to_draw, opacity);
 	} else if (was) {
 		//  First pic in first series, but there was another building here before –
 		//  get its most fitting picture and draw it instead
 		const uint32_t unocc = was->get_unoccupied_animation();
-		if (visible) {
-			dst->blit_animation(
-			   point_on_dst, Widelands::Coords::null(), scale, unocc,
-			   Time(kFrameLength * (g_animation_manager->get_animation(unocc).nr_frames() - 1)),
-			   &player_color);
-		} else {
-			dst->blit_animation(
-			   point_on_dst, Widelands::Coords::null(), scale, unocc,
-			   Time(kFrameLength * (g_animation_manager->get_animation(unocc).nr_frames() - 1)),
-			   nullptr, kBuildingSilhouetteOpacity);
-		}
+		dst->blit_animation(
+		   point_on_dst, Widelands::Coords::null(), scale, unocc,
+		   Time(kFrameLength * (g_animation_manager->get_animation(unocc).nr_frames() - 1)),
+		   player_color_to_draw, opacity);
 	}
+
 	// Now blit a segment of the current construction phase from the bottom.
 	int percent = 100 * completedtime.get() * total_frames;
 	if (totaltime.get()) {
@@ -135,13 +127,8 @@ void ConstructionsiteInformation::draw(const Vector2f& point_on_dst,
 	for (uint32_t i = 0; i < animation_index; ++i) {
 		percent -= 100 * animations[i].second;
 	}
-	if (visible) {
-		dst->blit_animation(point_on_dst, coords, scale, animations[animation_index].first, anim_time,
-		                    &player_color, 1.f, percent);
-	} else {
-		dst->blit_animation(point_on_dst, coords, scale, animations[animation_index].first, anim_time,
-		                    nullptr, kBuildingSilhouetteOpacity, percent);
-	}
+	dst->blit_animation(point_on_dst, coords, scale, animations[animation_index].first, anim_time,
+	                    player_color_to_draw, opacity, percent);
 }
 
 /**

--- a/src/logic/map_objects/tribes/constructionsite.h
+++ b/src/logic/map_objects/tribes/constructionsite.h
@@ -34,7 +34,8 @@ enum class StockPolicy;
 
 /// Per-player and per-field constructionsite information
 struct ConstructionsiteInformation {
-	ConstructionsiteInformation() : becomes(nullptr), was(nullptr), totaltime(0), completedtime(0) {
+	ConstructionsiteInformation()
+	   : becomes(nullptr), was(nullptr), intermediates(), totaltime(0), completedtime(0) {
 	}
 
 	/// Draw the partly finished constructionsite

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -99,9 +99,9 @@ void Player::Field::set_constructionsite(bool new_value) {
 		return;
 	}
 	if (new_value) {
-		new (&constructionsite) ConstructionsiteInformation();
+		constructionsite = new ConstructionsiteInformation();
 	} else {
-		constructionsite.~ConstructionsiteInformation();
+		delete constructionsite;
 	}
 	is_constructionsite = new_value;
 }
@@ -1352,7 +1352,7 @@ void Player::rediscover_node(const Map& map, const FCoords& f) {
 					} else {
 						if (upcast(ConstructionSite const, cs, building)) {
 							field.set_constructionsite(true);
-							field.constructionsite =
+							*field.constructionsite =
 							   const_cast<ConstructionSite*>(cs)->get_info();
 						} else if (upcast(DismantleSite const, ds, building)) {
 							field.set_constructionsite(false);

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -94,8 +94,16 @@ void terraform_for_building(Widelands::EditorGameBase& egbase,
 
 namespace Widelands {
 
-Player::Field::PartiallyFinishedBuildingDetails::PartiallyFinishedBuildingDetails() {
-	memset(this, 0, sizeof(Player::Field::PartiallyFinishedBuildingDetails));
+void Player::Field::set_constructionsite(bool new_value) {
+	if (is_constructionsite == new_value) {
+		return;
+	}
+	if (new_value) {
+		new (&constructionsite) ConstructionsiteInformation();
+	} else {
+		constructionsite.~ConstructionsiteInformation();
+	}
+	is_constructionsite = new_value;
 }
 
 /**
@@ -1343,12 +1351,13 @@ void Player::rediscover_node(const Map& map, const FCoords& f) {
 						}
 					} else {
 						if (upcast(ConstructionSite const, cs, building)) {
-							field.partially_finished_building.constructionsite =
+							field.set_constructionsite(true);
+							field.constructionsite =
 							   const_cast<ConstructionSite*>(cs)->get_info();
 						} else if (upcast(DismantleSite const, ds, building)) {
-							field.partially_finished_building.dismantlesite.progress =
-							   ds->get_built_per64k();
-							field.partially_finished_building.dismantlesite.building = ds->get_building();
+							field.set_constructionsite(false);
+							field.dismantlesite.progress = ds->get_built_per64k();
+							field.dismantlesite.building = ds->get_building();
 						}
 					}
 				}

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -1352,8 +1352,7 @@ void Player::rediscover_node(const Map& map, const FCoords& f) {
 					} else {
 						if (upcast(ConstructionSite const, cs, building)) {
 							field.set_constructionsite(true);
-							*field.constructionsite =
-							   const_cast<ConstructionSite*>(cs)->get_info();
+							*field.constructionsite = const_cast<ConstructionSite*>(cs)->get_info();
 						} else if (upcast(DismantleSite const, ds, building)) {
 							field.set_constructionsite(false);
 							field.dismantlesite.progress = ds->get_built_per64k();

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -221,6 +221,8 @@ public:
 		     owner(0),
 		     time_node_last_unseen(0),
 		     map_object_descr(nullptr),
+		     dismantlesite(),
+		     is_constructionsite(false),
 		     border(0),
 		     border_r(0),
 		     border_br(0),
@@ -232,6 +234,12 @@ public:
 
 			time_triangle_last_surveyed[0] = Time();
 			time_triangle_last_surveyed[1] = Time();
+		}
+
+		~Field() {
+			if (is_constructionsite) {
+				constructionsite.~ConstructionsiteInformation();
+			}
 		}
 
 		/// Military influence is exerted by buildings with the help of soldiers.
@@ -387,16 +395,15 @@ public:
 		 * on this node. `dismantlesite.progress` equals the value of
 		 * `get_built_per64k()` at the time the dismantlesite was last seen.
 		 */
-		union PartiallyFinishedBuildingDetails {
-			ConstructionsiteInformation constructionsite;
+		union {
 			struct {
 				uint32_t progress;
 				const BuildingDescr* building;
 			} dismantlesite;
-			PartiallyFinishedBuildingDetails();
-			~PartiallyFinishedBuildingDetails() {
-			}
-		} partially_finished_building;
+			ConstructionsiteInformation constructionsite;
+		};
+		bool is_constructionsite;
+		void set_constructionsite(bool);
 
 		/// Save whether the player saw a border the last time (s)he saw the node.
 		bool border;

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -375,10 +375,16 @@ public:
 		 */
 		const MapObjectDescr* map_object_descr;
 
-		/* Information for constructionSite and DismantleSite animation.
+		/* Information for ConstructionSite and DismantleSite animation.
 		 * `constructionsite` is only valid if there is a constructionsite
-		 * on this node. `dismantlesite.progress` equals the value of
-		 * `get_built_per64k()` at the time the dismantlesite was last seen.
+		 * on this node. `dismantlesite` is only valid if there is a dismantlesite.
+		 *
+		 * `dismantlesite.progress` equals the value of `get_built_per64k()`
+		 * at the time the dismantlesite was last seen.
+		 *
+		 * `constructionsite` is allocated on demand because of its size.
+		 * Call `set_constructionsite(true)` before using `constructionsite`,
+		 * and call `set_constructionsite(false)` before using `dismantlesite`.
 		 */
 		union {
 			struct {

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -218,7 +218,6 @@ public:
 		     r_e(RoadSegment::kNone),
 		     r_se(RoadSegment::kNone),
 		     r_sw(RoadSegment::kNone),
-		     owner(0),
 		     time_node_last_unseen(0),
 		     map_object_descr(nullptr),
 		     dismantlesite(),
@@ -226,7 +225,8 @@ public:
 		     border(0),
 		     border_r(0),
 		     border_br(0),
-		     border_bl(0) {
+		     border_bl(0),
+		     owner(0) {
 			//  Must be initialized because the rendering code is accessing it
 			//  even for triangles that the player does not see (it is the
 			//  darkening that actually hides the ground from the user).
@@ -299,21 +299,6 @@ public:
 		RoadSegment r_e;
 		RoadSegment r_se;
 		RoadSegment r_sw;
-
-		/**
-		 * The owner of this node, as far as this player knows.
-		 * Only valid when this player has seen this node.
-		 */
-		PlayerNumber owner;
-
-		/**
-		 * The amount of resource at each of the triangles, as far as this player
-		 * knows.
-		 * The d component is only valid when time_last_surveyed[0] != Never().
-		 * The r component is only valid when time_last_surveyed[1] != Never().
-		 */
-		// TODO(unknown): Check this on access, at least in debug builds
-		Widelands::Field::ResourceAmounts resource_amounts;
 
 		/// Whether there is a road between this node and the node to the
 		/// east, as far as this player knows.
@@ -410,6 +395,21 @@ public:
 		bool border_r;
 		bool border_br;
 		bool border_bl;
+
+		/**
+		 * The owner of this node, as far as this player knows.
+		 * Only valid when this player has seen this node.
+		 */
+		PlayerNumber owner;
+
+		/**
+		 * The amount of resource at each of the triangles, as far as this player
+		 * knows.
+		 * The d component is only valid when time_last_surveyed[0] != Never().
+		 * The r component is only valid when time_last_surveyed[1] != Never().
+		 */
+		// TODO(unknown): Check this on access, at least in debug builds
+		Widelands::Field::ResourceAmounts resource_amounts;
 
 	private:
 		DISALLOW_COPY_AND_ASSIGN(Field);

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -238,7 +238,7 @@ public:
 
 		~Field() {
 			if (is_constructionsite) {
-				constructionsite.~ConstructionsiteInformation();
+				delete constructionsite;
 			}
 		}
 
@@ -400,7 +400,7 @@ public:
 				uint32_t progress;
 				const BuildingDescr* building;
 			} dismantlesite;
-			ConstructionsiteInformation constructionsite;
+			ConstructionsiteInformation* constructionsite;
 		};
 		bool is_constructionsite;
 		void set_constructionsite(bool);

--- a/src/map_io/map_players_view_packet.cc
+++ b/src/map_io/map_players_view_packet.cc
@@ -436,9 +436,9 @@ void MapPlayersViewPacket::read(FileSystem& fs,
 								   egbase.tribes().safe_building_index(fr.string()));
 								descr = fr.string();
 								f.constructionsite->was = descr.empty() ?
-								                          nullptr :
-								                          egbase.tribes().get_building_descr(
-								                             egbase.tribes().safe_building_index(descr));
+								                             nullptr :
+								                             egbase.tribes().get_building_descr(
+								                                egbase.tribes().safe_building_index(descr));
 
 								for (uint32_t j = fr.unsigned_32(); j; --j) {
 									f.constructionsite->intermediates.push_back(
@@ -462,9 +462,9 @@ void MapPlayersViewPacket::read(FileSystem& fs,
 
 								descr = fr.string();
 								f.constructionsite->was = descr.empty() ?
-								                          nullptr :
-								                          egbase.tribes().get_building_descr(
-								                             egbase.tribes().safe_building_index(descr));
+								                             nullptr :
+								                             egbase.tribes().get_building_descr(
+								                                egbase.tribes().safe_building_index(descr));
 
 								for (uint32_t j = fr.unsigned_32(); j; --j) {
 									f.constructionsite->intermediates.push_back(
@@ -665,20 +665,15 @@ void MapPlayersViewPacket::write(FileSystem& fs, EditorGameBase& egbase) {
 				if (field->map_object_descr->type() == MapObjectType::DISMANTLESITE) {
 					// `building` can only be nullptr in compatibility cases.
 					// Remove the non-null check after v1.0
-					fw.string(field->dismantlesite.building ?
-					             field->dismantlesite.building->name() :
-					             "dismantlesite");
+					fw.string(field->dismantlesite.building ? field->dismantlesite.building->name() :
+					                                          "dismantlesite");
 					fw.unsigned_32(field->dismantlesite.progress);
 				} else if (field->map_object_descr->type() == MapObjectType::CONSTRUCTIONSITE) {
 					fw.string(field->constructionsite->becomes->name());
-					fw.string(field->constructionsite->was ?
-					             field->constructionsite->was->name() :
-					             "");
+					fw.string(field->constructionsite->was ? field->constructionsite->was->name() : "");
 
-					fw.unsigned_32(
-					   field->constructionsite->intermediates.size());
-					for (const BuildingDescr* d :
-					     field->constructionsite->intermediates) {
+					fw.unsigned_32(field->constructionsite->intermediates.size());
+					for (const BuildingDescr* d : field->constructionsite->intermediates) {
 						fw.string(d->name());
 					}
 

--- a/src/map_io/map_players_view_packet.cc
+++ b/src/map_io/map_players_view_packet.cc
@@ -320,30 +320,31 @@ void MapPlayersViewPacket::read(FileSystem& fs,
 						}
 
 						if (field->map_object_descr->type() == MapObjectType::DISMANTLESITE) {
-							field->partially_finished_building.dismantlesite.building =
+							field->set_constructionsite(false);
+							field->dismantlesite.building =
 							   egbase.tribes().get_building_descr(egbase.tribes().safe_building_index(
 							      tribes_lookup_table.lookup_building(fr.string())));
-							field->partially_finished_building.dismantlesite.progress = fr.unsigned_32();
+							field->dismantlesite.progress = fr.unsigned_32();
 						} else if (field->map_object_descr->type() == MapObjectType::CONSTRUCTIONSITE) {
-							field->partially_finished_building.constructionsite.becomes =
+							field->set_constructionsite(true);
+							field->constructionsite.becomes =
 							   egbase.tribes().get_building_descr(egbase.tribes().safe_building_index(
 							      tribes_lookup_table.lookup_building(fr.string())));
 							descr = fr.string();
-							field->partially_finished_building.constructionsite.was =
+							field->constructionsite.was =
 							   descr.empty() ?
 							      nullptr :
 							      egbase.tribes().get_building_descr(egbase.tribes().safe_building_index(
 							         tribes_lookup_table.lookup_building(descr)));
 
 							for (uint32_t j = fr.unsigned_32(); j; --j) {
-								field->partially_finished_building.constructionsite.intermediates.push_back(
+								field->constructionsite.intermediates.push_back(
 								   egbase.tribes().get_building_descr(egbase.tribes().safe_building_index(
 								      tribes_lookup_table.lookup_building(fr.string()))));
 							}
 
-							field->partially_finished_building.constructionsite.totaltime = Duration(fr);
-							field->partially_finished_building.constructionsite.completedtime =
-							   Duration(fr);
+							field->constructionsite.totaltime = Duration(fr);
+							field->constructionsite.completedtime = Duration(fr);
 						}
 					}
 				}
@@ -425,53 +426,54 @@ void MapPlayersViewPacket::read(FileSystem& fs,
 
 						if (packet_version > 1) {
 							if (f.map_object_descr->type() == MapObjectType::DISMANTLESITE) {
-								f.partially_finished_building.dismantlesite.building =
-								   egbase.tribes().get_building_descr(
-								      egbase.tribes().safe_building_index(fr.string()));
-								f.partially_finished_building.dismantlesite.progress = fr.unsigned_32();
+								f.set_constructionsite(false);
+								f.dismantlesite.building = egbase.tribes().get_building_descr(
+								   egbase.tribes().safe_building_index(fr.string()));
+								f.dismantlesite.progress = fr.unsigned_32();
 							} else if (f.map_object_descr->type() == MapObjectType::CONSTRUCTIONSITE) {
-								f.partially_finished_building.constructionsite.becomes =
-								   egbase.tribes().get_building_descr(
-								      egbase.tribes().safe_building_index(fr.string()));
+								f.set_constructionsite(true);
+								f.constructionsite.becomes = egbase.tribes().get_building_descr(
+								   egbase.tribes().safe_building_index(fr.string()));
 								descr = fr.string();
-								f.partially_finished_building.constructionsite.was =
-								   descr.empty() ? nullptr :
-								                   egbase.tribes().get_building_descr(
-								                      egbase.tribes().safe_building_index(descr));
+								f.constructionsite.was = descr.empty() ?
+								                          nullptr :
+								                          egbase.tribes().get_building_descr(
+								                             egbase.tribes().safe_building_index(descr));
 
 								for (uint32_t j = fr.unsigned_32(); j; --j) {
-									f.partially_finished_building.constructionsite.intermediates.push_back(
+									f.constructionsite.intermediates.push_back(
 									   egbase.tribes().get_building_descr(
 									      egbase.tribes().safe_building_index(fr.string())));
 								}
 
-								f.partially_finished_building.constructionsite.totaltime = Duration(fr);
-								f.partially_finished_building.constructionsite.completedtime = Duration(fr);
+								f.constructionsite.totaltime = Duration(fr);
+								f.constructionsite.completedtime = Duration(fr);
 							}
 						} else {
 							descr = fr.string();
 							if (descr.empty()) {
-								f.partially_finished_building.dismantlesite.building = nullptr;
-								f.partially_finished_building.dismantlesite.progress = 0;
+								f.set_constructionsite(false);
+								f.dismantlesite.building = nullptr;
+								f.dismantlesite.progress = 0;
 							} else {
-								f.partially_finished_building.constructionsite.becomes =
-								   egbase.tribes().get_building_descr(
-								      egbase.tribes().safe_building_index(descr));
+								f.set_constructionsite(true);
+								f.constructionsite.becomes = egbase.tribes().get_building_descr(
+								   egbase.tribes().safe_building_index(descr));
 
 								descr = fr.string();
-								f.partially_finished_building.constructionsite.was =
-								   descr.empty() ? nullptr :
-								                   egbase.tribes().get_building_descr(
-								                      egbase.tribes().safe_building_index(descr));
+								f.constructionsite.was = descr.empty() ?
+								                          nullptr :
+								                          egbase.tribes().get_building_descr(
+								                             egbase.tribes().safe_building_index(descr));
 
 								for (uint32_t j = fr.unsigned_32(); j; --j) {
-									f.partially_finished_building.constructionsite.intermediates.push_back(
+									f.constructionsite.intermediates.push_back(
 									   egbase.tribes().get_building_descr(
 									      egbase.tribes().safe_building_index(fr.string())));
 								}
 
-								f.partially_finished_building.constructionsite.totaltime = Duration(fr);
-								f.partially_finished_building.constructionsite.completedtime = Duration(fr);
+								f.constructionsite.totaltime = Duration(fr);
+								f.constructionsite.completedtime = Duration(fr);
 							}
 						}
 					}
@@ -663,25 +665,25 @@ void MapPlayersViewPacket::write(FileSystem& fs, EditorGameBase& egbase) {
 				if (field->map_object_descr->type() == MapObjectType::DISMANTLESITE) {
 					// `building` can only be nullptr in compatibility cases.
 					// Remove the non-null check after v1.0
-					fw.string(field->partially_finished_building.dismantlesite.building ?
-					             field->partially_finished_building.dismantlesite.building->name() :
+					fw.string(field->dismantlesite.building ?
+					             field->dismantlesite.building->name() :
 					             "dismantlesite");
-					fw.unsigned_32(field->partially_finished_building.dismantlesite.progress);
+					fw.unsigned_32(field->dismantlesite.progress);
 				} else if (field->map_object_descr->type() == MapObjectType::CONSTRUCTIONSITE) {
-					fw.string(field->partially_finished_building.constructionsite.becomes->name());
-					fw.string(field->partially_finished_building.constructionsite.was ?
-					             field->partially_finished_building.constructionsite.was->name() :
+					fw.string(field->constructionsite.becomes->name());
+					fw.string(field->constructionsite.was ?
+					             field->constructionsite.was->name() :
 					             "");
 
 					fw.unsigned_32(
-					   field->partially_finished_building.constructionsite.intermediates.size());
+					   field->constructionsite.intermediates.size());
 					for (const BuildingDescr* d :
-					     field->partially_finished_building.constructionsite.intermediates) {
+					     field->constructionsite.intermediates) {
 						fw.string(d->name());
 					}
 
-					field->partially_finished_building.constructionsite.totaltime.save(fw);
-					field->partially_finished_building.constructionsite.completedtime.save(fw);
+					field->constructionsite.totaltime.save(fw);
+					field->constructionsite.completedtime.save(fw);
 				}
 			} else {
 				fw.string("");

--- a/src/map_io/map_players_view_packet.cc
+++ b/src/map_io/map_players_view_packet.cc
@@ -327,24 +327,24 @@ void MapPlayersViewPacket::read(FileSystem& fs,
 							field->dismantlesite.progress = fr.unsigned_32();
 						} else if (field->map_object_descr->type() == MapObjectType::CONSTRUCTIONSITE) {
 							field->set_constructionsite(true);
-							field->constructionsite.becomes =
+							field->constructionsite->becomes =
 							   egbase.tribes().get_building_descr(egbase.tribes().safe_building_index(
 							      tribes_lookup_table.lookup_building(fr.string())));
 							descr = fr.string();
-							field->constructionsite.was =
+							field->constructionsite->was =
 							   descr.empty() ?
 							      nullptr :
 							      egbase.tribes().get_building_descr(egbase.tribes().safe_building_index(
 							         tribes_lookup_table.lookup_building(descr)));
 
 							for (uint32_t j = fr.unsigned_32(); j; --j) {
-								field->constructionsite.intermediates.push_back(
+								field->constructionsite->intermediates.push_back(
 								   egbase.tribes().get_building_descr(egbase.tribes().safe_building_index(
 								      tribes_lookup_table.lookup_building(fr.string()))));
 							}
 
-							field->constructionsite.totaltime = Duration(fr);
-							field->constructionsite.completedtime = Duration(fr);
+							field->constructionsite->totaltime = Duration(fr);
+							field->constructionsite->completedtime = Duration(fr);
 						}
 					}
 				}
@@ -432,22 +432,22 @@ void MapPlayersViewPacket::read(FileSystem& fs,
 								f.dismantlesite.progress = fr.unsigned_32();
 							} else if (f.map_object_descr->type() == MapObjectType::CONSTRUCTIONSITE) {
 								f.set_constructionsite(true);
-								f.constructionsite.becomes = egbase.tribes().get_building_descr(
+								f.constructionsite->becomes = egbase.tribes().get_building_descr(
 								   egbase.tribes().safe_building_index(fr.string()));
 								descr = fr.string();
-								f.constructionsite.was = descr.empty() ?
+								f.constructionsite->was = descr.empty() ?
 								                          nullptr :
 								                          egbase.tribes().get_building_descr(
 								                             egbase.tribes().safe_building_index(descr));
 
 								for (uint32_t j = fr.unsigned_32(); j; --j) {
-									f.constructionsite.intermediates.push_back(
+									f.constructionsite->intermediates.push_back(
 									   egbase.tribes().get_building_descr(
 									      egbase.tribes().safe_building_index(fr.string())));
 								}
 
-								f.constructionsite.totaltime = Duration(fr);
-								f.constructionsite.completedtime = Duration(fr);
+								f.constructionsite->totaltime = Duration(fr);
+								f.constructionsite->completedtime = Duration(fr);
 							}
 						} else {
 							descr = fr.string();
@@ -457,23 +457,23 @@ void MapPlayersViewPacket::read(FileSystem& fs,
 								f.dismantlesite.progress = 0;
 							} else {
 								f.set_constructionsite(true);
-								f.constructionsite.becomes = egbase.tribes().get_building_descr(
+								f.constructionsite->becomes = egbase.tribes().get_building_descr(
 								   egbase.tribes().safe_building_index(descr));
 
 								descr = fr.string();
-								f.constructionsite.was = descr.empty() ?
+								f.constructionsite->was = descr.empty() ?
 								                          nullptr :
 								                          egbase.tribes().get_building_descr(
 								                             egbase.tribes().safe_building_index(descr));
 
 								for (uint32_t j = fr.unsigned_32(); j; --j) {
-									f.constructionsite.intermediates.push_back(
+									f.constructionsite->intermediates.push_back(
 									   egbase.tribes().get_building_descr(
 									      egbase.tribes().safe_building_index(fr.string())));
 								}
 
-								f.constructionsite.totaltime = Duration(fr);
-								f.constructionsite.completedtime = Duration(fr);
+								f.constructionsite->totaltime = Duration(fr);
+								f.constructionsite->completedtime = Duration(fr);
 							}
 						}
 					}
@@ -670,20 +670,20 @@ void MapPlayersViewPacket::write(FileSystem& fs, EditorGameBase& egbase) {
 					             "dismantlesite");
 					fw.unsigned_32(field->dismantlesite.progress);
 				} else if (field->map_object_descr->type() == MapObjectType::CONSTRUCTIONSITE) {
-					fw.string(field->constructionsite.becomes->name());
-					fw.string(field->constructionsite.was ?
-					             field->constructionsite.was->name() :
+					fw.string(field->constructionsite->becomes->name());
+					fw.string(field->constructionsite->was ?
+					             field->constructionsite->was->name() :
 					             "");
 
 					fw.unsigned_32(
-					   field->constructionsite.intermediates.size());
+					   field->constructionsite->intermediates.size());
 					for (const BuildingDescr* d :
-					     field->constructionsite.intermediates) {
+					     field->constructionsite->intermediates) {
 						fw.string(d->name());
 					}
 
-					field->constructionsite.totaltime.save(fw);
-					field->constructionsite.completedtime.save(fw);
+					field->constructionsite->totaltime.save(fw);
+					field->constructionsite->completedtime.save(fw);
 				}
 			} else {
 				fw.string("");

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -117,7 +117,7 @@ void draw_immovable_for_formerly_visible_field(const FieldsToDraw::Field& field,
 		assert(field.owner != nullptr);
 		// this is a building therefore we either draw unoccupied or idle animation
 		if (building->type() == Widelands::MapObjectType::CONSTRUCTIONSITE) {
-			player_field.partially_finished_building.constructionsite.draw(
+			player_field.constructionsite.draw(
 			   field.rendertarget_pixel, field.fcoords, scale,
 			   (info_to_draw & InfoToDraw::kShowBuildings), field.owner->get_playercolor(), dst);
 		} else {
@@ -133,14 +133,14 @@ void draw_immovable_for_formerly_visible_field(const FieldsToDraw::Field& field,
 			if (building->type() == Widelands::MapObjectType::DISMANTLESITE &&
 			    // TODO(Nordfriese): `building` can only be nullptr in savegame
 			    // compatibility cases – remove that check after v1.0
-			    player_field.partially_finished_building.dismantlesite.building) {
+			    player_field.dismantlesite.building) {
 				dst->blit_animation(
 				   field.rendertarget_pixel, field.fcoords, scale,
-				   player_field.partially_finished_building.dismantlesite.building
+				   player_field.dismantlesite.building
 				      ->get_unoccupied_animation(),
 				   Time(0), player_color, opacity,
 				   100 -
-				      ((player_field.partially_finished_building.dismantlesite.progress * 100) >> 16));
+				      ((player_field.dismantlesite.progress * 100) >> 16));
 			} else {
 				dst->blit_animation(field.rendertarget_pixel, field.fcoords, scale,
 				                    building->get_unoccupied_animation(), Time(0), player_color,

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -117,9 +117,9 @@ void draw_immovable_for_formerly_visible_field(const FieldsToDraw::Field& field,
 		assert(field.owner != nullptr);
 		// this is a building therefore we either draw unoccupied or idle animation
 		if (building->type() == Widelands::MapObjectType::CONSTRUCTIONSITE) {
-			player_field.constructionsite->draw(
-			   field.rendertarget_pixel, field.fcoords, scale,
-			   (info_to_draw & InfoToDraw::kShowBuildings), field.owner->get_playercolor(), dst);
+			player_field.constructionsite->draw(field.rendertarget_pixel, field.fcoords, scale,
+			                                    (info_to_draw & InfoToDraw::kShowBuildings),
+			                                    field.owner->get_playercolor(), dst);
 		} else {
 			const RGBColor* player_color;
 			float opacity;
@@ -134,13 +134,10 @@ void draw_immovable_for_formerly_visible_field(const FieldsToDraw::Field& field,
 			    // TODO(Nordfriese): `building` can only be nullptr in savegame
 			    // compatibility cases – remove that check after v1.0
 			    player_field.dismantlesite.building) {
-				dst->blit_animation(
-				   field.rendertarget_pixel, field.fcoords, scale,
-				   player_field.dismantlesite.building
-				      ->get_unoccupied_animation(),
-				   Time(0), player_color, opacity,
-				   100 -
-				      ((player_field.dismantlesite.progress * 100) >> 16));
+				dst->blit_animation(field.rendertarget_pixel, field.fcoords, scale,
+				                    player_field.dismantlesite.building->get_unoccupied_animation(),
+				                    Time(0), player_color, opacity,
+				                    100 - ((player_field.dismantlesite.progress * 100) >> 16));
 			} else {
 				dst->blit_animation(field.rendertarget_pixel, field.fcoords, scale,
 				                    building->get_unoccupied_animation(), Time(0), player_color,

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -117,7 +117,7 @@ void draw_immovable_for_formerly_visible_field(const FieldsToDraw::Field& field,
 		assert(field.owner != nullptr);
 		// this is a building therefore we either draw unoccupied or idle animation
 		if (building->type() == Widelands::MapObjectType::CONSTRUCTIONSITE) {
-			player_field.constructionsite.draw(
+			player_field.constructionsite->draw(
 			   field.rendertarget_pixel, field.fcoords, scale,
 			   (info_to_draw & InfoToDraw::kShowBuildings), field.owner->get_playercolor(), dst);
 		} else {

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -120,35 +120,32 @@ void draw_immovable_for_formerly_visible_field(const FieldsToDraw::Field& field,
 			player_field.partially_finished_building.constructionsite.draw(
 			   field.rendertarget_pixel, field.fcoords, scale,
 			   (info_to_draw & InfoToDraw::kShowBuildings), field.owner->get_playercolor(), dst);
-		} else if (building->type() == Widelands::MapObjectType::DISMANTLESITE &&
-		           // TODO(Nordfriese): `building` can only be nullptr in savegame
-		           // compatibility cases – remove that check after v1.0
-		           player_field.partially_finished_building.dismantlesite.building) {
+		} else {
+			const RGBColor* player_color;
+			float opacity;
 			if (info_to_draw & InfoToDraw::kShowBuildings) {
+				player_color = &field.owner->get_playercolor();
+				opacity = 1.0f;
+			} else {
+				player_color = nullptr;
+				opacity = Widelands::kBuildingSilhouetteOpacity;
+			}
+			if (building->type() == Widelands::MapObjectType::DISMANTLESITE &&
+			    // TODO(Nordfriese): `building` can only be nullptr in savegame
+			    // compatibility cases – remove that check after v1.0
+			    player_field.partially_finished_building.dismantlesite.building) {
 				dst->blit_animation(
 				   field.rendertarget_pixel, field.fcoords, scale,
 				   player_field.partially_finished_building.dismantlesite.building
 				      ->get_unoccupied_animation(),
-				   Time(0), &field.owner->get_playercolor(), 1.f,
+				   Time(0), player_color, opacity,
 				   100 -
 				      ((player_field.partially_finished_building.dismantlesite.progress * 100) >> 16));
 			} else {
-				dst->blit_animation(
-				   field.rendertarget_pixel, field.fcoords, scale,
-				   player_field.partially_finished_building.dismantlesite.building
-				      ->get_unoccupied_animation(),
-				   Time(0), nullptr, Widelands::kBuildingSilhouetteOpacity,
-				   100 -
-				      ((player_field.partially_finished_building.dismantlesite.progress * 100) >> 16));
+				dst->blit_animation(field.rendertarget_pixel, field.fcoords, scale,
+				                    building->get_unoccupied_animation(), Time(0), player_color,
+				                    opacity);
 			}
-		} else if (info_to_draw & InfoToDraw::kShowBuildings) {
-			dst->blit_animation(field.rendertarget_pixel, field.fcoords, scale,
-			                    building->get_unoccupied_animation(), Time(0),
-			                    &field.owner->get_playercolor());
-		} else {
-			dst->blit_animation(field.rendertarget_pixel, field.fcoords, scale,
-			                    building->get_unoccupied_animation(), Time(0), nullptr,
-			                    Widelands::kBuildingSilhouetteOpacity);
 		}
 	} else if (player_field.map_object_descr->type() == Widelands::MapObjectType::FLAG) {
 		assert(field.owner != nullptr);


### PR DESCRIPTION
- Fix a memory leak (https://github.com/widelands/widelands/pull/4395#issuecomment-714376083)
- Fix a compiler warning (https://github.com/widelands/widelands/issues/4234#issuecomment-712987610)
- Reduce the size of `Player::Field` from 104 to 64 bytes (fields with construction sites will allocate at least 48 more bytes but these should be a minority)
- Add some temporary variables for readability