### PR TITLE
Remove wrong assert in came client

### DIFF
--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -249,7 +249,6 @@ void GameClient::run() {
 
 	d->send_hello();
 	d->settings.multiplayer = true;
-	assert(!d->settings.tribes.empty());
 
 	// Fill the list of possible system messages
 	NetworkGamingMessages::fill_map();


### PR DESCRIPTION
The information is received from the host at a later point, so we can't guarantee it.

Fixes https://github.com/widelands/widelands/issues/4442