### PR TITLE
Silence vision compiler warnings

### DIFF
--- a/src/logic/vision.h
+++ b/src/logic/vision.h
@@ -164,7 +164,7 @@ public:
 private:
 	enum class Override : uint8_t { kNormal = 0, kHidden = 1, kRevealed = 2 };
 	uint16_t value_ : 14;
-	Override override_ : 2;
+	Vision::Override override_ : 8;
 };
 
 }  // namespace Widelands


### PR DESCRIPTION
@Niektory This will silence the warnings, but we need more bits per field now. Should we replace the enum class with 2 booleans?

I'd like to get this in as a hotfix though to unclutter the compile logs.