### PR TITLE
Disambiguate soldier strings in training site tooltips

### DIFF
--- a/data/tribes/buildings/trainingsites/amazons/training_glade/init.lua
+++ b/data/tribes/buildings/trainingsites/amazons/training_glade/init.lua
@@ -229,7 +229,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 6,
-   trainer_patience = 11
+   trainer_patience = 11,
+
+   messages = {
+      -- TRANSLATORS: Amazon training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("amazons_building", "No soldier to train!"),
+      -- TRANSLATORS: Amazon training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("amazons_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/amazons/warriors_gathering/init.lua
+++ b/data/tribes/buildings/trainingsites/amazons/warriors_gathering/init.lua
@@ -115,7 +115,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 8,
-   trainer_patience = 9
+   trainer_patience = 9,
+
+   messages = {
+      -- TRANSLATORS: Amazon training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("amazons_building", "No soldier to train!"),
+      -- TRANSLATORS: Amazon training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("amazons_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/atlanteans/dungeon/init.lua
+++ b/data/tribes/buildings/trainingsites/atlanteans/dungeon/init.lua
@@ -64,13 +64,17 @@
 --            },
 --
 --    **soldier defense**
---            *Optional*. Just like ``soldier attack``, but for defense training.
+--        *Optional*. Just like ``soldier attack``, but for defense training.
 --
 --    **soldier health**
---            *Optional*. Just like ``soldier attack``, but for health training.
+--        *Optional*. Just like ``soldier attack``, but for health training.
 --
 --    **soldier evade**
---            *Optional*. Just like ``soldier attack``, but for evade training.
+--        *Optional*. Just like ``soldier attack``, but for evade training.
+--
+--    **messages**
+--        *Mandatory*. A table with translatable production tooltips, containing the
+--        keys ``no_soldier`` and ``no_soldier_for_level``. See example below for details.
 --
 -- For making the UI texts translateable, we also need to push/pop the correct textdomain.
 --
@@ -179,7 +183,14 @@
 --       },
 --
 --       soldier_capacity = 8,
---       trainer_patience = 8
+--       trainer_patience = 8,
+--
+--       messages = {
+--          -- Make this translatable with pgettext: Empire training site tooltip when it has no soldiers assigned
+--          no_soldier = "No soldier to train!"
+--          -- Make this translatable with pgettext: Empire training site tooltip when none of the present soldiers match the current training program
+--          no_soldier_for_level = "No soldier found for this training level!",
+--       },
 --    }
 --
 --    pop_textdomain()
@@ -322,7 +333,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 8,
-   trainer_patience = 16
+   trainer_patience = 16,
+
+   messages = {
+      -- TRANSLATORS: Atlantean training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("atlanteans_building", "No soldier to train!"),
+      -- TRANSLATORS: Atlantean training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("atlanteans_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/atlanteans/labyrinth/init.lua
+++ b/data/tribes/buildings/trainingsites/atlanteans/labyrinth/init.lua
@@ -156,7 +156,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 8,
-   trainer_patience = 20
+   trainer_patience = 20,
+
+   messages = {
+      -- TRANSLATORS: Atlantean training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("atlanteans_building", "No soldier to train!"),
+      -- TRANSLATORS: Atlantean training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("atlanteans_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/barbarians/battlearena/init.lua
+++ b/data/tribes/buildings/trainingsites/barbarians/battlearena/init.lua
@@ -113,7 +113,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 8,
-   trainer_patience = 3
+   trainer_patience = 3,
+
+   messages = {
+      -- TRANSLATORS: Barbarian training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("barbarians_building", "No soldier to train!"),
+      -- TRANSLATORS: Barbarian training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("barbarians_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/barbarians/trainingcamp/init.lua
+++ b/data/tribes/buildings/trainingsites/barbarians/trainingcamp/init.lua
@@ -211,7 +211,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 12,
-   trainer_patience = 5
+   trainer_patience = 5,
+
+   messages = {
+      -- TRANSLATORS: Barbarian training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("barbarians_building", "No soldier to train!"),
+      -- TRANSLATORS: Barbarian training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("barbarians_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/empire/arena/init.lua
+++ b/data/tribes/buildings/trainingsites/empire/arena/init.lua
@@ -104,7 +104,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 8,
-   trainer_patience = 8
+   trainer_patience = 8,
+
+   messages = {
+      -- TRANSLATORS: Empire training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("empire_building", "No soldier to train!"),
+      -- TRANSLATORS: Empire training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("empire_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/empire/colosseum/init.lua
+++ b/data/tribes/buildings/trainingsites/empire/colosseum/init.lua
@@ -78,7 +78,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 8,
-   trainer_patience = 9
+   trainer_patience = 9,
+
+   messages = {
+      -- TRANSLATORS: Empire training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("empire_building", "No soldier to train!"),
+      -- TRANSLATORS: Empire training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("empire_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/empire/trainingcamp/init.lua
+++ b/data/tribes/buildings/trainingsites/empire/trainingcamp/init.lua
@@ -205,7 +205,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 12,
-   trainer_patience = 12
+   trainer_patience = 12,
+
+   messages = {
+      -- TRANSLATORS: Empire training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("empire_building", "No soldier to train!"),
+      -- TRANSLATORS: Empire training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("empire_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/frisians/training_arena/init.lua
+++ b/data/tribes/buildings/trainingsites/frisians/training_arena/init.lua
@@ -198,7 +198,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 6,
-   trainer_patience = 3
+   trainer_patience = 3,
+
+   messages = {
+      -- TRANSLATORS: Frisian training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("frisians_building", "No soldier to train!"),
+      -- TRANSLATORS: Frisian training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("frisians_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/data/tribes/buildings/trainingsites/frisians/training_camp/init.lua
+++ b/data/tribes/buildings/trainingsites/frisians/training_camp/init.lua
@@ -195,7 +195,14 @@ descriptions:new_trainingsite_type {
    },
 
    soldier_capacity = 10,
-   trainer_patience = 5
+   trainer_patience = 5,
+
+   messages = {
+      -- TRANSLATORS: Frisian training site tooltip when it has no soldiers assigned
+      no_soldier = pgettext("frisians_building", "No soldier to train!"),
+      -- TRANSLATORS: Frisian training site tooltip when none of the present soldiers match the current training program
+      no_soldier_for_level = pgettext("frisians_building", "No soldier found for this training level!"),
+   },
 }
 
 pop_textdomain()

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -1700,8 +1700,11 @@ void ProductionProgram::ActCheckSoldier::execute(Game& game, ProductionSite& ps)
 	const SoldierControl* ctrl = ps.soldier_control();
 	assert(ctrl != nullptr);
 	const std::vector<Soldier*> soldiers = ctrl->present_soldiers();
+
+	upcast(TrainingSite, ts, &ps);
+
 	if (soldiers.empty()) {
-		ps.set_production_result(_("No soldier to train!"));
+		ps.set_production_result(ts->descr().no_soldier_to_train_message());
 		return ps.program_end(game, ProgramResult::kSkipped);
 	}
 	ps.molog(game.get_gametime(), "  Checking soldier (%u) level %d)\n",
@@ -1710,7 +1713,7 @@ void ProductionProgram::ActCheckSoldier::execute(Game& game, ProductionSite& ps)
 	const std::vector<Soldier*>::const_iterator soldiers_end = soldiers.end();
 	for (std::vector<Soldier*>::const_iterator it = soldiers.begin();; ++it) {
 		if (it == soldiers_end) {
-			ps.set_production_result(_("No soldier found for this training level!"));
+			ps.set_production_result(ts->descr().no_soldier_for_training_level_message());
 			return ps.program_end(game, ProgramResult::kSkipped);
 		}
 
@@ -1734,7 +1737,6 @@ void ProductionProgram::ActCheckSoldier::execute(Game& game, ProductionSite& ps)
 	}
 	ps.molog(game.get_gametime(), "    okay\n");  // okay, do nothing
 
-	upcast(TrainingSite, ts, &ps);
 	ts->training_attempted(training_.attribute, training_.level);
 
 	ps.molog(game.get_gametime(), "  Check done!\n");

--- a/src/logic/map_objects/tribes/trainingsite.cc
+++ b/src/logic/map_objects/tribes/trainingsite.cc
@@ -159,6 +159,15 @@ TrainingSiteDescr::TrainingSiteDescr(const std::string& init_descname,
 			}
 		}
 	}
+
+	if (table.has_key("messages")) {
+		items_table = table.get_table("messages");
+		no_soldier_to_train_message_ = items_table->get_string("no_soldier");
+		no_soldier_for_training_level_message_ = items_table->get_string("no_soldier_for_level");
+	} else {
+		// TODO(GunChleoc): API compatibility - require this after v1.0
+		log_warn("Training site '%s' is lacking its 'messages' table", name().c_str());
+	}
 }
 
 /**

--- a/src/logic/map_objects/tribes/trainingsite.h
+++ b/src/logic/map_objects/tribes/trainingsite.h
@@ -86,6 +86,14 @@ public:
 		return weapons_evade_;
 	}
 
+	const std::string& no_soldier_to_train_message() const {
+		return no_soldier_to_train_message_;
+	}
+
+	const std::string& no_soldier_for_training_level_message() const {
+		return no_soldier_for_training_level_message_;
+	}
+
 private:
 	// Read the table to add needed food and weapons for training a property.
 	// Properties are health, attack, defense, and evade.
@@ -138,6 +146,9 @@ private:
 	std::vector<std::string> weapons_attack_;
 	std::vector<std::string> weapons_defense_;
 	std::vector<std::string> weapons_evade_;
+
+	std::string no_soldier_to_train_message_;
+	std::string no_soldier_for_training_level_message_;
 
 	DISALLOW_COPY_AND_ASSIGN(TrainingSiteDescr);
 };


### PR DESCRIPTION
Re https://github.com/widelands/widelands/issues/4490

The soldier capacity strings are more complicated because of the plurals, so I'll create a 3rd branch for them.

@hessenfarmer 