### PR TITLE
Read mining information for help & AI

### DIFF
--- a/data/tribes/buildings/productionsites/amazons/gold_digger_dwelling/init.lua
+++ b/data/tribes/buildings/productionsites/amazons/gold_digger_dwelling/init.lua
@@ -34,8 +34,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_gold",
-      mines_percent = 100,
       prohibited_till = 1100
    },
 

--- a/data/tribes/buildings/productionsites/amazons/stonemine/init.lua
+++ b/data/tribes/buildings/productionsites/amazons/stonemine/init.lua
@@ -33,8 +33,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_stones",
-      mines_percent = 100,
       prohibited_till = 630
    },
 

--- a/data/tribes/buildings/productionsites/atlanteans/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/coalmine/init.lua
@@ -35,7 +35,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_coal",
       prohibited_till = 910
    },
 

--- a/data/tribes/buildings/productionsites/atlanteans/crystalmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/crystalmine/init.lua
@@ -35,7 +35,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_stones",
       prohibited_till = 600
    },
 

--- a/data/tribes/buildings/productionsites/atlanteans/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/goldmine/init.lua
@@ -35,7 +35,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_gold",
       prohibited_till = 1200
    },
 

--- a/data/tribes/buildings/productionsites/atlanteans/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/atlanteans/ironmine/init.lua
@@ -35,7 +35,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_iron",
       prohibited_till = 1000
    },
 

--- a/data/tribes/buildings/productionsites/barbarians/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine/init.lua
@@ -50,8 +50,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_coal",
-      mines_percent = 30,
       prohibited_till = 910
    },
 

--- a/data/tribes/buildings/productionsites/barbarians/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine_deep/init.lua
@@ -40,10 +40,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_coal",
-      mines_percent = 60
-   },
+   aihints = {},
 
    working_positions = {
       barbarians_miner = 1,

--- a/data/tribes/buildings/productionsites/barbarians/coalmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/coalmine_deeper/init.lua
@@ -28,9 +28,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_coal"
-   },
+   aihints = {},
 
    working_positions = {
       barbarians_miner = 1,

--- a/data/tribes/buildings/productionsites/barbarians/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine/init.lua
@@ -50,8 +50,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_gold",
-      mines_percent = 30,
       prohibited_till = 1200
    },
 

--- a/data/tribes/buildings/productionsites/barbarians/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine_deep/init.lua
@@ -40,10 +40,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_gold",
-      mines_percent = 60
-   },
+   aihints = {},
 
    working_positions = {
       barbarians_miner = 1,

--- a/data/tribes/buildings/productionsites/barbarians/goldmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/goldmine_deeper/init.lua
@@ -28,9 +28,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_gold",
-   },
+   aihints = {},
 
    working_positions = {
       barbarians_miner = 1,

--- a/data/tribes/buildings/productionsites/barbarians/granitemine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/granitemine/init.lua
@@ -38,7 +38,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_stones",
       prohibited_till = 600
    },
 

--- a/data/tribes/buildings/productionsites/barbarians/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine/init.lua
@@ -50,9 +50,7 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_iron",
-      prohibited_till = 1000,
-      mines_percent = 30
+      prohibited_till = 1000
    },
 
    working_positions = {

--- a/data/tribes/buildings/productionsites/barbarians/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine_deep/init.lua
@@ -40,10 +40,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_iron",
-      mines_percent = 60
-   },
+   aihints = {},
 
    working_positions = {
       barbarians_miner = 1,

--- a/data/tribes/buildings/productionsites/barbarians/ironmine_deeper/init.lua
+++ b/data/tribes/buildings/productionsites/barbarians/ironmine_deeper/init.lua
@@ -28,9 +28,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_iron",
-   },
+   aihints = {},
 
    working_positions = {
       barbarians_miner = 1,

--- a/data/tribes/buildings/productionsites/empire/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/coalmine/init.lua
@@ -47,8 +47,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_coal",
-      mines_percent = 50,
       prohibited_till = 910
    },
 

--- a/data/tribes/buildings/productionsites/empire/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/coalmine_deep/init.lua
@@ -25,9 +25,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_coal"
-   },
+   aihints = {},
 
    working_positions = {
       empire_miner = 1,

--- a/data/tribes/buildings/productionsites/empire/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/goldmine/init.lua
@@ -47,8 +47,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_gold",
-      mines_percent = 50,
       prohibited_till = 1200
    },
 

--- a/data/tribes/buildings/productionsites/empire/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/goldmine_deep/init.lua
@@ -25,9 +25,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_gold"
-   },
+   aihints = {},
 
    working_positions = {
       empire_miner = 1,

--- a/data/tribes/buildings/productionsites/empire/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/ironmine/init.lua
@@ -47,8 +47,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_iron",
-      mines_percent = 50,
       prohibited_till = 1000
    },
 

--- a/data/tribes/buildings/productionsites/empire/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/ironmine_deep/init.lua
@@ -25,9 +25,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_iron"
-   },
+   aihints = {},
 
    working_positions = {
       empire_miner = 1,

--- a/data/tribes/buildings/productionsites/empire/marblemine/init.lua
+++ b/data/tribes/buildings/productionsites/empire/marblemine/init.lua
@@ -47,8 +47,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_stones",
-      mines_percent = 50,
       prohibited_till = 600,
       basic_amount = 1
    },

--- a/data/tribes/buildings/productionsites/empire/marblemine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/empire/marblemine_deep/init.lua
@@ -25,9 +25,7 @@ descriptions:new_productionsite_type {
       },
    },
 
-   aihints = {
-      mines = "resource_stones"
-   },
+   aihints = {},
 
    working_positions = {
       empire_miner = 1,

--- a/data/tribes/buildings/productionsites/frisians/coalmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/coalmine/init.lua
@@ -73,10 +73,7 @@ descriptions:new_productionsite_type {
       }
    },
 
-   aihints = {
-      mines = "resource_coal",
-      mines_percent = 50,
-   },
+   aihints = {},
 
    working_positions = {
       frisians_miner = 1

--- a/data/tribes/buildings/productionsites/frisians/coalmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/coalmine_deep/init.lua
@@ -46,9 +46,7 @@ descriptions:new_productionsite_type {
       }
    },
 
-   aihints = {
-      mines = "resource_coal",
-   },
+   aihints = {},
 
    working_positions = {
       frisians_miner = 1,

--- a/data/tribes/buildings/productionsites/frisians/goldmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/goldmine/init.lua
@@ -74,8 +74,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_gold",
-      mines_percent = 50,
       prohibited_till = 1100
    },
 

--- a/data/tribes/buildings/productionsites/frisians/goldmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/goldmine_deep/init.lua
@@ -46,9 +46,7 @@ descriptions:new_productionsite_type {
       }
    },
 
-   aihints = {
-      mines = "resource_gold",
-   },
+   aihints = {},
 
    working_positions = {
       frisians_miner = 1,

--- a/data/tribes/buildings/productionsites/frisians/ironmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/ironmine/init.lua
@@ -74,8 +74,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_iron",
-      mines_percent = 50,
       prohibited_till = 1000
    },
 

--- a/data/tribes/buildings/productionsites/frisians/ironmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/ironmine_deep/init.lua
@@ -46,9 +46,7 @@ descriptions:new_productionsite_type {
       }
    },
 
-   aihints = {
-      mines = "resource_iron",
-   },
+   aihints = {},
 
    working_positions = {
       frisians_miner = 1,

--- a/data/tribes/buildings/productionsites/frisians/rockmine/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/rockmine/init.lua
@@ -74,8 +74,6 @@ descriptions:new_productionsite_type {
    },
 
    aihints = {
-      mines = "resource_stones",
-      mines_percent = 50,
       prohibited_till = 630
    },
 

--- a/data/tribes/buildings/productionsites/frisians/rockmine_deep/init.lua
+++ b/data/tribes/buildings/productionsites/frisians/rockmine_deep/init.lua
@@ -46,9 +46,7 @@ descriptions:new_productionsite_type {
       }
    },
 
-   aihints = {
-      mines = "resource_stones",
-   },
+   aihints = {},
 
    working_positions = {
       frisians_miner = 1,

--- a/data/tribes/initialization/barbarians/units.lua
+++ b/data/tribes/initialization/barbarians/units.lua
@@ -1491,8 +1491,6 @@ descriptions:new_tribe {
             -- TRANSLATORS: Purpose helptext for a barbarian production site: Granite Mine
             purpose = pgettext("barbarians_building", "Carves granite out of the rock in mountain terrain."),
             note = {
-               -- TRANSLATORS: Note helptext for a barbarian production site: Granite Mine
-               pgettext("barbarians_building","This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more granite."):bformat("5%"),
                -- TRANSLATORS: 'It' is a mine
                pgettext("barbarians_building", "It cannot be enhanced.")
             },
@@ -1511,8 +1509,6 @@ descriptions:new_tribe {
             },
             -- TRANSLATORS: Purpose helptext for production site: Coal Mine
             purpose = pgettext("building", "Digs coal out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for production site: Coal Mine
-            note = pgettext("barbarians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any coal."):bformat("1/3"),
             -- TRANSLATORS: Performance helptext for production site: Coal Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce coal in 32.5 seconds on average.")
          }
@@ -1528,8 +1524,6 @@ descriptions:new_tribe {
             },
             -- TRANSLATORS: Purpose helptext for production site: Deep Coal Mine
             purpose = pgettext("building", "Digs coal out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for production site: Deep Coal Mine
-            note = pgettext("barbarians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any coal."):bformat("2/3"),
             -- TRANSLATORS: Performance helptext for production site: Deep Coal Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce coal in 19.5 seconds on average.")
          }
@@ -1545,8 +1539,6 @@ descriptions:new_tribe {
             },
             -- TRANSLATORS: Purpose helptext for production site: Deeper Coal Mine
             purpose = pgettext("building", "Digs coal out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for production site: Deeper Coal Mine
-            note = pgettext("barbarians_building", "This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more coal."):bformat("10%"),
             -- TRANSLATORS: Performance helptext for production site: Deeper Coal Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce coal in 14.4 seconds on average.")
          }
@@ -1560,8 +1552,6 @@ descriptions:new_tribe {
             lore_author = pgettext("barbarians_building", "Quote from an anonymous miner."),
             -- TRANSLATORS: Purpose helptext for a barbarian production site: Iron Mine
             purpose = pgettext("building", "Digs iron ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a barbarian production site: Iron Mine
-            note = pgettext("barbarians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any iron ore."):bformat("1/3"),
             -- TRANSLATORS: Performance helptext for a barbarian production site: Iron Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce iron ore in %s on average."):bformat(ngettext("%d second", "%d seconds", 65):bformat(65))
          }
@@ -1575,8 +1565,6 @@ descriptions:new_tribe {
             lore_author = pgettext("barbarians_building", "Quote from an anonymous miner."),
             -- TRANSLATORS: Purpose helptext for a barbarian production site: Deep Iron Mine
             purpose = pgettext("building", "Digs iron ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a barbarian production site: Deep Iron Mine
-            note = pgettext("barbarians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any iron ore."):bformat("2/3"),
             -- TRANSLATORS: Performance helptext for a barbarian production site: Deep Iron Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce iron ore in 39.5 seconds on average.")
          }
@@ -1590,8 +1578,6 @@ descriptions:new_tribe {
             lore_author = pgettext("barbarians_building", "Quote from an anonymous miner."),
             -- TRANSLATORS: Purpose helptext for a barbarian production site: Deeper Iron Mine
             purpose = pgettext("building", "Digs iron ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a barbarian production site: Deeper Iron Mine
-            note = pgettext("barbarians_building", "This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more iron ore."):bformat("10%"),
             -- TRANSLATORS: Performance helptext for a barbarian production site: Deeper Iron Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce iron ore in 17.6 seconds on average.")
          }
@@ -1605,8 +1591,6 @@ descriptions:new_tribe {
             lore_author = pgettext("barbarians_building", "Excerpt from ‘Our Treasures Underground’,<br> a traditional Barbarian song."),
             -- TRANSLATORS: Purpose helptext for production site: Gold Mine
             purpose = pgettext("building", "Digs gold ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for production site: Gold Mine
-            note = pgettext("barbarians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any gold ore."):bformat("1/3"),
             -- TRANSLATORS: Performance helptext for production site: Gold Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce gold ore in %s on average."):bformat(ngettext("%d second", "%d seconds", 65):bformat(65))
          }
@@ -1620,8 +1604,6 @@ descriptions:new_tribe {
             lore_author = pgettext("barbarians_building", "Excerpt from ‘Our Treasures Underground’,<br> a traditional Barbarian song."),
             -- TRANSLATORS: Purpose helptext for production site: Deep Gold Mine
             purpose = pgettext("building", "Digs gold ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for production site: Deep Gold Mine
-            note = pgettext("barbarians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any gold ore."):bformat("2/3"),
             -- TRANSLATORS: Performance helptext for production site: Deep Gold Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce gold ore in 19.5 seconds on average.")
          }
@@ -1635,8 +1617,6 @@ descriptions:new_tribe {
             lore_author = pgettext("barbarians_building", "Excerpt from ‘Our Treasures Underground’,<br> a traditional Barbarian song."),
             -- TRANSLATORS: Purpose helptext for production site: Deeper Gold Mine
             purpose = pgettext("building", "Digs gold ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for production site: Deeper Gold Mine
-            note = pgettext("barbarians_building", "This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more gold ore."):bformat("10%"),
             -- TRANSLATORS: Performance helptext for production site: Deeper Gold Mine
             performance = pgettext("barbarians_building", "If the food supply is steady, this mine can produce gold ore in 18.5 seconds on average.")
          }

--- a/data/tribes/initialization/frisians/units.lua
+++ b/data/tribes/initialization/frisians/units.lua
@@ -1944,8 +1944,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Rock Mine
             purpose = pgettext("building", "Digs granite out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Rock Mine
-            note = pgettext("frisians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any granite."):bformat("1/2"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Rock Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the rock mine can produce two blocks of granite in %s on average."):bformat(ngettext("%d second", "%d seconds", 85):bformat(85))
          }
@@ -1955,8 +1953,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Deep Rock Mine
             purpose = pgettext("building", "Digs granite out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Deep Rock Mine
-            note = pgettext("frisians_building", "This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more granite."):bformat("10%"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Deep Rock Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the deep rock mine can produce three blocks of granite in %s on average."):bformat(ngettext("%d second", "%d seconds", 76):bformat(76))
          }
@@ -1966,8 +1962,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Coal Mine
             purpose = pgettext("building", "Digs coal out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Coal Mine
-            note = pgettext("frisians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any coal."):bformat("1/2"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Coal Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the coal mine can produce two pieces of coal in %s on average."):bformat(ngettext("%d second", "%d seconds", 85):bformat(85))
          }
@@ -1977,8 +1971,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Deep Coal Mine
             purpose = pgettext("building", "Digs coal out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Deep Coal Mine
-            note = pgettext("frisians_building", "This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more coal."):bformat("10%"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Deep Coal Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the deep coal mine can produce four pieces of coal in %s on average."):bformat(ngettext("%d second", "%d seconds", 76):bformat(76))
          }
@@ -1988,8 +1980,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Iron Mine
             purpose = pgettext("building", "Digs iron ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Iron Mine
-            note = pgettext("frisians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any iron ore."):bformat("1/2"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Iron Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the iron mine can produce one piece of iron ore in %s on average."):bformat(ngettext("%d second", "%d seconds", 65):bformat(65))
          }
@@ -1999,8 +1989,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Deep Iron Mine
             purpose = pgettext("building", "Digs iron ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Deep Iron Mine
-            note = pgettext("frisians_building", "This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more iron ore."):bformat("10%"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Deep Iron Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the deep iron mine can produce two pieces of iron ore in %s on average."):bformat(ngettext("%d second", "%d seconds", 76):bformat(76))
          }
@@ -2010,8 +1998,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Gold Mine
             purpose = pgettext("building", "Digs gold ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Gold Mine
-            note = pgettext("frisians_building", "This mine exploits only %s of the resource. From there on out, it will only have a 5%% chance of finding any gold ore."):bformat("1/2"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Gold Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the gold mine can produce one piece of gold ore in %s on average."):bformat(ngettext("%d second", "%d seconds", 65):bformat(65))
          }
@@ -2021,8 +2007,6 @@ descriptions:new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a frisian production site: Deep Gold Mine
             purpose = pgettext("building", "Digs gold ore out of the ground in mountain terrain."),
-            -- TRANSLATORS: Note helptext for a frisian production site: Deep Gold Mine
-            note = pgettext("frisians_building", "This mine exploits all of the resource down to the deepest level. But even after having done so, it will still have a %s chance of finding some more gold ore."):bformat("10%"),
             -- TRANSLATORS: Performance helptext for a frisian production site: Deep Gold Mine
             performance = pgettext("frisians_building", "If the food supply is steady, the deep gold mine can produce two pieces of gold ore in %s on average."):bformat(ngettext("%d second", "%d seconds", 76):bformat(76))
          }

--- a/data/tribes/scripting/help/building_help.lua
+++ b/data/tribes/scripting/help/building_help.lua
@@ -414,8 +414,8 @@ function building_help_general_string(tribe, building_description)
       local number_of_resources = #collected_resources
       if number_of_resources > 0 then
          for i, resource in ipairs(collected_resources) do
-            max_percent = max_percent + resource.max
-            depletion_chance = depletion_chance + resource.chance
+            max_percent = max_percent + resource.yield
+            depletion_chance = depletion_chance + resource.when_empty
          end
          max_percent = max_percent / number_of_resources
          depletion_chance = depletion_chance / number_of_resources

--- a/src/ai/ai_help_structs.h
+++ b/src/ai/ai_help_structs.h
@@ -479,7 +479,8 @@ struct BuildingObserver {
 
 	uint16_t unconnected_count;  // to any warehouse (count of such buildings)
 
-	Widelands::DescriptionIndex mines;  // type of resource it mines_
+	Widelands::DescriptionIndex mines;  // type of resource it mines
+	// TODO(GunChleoc): mines_percent is not used anywhere yet
 	uint16_t mines_percent;             // % of res it can mine
 	uint32_t current_stats;
 

--- a/src/ai/ai_help_structs.h
+++ b/src/ai/ai_help_structs.h
@@ -480,8 +480,6 @@ struct BuildingObserver {
 	uint16_t unconnected_count;  // to any warehouse (count of such buildings)
 
 	Widelands::DescriptionIndex mines;  // type of resource it mines
-	// TODO(GunChleoc): mines_percent is not used anywhere yet
-	uint16_t mines_percent;             // % of res it can mine
 	uint32_t current_stats;
 
 	uint32_t basic_amount;  // basic amount for basic economy as defined in init.lua

--- a/src/ai/ai_hints.cc
+++ b/src/ai/ai_hints.cc
@@ -230,7 +230,7 @@ Production Sites
 
 */
 
-BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table)
+BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table, const std::string& building_name)
    : needs_water_(table->has_key("needs_water") ? table->get_bool("needs_water") : false),
      space_consumer_(table->has_key("space_consumer") ? table->get_bool("space_consumer") : false),
      expansion_(table->has_key("expansion") ? table->get_bool("expansion") : false),
@@ -264,10 +264,10 @@ BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table)
 	}
 
 	if (table->has_key("mines")) {
-		log_warn("The 'mines' key in 'ai_hints' is no longer used\n");
+		log_warn("%s: The 'mines' key in 'ai_hints' is no longer used", building_name.c_str());
 	}
 	if (table->has_key("mines_percent")) {
-		log_warn("The 'mines_percent' key in 'ai_hints' is no longer used\n");
+		log_warn("%s: The 'mines_percent' key in 'ai_hints' is no longer used", building_name.c_str());
 	}
 }
 

--- a/src/ai/ai_hints.cc
+++ b/src/ai/ai_hints.cc
@@ -159,12 +159,12 @@ Production Sites
     ``water`` (well).
 
 **mines**
-    The building will mine to obtain the given ware, e.g.::
+    **DEPRECATED** The building will mine to obtain the given ware, e.g.::
 
         mines = "resource_gold",
 
 **mines_percent**
-    The percentage that a mine will mine of its resource before it needs enhancing, e.g.::
+    **DEPRECATED** The percentage that a mine will mine of its resource before it needs enhancing, e.g.::
 
         mines_percent = 60,
 
@@ -231,7 +231,7 @@ Production Sites
 */
 
 BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table)
-   : mines_(table->has_key("mines") ? table->get_string("mines") : ""),
+   : mines_(Widelands::INVALID_INDEX),
      needs_water_(table->has_key("needs_water") ? table->get_bool("needs_water") : false),
      space_consumer_(table->has_key("space_consumer") ? table->get_bool("space_consumer") : false),
      expansion_(table->has_key("expansion") ? table->get_bool("expansion") : false),
@@ -248,7 +248,6 @@ BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table)
      basic_amount_(table->has_key("basic_amount") ? table->get_int("basic_amount") : 0),
      // 10 days default
      forced_after_(table->has_key("forced_after") ? table->get_int("forced_after") : 864000),
-     mines_percent_(table->has_key("mines_percent") ? table->get_int("mines_percent") : 100),
      very_weak_ai_limit_(
         table->has_key("very_weak_ai_limit") ? table->get_int("very_weak_ai_limit") : -1),
      weak_ai_limit_(table->has_key("weak_ai_limit") ? table->get_int("weak_ai_limit") : -1),
@@ -263,6 +262,13 @@ BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table)
 		     table->get_table("supports_production_of")->array_entries<std::string>()) {
 			supported_production_.insert(ware_name);
 		}
+	}
+
+	if (table->has_key("mines")) {
+		log_warn("The 'mines' key in 'ai_hints' is no longer used\n");
+	}
+	if (table->has_key("mines_percent")) {
+		log_warn("The 'mines_percent' key in 'ai_hints' is no longer used\n");
 	}
 }
 

--- a/src/ai/ai_hints.cc
+++ b/src/ai/ai_hints.cc
@@ -231,8 +231,7 @@ Production Sites
 */
 
 BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table)
-   : mines_(Widelands::INVALID_INDEX),
-     needs_water_(table->has_key("needs_water") ? table->get_bool("needs_water") : false),
+   : needs_water_(table->has_key("needs_water") ? table->get_bool("needs_water") : false),
      space_consumer_(table->has_key("space_consumer") ? table->get_bool("space_consumer") : false),
      expansion_(table->has_key("expansion") ? table->get_bool("expansion") : false),
      fighting_(table->has_key("fighting") ? table->get_bool("fighting") : false),

--- a/src/ai/ai_hints.cc
+++ b/src/ai/ai_hints.cc
@@ -164,7 +164,8 @@ Production Sites
         mines = "resource_gold",
 
 **mines_percent**
-    **DEPRECATED** The percentage that a mine will mine of its resource before it needs enhancing, e.g.::
+    **DEPRECATED** The percentage that a mine will mine of its resource before it needs enhancing,
+e.g.::
 
         mines_percent = 60,
 
@@ -267,7 +268,8 @@ BuildingHints::BuildingHints(std::unique_ptr<LuaTable> table, const std::string&
 		log_warn("%s: The 'mines' key in 'ai_hints' is no longer used", building_name.c_str());
 	}
 	if (table->has_key("mines_percent")) {
-		log_warn("%s: The 'mines_percent' key in 'ai_hints' is no longer used", building_name.c_str());
+		log_warn(
+		   "%s: The 'mines_percent' key in 'ai_hints' is no longer used", building_name.c_str());
 	}
 }
 

--- a/src/ai/ai_hints.cc
+++ b/src/ai/ai_hints.cc
@@ -165,7 +165,7 @@ Production Sites
 
 **mines_percent**
     **DEPRECATED** The percentage that a mine will mine of its resource before it needs enhancing,
-e.g.::
+    e.g.::
 
         mines_percent = 60,
 

--- a/src/ai/ai_hints.h
+++ b/src/ai/ai_hints.h
@@ -34,7 +34,7 @@ enum class AiType : uint8_t { kVeryWeak, kWeak, kNormal };
 /// buildings conf file. It is used to tell the computer player about the
 /// special properties of a building.
 struct BuildingHints {
-	explicit BuildingHints(std::unique_ptr<LuaTable>);
+	explicit BuildingHints(std::unique_ptr<LuaTable>, const std::string& building_name);
 	~BuildingHints() {
 	}
 

--- a/src/ai/ai_hints.h
+++ b/src/ai/ai_hints.h
@@ -42,18 +42,6 @@ struct BuildingHints {
 		return supported_production_;
 	}
 
-	void set_mines(Widelands::DescriptionIndex world_resource, uint8_t mines_percent) {
-		mines_ = world_resource;
-		mines_percent_ = mines_percent;
-	}
-
-	Widelands::DescriptionIndex get_mines() const {
-		return mines_;
-	}
-	uint8_t get_mines_percent() const {
-		return mines_percent_;
-	}
-
 	bool get_needs_water() const {
 		return needs_water_;
 	}
@@ -106,8 +94,6 @@ struct BuildingHints {
 	uint8_t trainingsites_max_percent() const;
 
 private:
-	Widelands::DescriptionIndex mines_;
-	uint8_t mines_percent_;
 	const bool needs_water_;
 	const bool space_consumer_;
 	const bool expansion_;

--- a/src/ai/ai_hints.h
+++ b/src/ai/ai_hints.h
@@ -42,12 +42,16 @@ struct BuildingHints {
 		return supported_production_;
 	}
 
-	bool has_mines() const {
-		return !mines_.empty();
+	void set_mines(Widelands::DescriptionIndex world_resource, uint8_t mines_percent) {
+		mines_ = world_resource;
+		mines_percent_ = mines_percent;
 	}
 
-	char const* get_mines() const {
-		return mines_.c_str();
+	Widelands::DescriptionIndex get_mines() const {
+		return mines_;
+	}
+	uint8_t get_mines_percent() const {
+		return mines_percent_;
 	}
 
 	bool get_needs_water() const {
@@ -95,10 +99,6 @@ struct BuildingHints {
 		return forced_after_;
 	}
 
-	uint8_t get_mines_percent() const {
-		return mines_percent_;
-	}
-
 	int16_t get_ai_limit(AiType) const;
 
 	void set_trainingsites_max_percent(int percent);
@@ -106,7 +106,8 @@ struct BuildingHints {
 	uint8_t trainingsites_max_percent() const;
 
 private:
-	const std::string mines_;
+	Widelands::DescriptionIndex mines_;
+	uint8_t mines_percent_;
 	const bool needs_water_;
 	const bool space_consumer_;
 	const bool expansion_;
@@ -118,7 +119,6 @@ private:
 	const int32_t prohibited_till_;
 	const uint32_t basic_amount_;
 	const int32_t forced_after_;
-	const int8_t mines_percent_;
 	const int16_t very_weak_ai_limit_;
 	const int16_t weak_ai_limit_;
 	const int16_t normal_ai_limit_;

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -760,10 +760,7 @@ void DefaultAI::late_initialization() {
 
 			if (bo.type == BuildingObserver::Type::kMine) {
 				// get the resource needed by the mine
-				if (bh.get_mines()) {
-					bo.mines = game().descriptions().resource_index(bh.get_mines());
-				}
-
+				bo.mines = bh.get_mines();
 				bo.mines_percent = bh.get_mines_percent();
 
 				// populating mines_per_type map

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -768,10 +768,8 @@ void DefaultAI::late_initialization() {
 				if (first_resource_it == collected_resources.end()) {
 					log_warn("AI %d: The mine '%s' does not mine any resources!", player_number(), bo.name);
 					bo.mines = Widelands::INVALID_INDEX;
-					bo.mines_percent = 0;
 				} else {
 					bo.mines = game().descriptions().resource_index(first_resource_it->first);
-					bo.mines_percent = first_resource_it->second.max_percent;
 				}
 
 				// populating mines_per_type map

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -762,11 +762,14 @@ void DefaultAI::late_initialization() {
 				// get the resource needed by the mine
 				const auto& collected_resources = prod.collected_resources();
 				if (collected_resources.size() > 1) {
-					log_warn("AI %d: The mine '%s' will mine multiple resources. The AI can't handle this and will simply pick the first one from the list.", player_number(), bo.name);
+					log_warn("AI %d: The mine '%s' will mine multiple resources. The AI can't handle "
+					         "this and will simply pick the first one from the list.",
+					         player_number(), bo.name);
 				}
 				const auto& first_resource_it = collected_resources.begin();
 				if (first_resource_it == collected_resources.end()) {
-					log_warn("AI %d: The mine '%s' does not mine any resources!", player_number(), bo.name);
+					log_warn(
+					   "AI %d: The mine '%s' does not mine any resources!", player_number(), bo.name);
 					bo.mines = Widelands::INVALID_INDEX;
 				} else {
 					bo.mines = game().descriptions().resource_index(first_resource_it->first);

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -762,11 +762,11 @@ void DefaultAI::late_initialization() {
 				// get the resource needed by the mine
 				const auto& collected_resources = prod.collected_resources();
 				if (collected_resources.size() > 1) {
-					log_warn("AI %d: The mine %s will mine multiple resources. The AI can't handle this and will simply pick the first one from the list.", player_number(), bo.name);
+					log_warn("AI %d: The mine '%s' will mine multiple resources. The AI can't handle this and will simply pick the first one from the list.", player_number(), bo.name);
 				}
 				const auto& first_resource_it = collected_resources.begin();
 				if (first_resource_it == collected_resources.end()) {
-					log_warn("AI %d: The mine %s does not mine any resources!", player_number(), bo.name);
+					log_warn("AI %d: The mine '%s' does not mine any resources!", player_number(), bo.name);
 					bo.mines = Widelands::INVALID_INDEX;
 					bo.mines_percent = 0;
 				} else {

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -760,8 +760,19 @@ void DefaultAI::late_initialization() {
 
 			if (bo.type == BuildingObserver::Type::kMine) {
 				// get the resource needed by the mine
-				bo.mines = bh.get_mines();
-				bo.mines_percent = bh.get_mines_percent();
+				const auto& collected_resources = prod.collected_resources();
+				if (collected_resources.size() > 1) {
+					log_warn("AI %d: The mine %s will mine multiple resources. The AI can't handle this and will simply pick the first one from the list.", player_number(), bo.name);
+				}
+				const auto& first_resource_it = collected_resources.begin();
+				if (first_resource_it == collected_resources.end()) {
+					log_warn("AI %d: The mine %s does not mine any resources!", player_number(), bo.name);
+					bo.mines = Widelands::INVALID_INDEX;
+					bo.mines_percent = 0;
+				} else {
+					bo.mines = game().descriptions().resource_index(first_resource_it->first);
+					bo.mines_percent = first_resource_it->second;
+				}
 
 				// populating mines_per_type map
 				if (mines_per_type.count(bo.mines) == 0) {

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -771,7 +771,7 @@ void DefaultAI::late_initialization() {
 					bo.mines_percent = 0;
 				} else {
 					bo.mines = game().descriptions().resource_index(first_resource_it->first);
-					bo.mines_percent = first_resource_it->second;
+					bo.mines_percent = first_resource_it->second.max_percent;
 				}
 
 				// populating mines_per_type map

--- a/src/logic/map_objects/tribes/building.cc
+++ b/src/logic/map_objects/tribes/building.cc
@@ -55,6 +55,7 @@ BuildingDescr::BuildingDescr(const std::string& init_descname,
                              const LuaTable& table,
                              Descriptions& descriptions)
    : MapObjectDescr(init_type, table.get_string("name"), init_descname, table),
+     hints_(table.get_table("aihints")),
      descriptions_(descriptions),
      buildable_(table.has_key("buildcost")),
      can_be_dismantled_(table.has_key("return_on_dismantle")),
@@ -65,7 +66,6 @@ BuildingDescr::BuildingDescr(const std::string& init_descname,
      enhancement_(INVALID_INDEX),
      enhanced_from_(INVALID_INDEX),
      enhanced_building_(false),
-     hints_(table.get_table("aihints")),
      vision_range_(0) {
 	if (!is_animation_known("idle")) {
 		throw GameDataError("Building %s has no idle animation", name().c_str());

--- a/src/logic/map_objects/tribes/building.cc
+++ b/src/logic/map_objects/tribes/building.cc
@@ -55,7 +55,6 @@ BuildingDescr::BuildingDescr(const std::string& init_descname,
                              const LuaTable& table,
                              Descriptions& descriptions)
    : MapObjectDescr(init_type, table.get_string("name"), init_descname, table),
-     hints_(table.get_table("aihints")),
      descriptions_(descriptions),
      buildable_(table.has_key("buildcost")),
      can_be_dismantled_(table.has_key("return_on_dismantle")),
@@ -66,6 +65,7 @@ BuildingDescr::BuildingDescr(const std::string& init_descname,
      enhancement_(INVALID_INDEX),
      enhanced_from_(INVALID_INDEX),
      enhanced_building_(false),
+     hints_(table.get_table("aihints"), name()),
      vision_range_(0) {
 	if (!is_animation_known("idle")) {
 		throw GameDataError("Building %s has no idle animation", name().c_str());

--- a/src/logic/map_objects/tribes/building.h
+++ b/src/logic/map_objects/tribes/building.h
@@ -172,8 +172,6 @@ protected:
 	virtual Building& create_object() const = 0;
 	Building& create_constructionsite() const;
 
-	AI::BuildingHints hints_;     // hints (knowledge) for computer players
-
 private:
 	void set_enhancement_cost(const Buildcost& enhance_cost, const Buildcost& return_enhanced);
 
@@ -196,6 +194,7 @@ private:
 	DescriptionIndex
 	   enhanced_from_;         // The building this building was enhanced from, or INVALID_INDEX
 	bool enhanced_building_;   // if it is one, it is bulldozable
+	AI::BuildingHints hints_;  // hints (knowledge) for computer players
 	DescriptionIndex built_over_immovable_;  // can be built only on nodes where an immovable with
 	                                         // this attribute stands
 

--- a/src/logic/map_objects/tribes/building.h
+++ b/src/logic/map_objects/tribes/building.h
@@ -172,6 +172,8 @@ protected:
 	virtual Building& create_object() const = 0;
 	Building& create_constructionsite() const;
 
+	AI::BuildingHints hints_;     // hints (knowledge) for computer players
+
 private:
 	void set_enhancement_cost(const Buildcost& enhance_cost, const Buildcost& return_enhanced);
 
@@ -194,7 +196,6 @@ private:
 	DescriptionIndex
 	   enhanced_from_;         // The building this building was enhanced from, or INVALID_INDEX
 	bool enhanced_building_;   // if it is one, it is bulldozable
-	AI::BuildingHints hints_;  // hints (knowledge) for computer players
 	DescriptionIndex built_over_immovable_;  // can be built only on nodes where an immovable with
 	                                         // this attribute stands
 

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -967,7 +967,8 @@ ProductionProgram::ActCallWorker::ActCallWorker(const std::vector<std::string>& 
 		descr->add_created_attribute(attribute_info);
 	}
 	for (const std::string& resourcename : workerprogram->collected_resources()) {
-		descr->add_collected_resource(resourcename);
+		// Workers always collect 100% of the resource
+		descr->add_collected_resource(resourcename, 100);
 	}
 	for (const std::string& resourcename : workerprogram->created_resources()) {
 		descr->add_created_resource(resourcename);
@@ -1504,14 +1505,11 @@ ProductionProgram::ActMine::ActMine(const std::vector<std::string>& arguments,
 		}
 	}
 
-	// NOCOM partial duplicate with add_collected_resource
-	descr->set_mines(resource_, max_resources_);
-
 	const std::string description = descr->name() + " " + production_program_name + " mine " +
 	                                descriptions.get_resource_descr(resource_)->name();
 	descr->workarea_info_[workarea_].insert(description);
 
-	descr->add_collected_resource(arguments.front());
+	descr->add_collected_resource(arguments.front(), max_resources_);
 }
 
 void ProductionProgram::ActMine::execute(Game& game, ProductionSite& ps) const {

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -967,8 +967,8 @@ ProductionProgram::ActCallWorker::ActCallWorker(const std::vector<std::string>& 
 		descr->add_created_attribute(attribute_info);
 	}
 	for (const std::string& resourcename : workerprogram->collected_resources()) {
-		// Workers always collect 100% of the resource
-		descr->add_collected_resource(resourcename, 100);
+		// Workers always collect 100% of the resource, and then find no more
+		descr->add_collected_resource(resourcename, 100, 0);
 	}
 	for (const std::string& resourcename : workerprogram->created_resources()) {
 		descr->add_created_resource(resourcename);
@@ -1509,7 +1509,7 @@ ProductionProgram::ActMine::ActMine(const std::vector<std::string>& arguments,
 	                                descriptions.get_resource_descr(resource_)->name();
 	descr->workarea_info_[workarea_].insert(description);
 
-	descr->add_collected_resource(arguments.front(), max_resources_);
+	descr->add_collected_resource(arguments.front(), max_resources_, depleted_chance_);
 }
 
 void ProductionProgram::ActMine::execute(Game& game, ProductionSite& ps) const {

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -1504,6 +1504,9 @@ ProductionProgram::ActMine::ActMine(const std::vector<std::string>& arguments,
 		}
 	}
 
+	// NOCOM partial duplicate with add_collected_resource
+	descr->set_mines(resource_, max_resources_);
+
 	const std::string description = descr->name() + " " + production_program_name + " mine " +
 	                                descriptions.get_resource_descr(resource_)->name();
 	descr->workarea_info_[workarea_].insert(description);

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -243,6 +243,11 @@ protected:
 		created_resources_.insert(resource);
 	}
 
+	/// Set AI hints for mined world resource
+	void set_mines(Widelands::DescriptionIndex world_resource, uint8_t mines_percent) {
+		hints_.set_mines(world_resource, mines_percent);
+	}
+
 private:
 	std::unique_ptr<std::set<DescriptionIndex>> ware_demand_checks_;
 	std::unique_ptr<std::set<DescriptionIndex>> worker_demand_checks_;

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -112,8 +112,8 @@ public:
 	/// We only need the attributes during tribes initialization
 	void clear_attributes();
 
-	/// The resources that this production site needs to collect from the map
-	const std::set<std::string>& collected_resources() const {
+	/// The resources that this production site needs to collect from the map, and the max percent it can achieve
+	const std::map<std::string, uint8_t>& collected_resources() const {
 		return collected_resources_;
 	}
 	/// The resources that this production site will place on the map
@@ -235,17 +235,12 @@ protected:
 		created_attributes_.insert(attribute_info);
 	}
 	/// Set that this production site needs to collect the given resource from the map
-	void add_collected_resource(const std::string& resource) {
-		collected_resources_.insert(resource);
+	void add_collected_resource(const std::string& resource, uint8_t max_percent) {
+		collected_resources_.insert(std::make_pair(resource, max_percent));
 	}
 	/// Set that this production site will place the given resource on the map
 	void add_created_resource(const std::string& resource) {
 		created_resources_.insert(resource);
-	}
-
-	/// Set AI hints for mined world resource
-	void set_mines(Widelands::DescriptionIndex world_resource, uint8_t mines_percent) {
-		hints_.set_mines(world_resource, mines_percent);
 	}
 
 private:
@@ -258,7 +253,8 @@ private:
 	Output output_worker_types_;
 	std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>> collected_attributes_;
 	std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>> created_attributes_;
-	std::set<std::string> collected_resources_;
+	// Resource name, max percent
+	std::map<std::string, uint8_t> collected_resources_;
 	std::set<std::string> created_resources_;
 	std::set<std::string> collected_bobs_;
 	std::set<std::string> created_bobs_;

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -112,8 +112,13 @@ public:
 	/// We only need the attributes during tribes initialization
 	void clear_attributes();
 
+	struct MinedResourceInfo {
+		unsigned max_percent;
+		unsigned depleted_chance;
+	};
+
 	/// The resources that this production site needs to collect from the map, and the max percent it can achieve
-	const std::map<std::string, uint8_t>& collected_resources() const {
+	const std::map<std::string, MinedResourceInfo>& collected_resources() const {
 		return collected_resources_;
 	}
 	/// The resources that this production site will place on the map
@@ -235,8 +240,8 @@ protected:
 		created_attributes_.insert(attribute_info);
 	}
 	/// Set that this production site needs to collect the given resource from the map
-	void add_collected_resource(const std::string& resource, uint8_t max_percent) {
-		collected_resources_.insert(std::make_pair(resource, max_percent));
+	void add_collected_resource(const std::string& resource, unsigned max_percent, unsigned depleted_chance) {
+		collected_resources_.insert(std::make_pair(resource, MinedResourceInfo{max_percent, depleted_chance}));
 	}
 	/// Set that this production site will place the given resource on the map
 	void add_created_resource(const std::string& resource) {
@@ -254,7 +259,7 @@ private:
 	std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>> collected_attributes_;
 	std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>> created_attributes_;
 	// Resource name, max percent
-	std::map<std::string, uint8_t> collected_resources_;
+	std::map<std::string, MinedResourceInfo> collected_resources_;
 	std::set<std::string> created_resources_;
 	std::set<std::string> collected_bobs_;
 	std::set<std::string> created_bobs_;

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -117,7 +117,8 @@ public:
 		unsigned depleted_chance;
 	};
 
-	/// The resources that this production site needs to collect from the map, the max percent it can achieve, and the chance when depleted
+	/// The resources that this production site needs to collect from the map, the max percent it can
+	/// achieve, and the chance when depleted
 	const std::map<std::string, CollectedResourceInfo>& collected_resources() const {
 		return collected_resources_;
 	}
@@ -240,8 +241,11 @@ protected:
 		created_attributes_.insert(attribute_info);
 	}
 	/// Set that this production site needs to collect the given resource from the map
-	void add_collected_resource(const std::string& resource, unsigned max_percent, unsigned depleted_chance) {
-		collected_resources_.insert(std::make_pair(resource, CollectedResourceInfo{max_percent, depleted_chance}));
+	void add_collected_resource(const std::string& resource,
+	                            unsigned max_percent,
+	                            unsigned depleted_chance) {
+		collected_resources_.insert(
+		   std::make_pair(resource, CollectedResourceInfo{max_percent, depleted_chance}));
 	}
 	/// Set that this production site will place the given resource on the map
 	void add_created_resource(const std::string& resource) {

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -112,13 +112,13 @@ public:
 	/// We only need the attributes during tribes initialization
 	void clear_attributes();
 
-	struct MinedResourceInfo {
+	struct CollectedResourceInfo {
 		unsigned max_percent;
 		unsigned depleted_chance;
 	};
 
-	/// The resources that this production site needs to collect from the map, and the max percent it can achieve
-	const std::map<std::string, MinedResourceInfo>& collected_resources() const {
+	/// The resources that this production site needs to collect from the map, the max percent it can achieve, and the chance when depleted
+	const std::map<std::string, CollectedResourceInfo>& collected_resources() const {
 		return collected_resources_;
 	}
 	/// The resources that this production site will place on the map
@@ -241,7 +241,7 @@ protected:
 	}
 	/// Set that this production site needs to collect the given resource from the map
 	void add_collected_resource(const std::string& resource, unsigned max_percent, unsigned depleted_chance) {
-		collected_resources_.insert(std::make_pair(resource, MinedResourceInfo{max_percent, depleted_chance}));
+		collected_resources_.insert(std::make_pair(resource, CollectedResourceInfo{max_percent, depleted_chance}));
 	}
 	/// Set that this production site will place the given resource on the map
 	void add_created_resource(const std::string& resource) {
@@ -258,8 +258,7 @@ private:
 	Output output_worker_types_;
 	std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>> collected_attributes_;
 	std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>> created_attributes_;
-	// Resource name, max percent
-	std::map<std::string, MinedResourceInfo> collected_resources_;
+	std::map<std::string, CollectedResourceInfo> collected_resources_;
 	std::set<std::string> created_resources_;
 	std::set<std::string> collected_bobs_;
 	std::set<std::string> created_bobs_;

--- a/src/logic/map_objects/tribes/tribe_descr.cc
+++ b/src/logic/map_objects/tribes/tribe_descr.cc
@@ -858,8 +858,8 @@ void TribeDescr::process_productionsites(Descriptions& descriptions) {
 				descriptions.get_mutable_worker_descr(job.first)->add_employer(index);
 			}
 			// Resource info
-			for (const std::string& r : productionsite->collected_resources()) {
-				used_resources_.insert(r);
+			for (const auto& r : productionsite->collected_resources()) {
+				used_resources_.insert(r.first);
 			}
 			for (const std::string& r : productionsite->created_resources()) {
 				used_resources_.insert(r);
@@ -996,8 +996,8 @@ void TribeDescr::process_productionsites(Descriptions& descriptions) {
 		for (const std::string& resource : prod->created_resources()) {
 			add_creator(resource, prod);
 		}
-		for (const std::string& resource : prod->collected_resources()) {
-			add_collector(resource, prod);
+		for (const auto& resource : prod->collected_resources()) {
+			add_collector(resource.first, prod);
 		}
 		for (const std::string& bob : prod->collected_bobs()) {
 			add_collector(bob, prod);
@@ -1072,11 +1072,11 @@ void TribeDescr::process_productionsites(Descriptions& descriptions) {
 				}
 			}
 		}
-		for (const std::string& item : prod->collected_resources()) {
+		for (const auto& item : prod->collected_resources()) {
 			// Sites that collect resources and sites of other types that create resources for them
 			// should overlap each other
-			if (creators.count(item)) {
-				for (ProductionSiteDescr* creator : creators.at(item)) {
+			if (creators.count(item.first)) {
+				for (ProductionSiteDescr* creator : creators.at(item.first)) {
 					if (creator != prod) {
 						prod->add_supported_by_productionsite(creator->name());
 						creator->add_supports_productionsite(prod->name());
@@ -1084,8 +1084,8 @@ void TribeDescr::process_productionsites(Descriptions& descriptions) {
 				}
 			}
 			// Sites that collect resources should not overlap sites that collect the same resource
-			if (collectors.count(item)) {
-				for (const ProductionSiteDescr* collector : collectors.at(item)) {
+			if (collectors.count(item.first)) {
+				for (const ProductionSiteDescr* collector : collectors.at(item.first)) {
 					prod->add_competing_productionsite(collector->name());
 				}
 			}

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -2680,17 +2680,27 @@ int LuaProductionSiteDescription::get_collected_immovables(lua_State* L) {
       this building will collect from the map.
       For example, a Fishers's House will collect the "fish" resource.
 */
+// NOCOM
 int LuaProductionSiteDescription::get_collected_resources(lua_State* L) {
 	lua_newtable(L);
 	int index = 1;
 	Widelands::EditorGameBase& egbase = get_egbase(L);
 	for (const auto& resource_info : get()->collected_resources()) {
 		lua_pushint32(L, index++);
+		lua_newtable(L);
+		lua_pushstring(L, "resource");
 		const Widelands::ResourceDescription* resource = egbase.descriptions().get_resource_descr(
 		   egbase.descriptions().resource_index(resource_info.first));
 		assert(resource != nullptr);
 		to_lua<LuaResourceDescription>(L, new LuaResourceDescription(resource));
 		lua_rawset(L, -3);
+		lua_pushstring(L, "max");
+		lua_pushnumber(L, resource_info.second.max_percent / 100.f);
+		lua_settable(L, -3);
+		lua_pushstring(L, "chance");
+		lua_pushnumber(L, resource_info.second.depleted_chance / 100.f);
+		lua_settable(L, -3);
+		lua_settable(L, -3);
 	}
 	return 1;
 }

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -2677,10 +2677,31 @@ int LuaProductionSiteDescription::get_collected_immovables(lua_State* L) {
    .. attribute:: collected_resources
 
       (RO) An array with :class:`ResourceDescription` containing the resources that
-      this building will collect from the map.
-      For example, a Fishers's House will collect the "fish" resource.
+      this building will collect from the map, along with the maximum percentage mined and the
+      chance to still find some more after depletion. For example, a Fishers's House will collect:
+
+      .. code-block:: lua
+
+       {
+            {
+               resource = <resource description for fish>,
+               yield = 100,
+               when_empty = 0
+            }
+         }
+
+      and a Barbarian Coal Mine will collect:
+
+      .. code-block:: lua
+
+         {
+            {
+               resource = <resource description for coal>,
+               yield = 33.33,
+               when_empty = 5
+            }
+         }
 */
-// NOCOM
 int LuaProductionSiteDescription::get_collected_resources(lua_State* L) {
 	lua_newtable(L);
 	int index = 1;
@@ -2694,10 +2715,10 @@ int LuaProductionSiteDescription::get_collected_resources(lua_State* L) {
 		assert(resource != nullptr);
 		to_lua<LuaResourceDescription>(L, new LuaResourceDescription(resource));
 		lua_rawset(L, -3);
-		lua_pushstring(L, "max");
+		lua_pushstring(L, "yield");
 		lua_pushnumber(L, resource_info.second.max_percent / 100.f);
 		lua_settable(L, -3);
-		lua_pushstring(L, "chance");
+		lua_pushstring(L, "when_empty");
 		lua_pushnumber(L, resource_info.second.depleted_chance / 100.f);
 		lua_settable(L, -3);
 		lua_settable(L, -3);

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -2716,10 +2716,10 @@ int LuaProductionSiteDescription::get_collected_resources(lua_State* L) {
 		to_lua<LuaResourceDescription>(L, new LuaResourceDescription(resource));
 		lua_rawset(L, -3);
 		lua_pushstring(L, "yield");
-		lua_pushnumber(L, resource_info.second.max_percent / 100.f);
+		lua_pushnumber(L, resource_info.second.max_percent / 100.0);
 		lua_settable(L, -3);
 		lua_pushstring(L, "when_empty");
-		lua_pushnumber(L, resource_info.second.depleted_chance / 100.f);
+		lua_pushnumber(L, resource_info.second.depleted_chance / 100.0);
 		lua_settable(L, -3);
 		lua_settable(L, -3);
 	}

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -2684,10 +2684,10 @@ int LuaProductionSiteDescription::get_collected_resources(lua_State* L) {
 	lua_newtable(L);
 	int index = 1;
 	Widelands::EditorGameBase& egbase = get_egbase(L);
-	for (const std::string& resource_name : get()->collected_resources()) {
+	for (const auto& resource_info : get()->collected_resources()) {
 		lua_pushint32(L, index++);
 		const Widelands::ResourceDescription* resource = egbase.descriptions().get_resource_descr(
-		   egbase.descriptions().resource_index(resource_name));
+		   egbase.descriptions().resource_index(resource_info.first));
 		assert(resource != nullptr);
 		to_lua<LuaResourceDescription>(L, new LuaResourceDescription(resource));
 		lua_rawset(L, -3);

--- a/src/ui_fsmenu/mapselect.cc
+++ b/src/ui_fsmenu/mapselect.cc
@@ -103,7 +103,8 @@ FullscreenMenuMapSelect::FullscreenMenuMapSelect(FullscreenMenuMain& fsmm,
 	   hbox, "dropdown_team_tags", 0, 0, 200, 50, 24, "", UI::DropdownType::kTextual,
 	   UI::PanelStyle::kFsMenu, UI::ButtonStyle::kFsMenuMenu);
 	team_tags_dropdown_->set_autoexpand_display_button();
-    /** TRANSLATORS: Filter entry in map selection. Other entries are "Free for all"", "Teams of 2" etc. */
+	/** TRANSLATORS: Filter entry in map selection. Other entries are "Free for all"", "Teams of 2"
+	 * etc. */
 	team_tags_dropdown_->add(_("Any Teams"), "");
 	team_tags_dropdown_->add(localize_tag("ffa"), "ffa");
 	team_tags_dropdown_->add(localize_tag("1v1"), "1v1");


### PR DESCRIPTION
- Get rid of `mines` and `mines_percent` AI hints
- Remove unused variable `mines_percent` from BuildingObserver
- Automate building help for mines regarding yield and chance when empty.

Re. https://github.com/widelands/widelands/issues/3989