### PR TITLE
Fix tooltip position

### DIFF
--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -1288,11 +1288,20 @@ bool Panel::draw_tooltip(const std::string& text, const PanelStyle style) {
                                                                 UI::FontStyle::kFsTooltip);
 	}
 
-	constexpr uint32_t kTipWidthMax = 360;
+	constexpr int kTipWidthMax = 360;
 	std::shared_ptr<const UI::RenderedText> rendered_text =
 	   g_fh->render(text_to_render, kTipWidthMax);
+
 	if (rendered_text->rects.empty()) {
 		return false;
+	}
+
+	// the rendering engine can only adhere to width limitation when there is a whitespace to
+	// introduce a line break. If not, the actual tooltips width exceeds kTipWidthMax. To avoid
+	// unnecessary linebreaks in subsequent string (when it is a formatted string), re-render with
+	// needed width
+	if (rendered_text->width() > kTipWidthMax) {
+		rendered_text = g_fh->render(text_to_render, rendered_text->width());
 	}
 
 	constexpr int kPadding = 4;

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -1284,8 +1284,8 @@ bool Panel::draw_tooltip(const std::string& text, const PanelStyle style) {
 	std::string text_to_render = text;
 	if (!is_richtext(text_to_render)) {
 		text_to_render = as_richtext_paragraph(text_to_render, style == PanelStyle::kWui ?
-		                                                          UI::FontStyle::kWuiTooltip :
-		                                                          UI::FontStyle::kFsTooltip);
+                                                                UI::FontStyle::kWuiTooltip :
+                                                                UI::FontStyle::kFsTooltip);
 	}
 
 	constexpr uint32_t kTipWidthMax = 360;
@@ -1295,18 +1295,23 @@ bool Panel::draw_tooltip(const std::string& text, const PanelStyle style) {
 		return false;
 	}
 
-	const uint16_t tip_width = rendered_text->width() + 4;
-	const uint16_t tip_height = rendered_text->height() + 4;
+	constexpr int kPadding = 4;
+	constexpr int kCursorHeight = 32;
+	const uint16_t tip_width = rendered_text->width() + kPadding;
+	const uint16_t tip_height = rendered_text->height() + kPadding;
 
-	Recti r(WLApplication::get()->get_mouse_position() + Vector2i(2, 32), tip_width, tip_height);
+	Recti r(WLApplication::get()->get_mouse_position() + Vector2i(2, kCursorHeight), tip_width,
+	        tip_height);
 	const Vector2i tooltip_bottom_right = r.opposite_of_origin();
 	const Vector2i screen_bottom_right(g_gr->get_xres(), g_gr->get_yres());
 	if (screen_bottom_right.x < tooltip_bottom_right.x) {
-		r.x -= 4 + r.w;
+		r.x -= kPadding + r.w;
 	}
 	if (screen_bottom_right.y < tooltip_bottom_right.y) {
-		r.y -= 35 + r.h;
+		r.y -= kCursorHeight + kPadding + r.h;
 	}
+	r.x = std::max(kPadding, r.x);
+	r.y = std::max(kPadding, r.y);
 
 	dst.fill_rect(r, RGBColor(63, 52, 34));
 	dst.draw_rect(r, RGBColor(0, 0, 0));

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -1284,8 +1284,8 @@ bool Panel::draw_tooltip(const std::string& text, const PanelStyle style) {
 	std::string text_to_render = text;
 	if (!is_richtext(text_to_render)) {
 		text_to_render = as_richtext_paragraph(text_to_render, style == PanelStyle::kWui ?
-                                                                UI::FontStyle::kWuiTooltip :
-                                                                UI::FontStyle::kFsTooltip);
+		                                                          UI::FontStyle::kWuiTooltip :
+		                                                          UI::FontStyle::kFsTooltip);
 	}
 
 	constexpr int kTipWidthMax = 360;


### PR DESCRIPTION
fixes #4180

Not sure if the workaround for the unwanted line break is ok. Maybe it better should be fixed in the text rendering component itself (but that looks rather complicated to me imho)?

![grafik](https://user-images.githubusercontent.com/10723431/98466622-ed1dcf00-21d0-11eb-8f17-6e81d7d4b037.png)
