### PR TITLE
Fix loading saves with see_all players

### DIFF
--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -184,7 +184,7 @@ Player::Player(EditorGameBase& the_egbase,
 	// Subscribe to NoteFieldTerrainChanged.
 	field_terrain_changed_subscriber_ = Notifications::subscribe<NoteFieldTerrainChanged>(
 	   [this](const NoteFieldTerrainChanged& note) {
-		   if (is_seeing(note.map_index)) {
+		   if (fields_[note.map_index].vision == VisibleState::kVisible) {
 			   rediscover_node(egbase().map(), note.fc);
 		   }
 	   });


### PR DESCRIPTION
Follow-up to #4521
There's a problem loading saves with see_all (defeated) players like this one: [europa_ai_frisian_4.wgf.zip](https://github.com/widelands/widelands/files/5566109/europa_ai_frisian_4.wgf.zip)
This should fix it.