### PR TITLE
Set OpenGL swap interval to 0

### DIFF
--- a/src/graphic/gl/initialize.cc
+++ b/src/graphic/gl/initialize.cc
@@ -51,6 +51,8 @@ SDL_GLContext initialize(
 	SDL_GLContext gl_context = SDL_GL_CreateContext(sdl_window);
 	SDL_GL_MakeCurrent(sdl_window, gl_context);
 
+	SDL_GL_SetSwapInterval(0);
+
 #ifdef USE_GLBINDING
 #ifndef GLBINDING3
 	glbinding::Binding::initialize();


### PR DESCRIPTION
This reduces graphics latency but may cause frame tearing on some systems. Please test (moving large windows, scrolling the map), both in fullscreen and not. If there are negative effects I'll make this an option.