### PR TITLE
Speed up Economy::find_best_supply()

### DIFF
--- a/src/economy/economy.h
+++ b/src/economy/economy.h
@@ -280,6 +280,8 @@ private:
 	// 'list' of unique providers
 	std::map<UniqueDistance, Supply*> available_supplies_;
 
+	std::unordered_map<Serial, std::unordered_map<Serial, int32_t>> cached_costs_;
+
 	DISALLOW_COPY_AND_ASSIGN(Economy);
 };
 }  // namespace Widelands

--- a/src/economy/router.cc
+++ b/src/economy/router.cc
@@ -74,8 +74,7 @@ bool Router::find_route(RoutingNode& start,
 	astar.push(start);
 
 	while (RoutingNode* current = astar.step()) {
-		if (cost_cutoff >= 0 && (type == wwWARE ? current->mpf_realcost_ware :
-		                                          current->mpf_realcost_worker) > cost_cutoff) {
+		if (cost_cutoff >= 0 && current->cost(type) > cost_cutoff) {
 			return false;
 		}
 


### PR DESCRIPTION
Experimental. Cut searches earlier and cache the calculated costs to better sort future searches.