### PR TITLE
Update partially seen buildings' visibility when placed/removed

### DIFF
--- a/src/logic/map_objects/immovable.cc
+++ b/src/logic/map_objects/immovable.cc
@@ -95,7 +95,9 @@ void BaseImmovable::set_position(EditorGameBase& egbase, const Coords& c) {
 	}
 
 	// Needed so players can update partially visible buildings' vision.
-	Notifications::publish(NoteFieldTerrainChanged{f, map->get_index(f)});
+	if (get_size() >= BIG) {
+		Notifications::publish(NoteFieldTerrainChanged{f, map->get_index(f)});
+	}
 }
 
 /**
@@ -119,7 +121,9 @@ void BaseImmovable::unset_position(EditorGameBase& egbase, const Coords& c) {
 	assert(f.field->immovable == this);
 
 	// Needed so players can update partially visible buildings' vision.
-	Notifications::publish(NoteFieldTerrainChanged{f, map->get_index(f)});
+	if (get_size() >= BIG) {
+		Notifications::publish(NoteFieldTerrainChanged{f, map->get_index(f)});
+	}
 
 	f.field->immovable = nullptr;
 	egbase.inform_players_about_immovable(f.field - &(*map)[0], nullptr);

--- a/src/logic/map_objects/immovable.cc
+++ b/src/logic/map_objects/immovable.cc
@@ -93,6 +93,9 @@ void BaseImmovable::set_position(EditorGameBase& egbase, const Coords& c) {
 	if (get_size() >= SMALL) {
 		map->recalc_for_field_area(egbase, Area<FCoords>(f, 2));
 	}
+
+	// Needed so players can update partially visible buildings' vision.
+	Notifications::publish(NoteFieldTerrainChanged{f, map->get_index(f)});
 }
 
 /**
@@ -114,6 +117,9 @@ void BaseImmovable::unset_position(EditorGameBase& egbase, const Coords& c) {
 	}
 
 	assert(f.field->immovable == this);
+
+	// Needed so players can update partially visible buildings' vision.
+	Notifications::publish(NoteFieldTerrainChanged{f, map->get_index(f)});
 
 	f.field->immovable = nullptr;
 	egbase.inform_players_about_immovable(f.field - &(*map)[0], nullptr);


### PR DESCRIPTION
Fix #4480

Partially seen buildings were not being discovered during gameplay when built at the edge of vision, but they were during loading. This caused a mismatch.

Now they should be discovered immediately when placed.

This doesn't fix broken savegames but you should be able to resave from a replay to get a good one.