### PR TITLE
Fix double-deletion of message previews

### DIFF
--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -571,17 +571,20 @@ void Panel::think() {
  * (grand-)children for which set_thinks(false) has not been called.
  */
 void Panel::do_think() {
+	// No longer think when we are about to die
 	if (is_dying()) {
 		return;
 	}
 
 	if (thinks()) {
 		think();
-	}
 
-	// think() may have called die()
-	if (is_dying()) {
-		return;
+		// think() may have called die().
+		// When we are deleted, our children will be deleted as well, so they are
+		// effectively dying as well and should not continue to think either.
+		if (is_dying()) {
+			return;
+		}
 	}
 
 	for (Panel* child = first_child_; child; child = child->next_) {

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -571,8 +571,17 @@ void Panel::think() {
  * (grand-)children for which set_thinks(false) has not been called.
  */
 void Panel::do_think() {
+	if (is_dying()) {
+		return;
+	}
+
 	if (thinks()) {
 		think();
+	}
+
+	// think() may have called die()
+	if (is_dying()) {
+		return;
 	}
 
 	for (Panel* child = first_child_; child; child = child->next_) {

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -97,6 +97,10 @@ public:
 
 	void free_children();
 
+	bool is_dying() const {
+		return flags_ & pf_die;
+	}
+
 	// Modal
 	enum class Returncodes { kBack, kOk };
 

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -97,6 +97,9 @@ public:
 
 	void free_children();
 
+	// Checks whether this panel will be deleted in the next think cycle.
+	// This check is used to stop panels from thinking and performing other
+	// activities to prevent undesired side-effects.
 	bool is_dying() const {
 		return flags_ & pf_die;
 	}


### PR DESCRIPTION
Should fix #4575 

The crash happens if a message preview is being deleted when the maximum number of previews is exceeded and *in the same tick* the same preview attempts to delete itself because the timeout is reached. Most often seen with the `test_no_double_colonizing` test because of the large number of messages sent within the first minute.