### PR TITLE
Reverse priority colors

### DIFF
--- a/src/wui/inputqueuedisplay.cc
+++ b/src/wui/inputqueuedisplay.cc
@@ -530,7 +530,7 @@ void InputQueueDisplay::think() {
 	                                                  "images/ui_basic/scrollbar_left.png"));
 }
 
-static const RGBAColor kPriorityColors[] = {RGBAColor(0, 127, 255, 127), RGBAColor(0, 255, 0, 127),
+static const RGBAColor kPriorityColors[] = {RGBAColor(0, 0, 255, 127), RGBAColor(63, 127, 255, 127),
                                             RGBAColor(255, 255, 0, 127),
                                             RGBAColor(255, 127, 0, 127), RGBAColor(255, 0, 0, 127)};
 

--- a/src/wui/inputqueuedisplay.cc
+++ b/src/wui/inputqueuedisplay.cc
@@ -530,9 +530,9 @@ void InputQueueDisplay::think() {
 	                                                  "images/ui_basic/scrollbar_left.png"));
 }
 
-static const RGBAColor kPriorityColors[] = {RGBAColor(255, 0, 0, 127), RGBAColor(255, 127, 0, 127),
-                                            RGBAColor(255, 255, 0, 127), RGBAColor(0, 255, 0, 127),
-                                            RGBAColor(0, 127, 255, 127)};
+static const RGBAColor kPriorityColors[] = {RGBAColor(0, 127, 255, 127), RGBAColor(0, 255, 0, 127),
+                                            RGBAColor(255, 255, 0, 127),
+                                            RGBAColor(255, 127, 0, 127), RGBAColor(255, 0, 0, 127)};
 
 void InputQueueDisplay::draw(RenderTarget& r) {
 	// Draw priority indicator


### PR DESCRIPTION
I got confused while using the priority slider, because the traffic lights metaphor (red  = stop) does not hold any more. I am associating red with urgency and blue with calm, so I think they should be the other way around.