### PR TITLE
Get rid of the std::move warnings without triggering the other ones

### DIFF
--- a/src/logic/map_objects/tribes/militarysite.cc
+++ b/src/logic/map_objects/tribes/militarysite.cc
@@ -1080,7 +1080,8 @@ std::unique_ptr<const BuildingSettings> MilitarySite::create_building_settings()
 	// Prior to the resolution of a defect report against ISO C++11, local variable 'settings' would
 	// have been copied despite being returned by name, due to its not matching the function return
 	// type. Call 'std::move' explicitly to avoid copying on older compilers.
-	return std::move(settings);
+	// On modern compilers a simple 'return settings;' would've been fine.
+	return std::unique_ptr<const BuildingSettings>(std::move(settings));
 }
 
 // setters

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -1143,7 +1143,8 @@ std::unique_ptr<const BuildingSettings> ProductionSite::create_building_settings
 	// Prior to the resolution of a defect report against ISO C++11, local variable 'settings' would
 	// have been copied despite being returned by name, due to its not matching the function return
 	// type. Call 'std::move' explicitly to avoid copying on older compilers.
-	return std::move(settings);
+	// On modern compilers a simple 'return settings;' would've been fine.
+	return std::unique_ptr<const BuildingSettings>(std::move(settings));
 }
 
 /// Changes the default anim string to \li anim

--- a/src/logic/map_objects/tribes/trainingsite.cc
+++ b/src/logic/map_objects/tribes/trainingsite.cc
@@ -906,7 +906,8 @@ std::unique_ptr<const BuildingSettings> TrainingSite::create_building_settings()
 	// Prior to the resolution of a defect report against ISO C++11, local variable 'settings' would
 	// have been copied despite being returned by name, due to its not matching the function return
 	// type. Call 'std::move' explicitly to avoid copying on older compilers.
-	return std::move(settings);
+	// On modern compilers a simple 'return settings;' would've been fine.
+	return std::unique_ptr<const BuildingSettings>(std::move(settings));
 }
 
 /**

--- a/src/logic/map_objects/tribes/warehouse.cc
+++ b/src/logic/map_objects/tribes/warehouse.cc
@@ -1450,7 +1450,8 @@ std::unique_ptr<const BuildingSettings> Warehouse::create_building_settings() co
 	// Prior to the resolution of a defect report against ISO C++11, local variable 'settings' would
 	// have been copied despite being returned by name, due to its not matching the function return
 	// type. Call 'std::move' explicitly to avoid copying on older compilers.
-	return std::move(settings);
+	// On modern compilers a simple 'return settings;' would've been fine.
+	return std::unique_ptr<const BuildingSettings>(std::move(settings));
 }
 
 void Warehouse::log_general_info(const EditorGameBase& egbase) const {


### PR DESCRIPTION
Hopefully.