### PR TITLE
Increase player info packet version

### DIFF
--- a/src/game_io/game_player_info_packet.cc
+++ b/src/game_io/game_player_info_packet.cc
@@ -32,7 +32,7 @@
 
 namespace Widelands {
 
-constexpr uint16_t kCurrentPacketVersion = 27;
+constexpr uint16_t kCurrentPacketVersion = 28;
 
 void GamePlayerInfoPacket::read(FileSystem& fs, Game& game, MapObjectLoader*) {
 	try {
@@ -54,11 +54,11 @@ void GamePlayerInfoPacket::read(FileSystem& fs, Game& game, MapObjectLoader*) {
 
 					// TODO(Nordfriese): Savegame compatibility, remove after v1.0
 					const uint8_t playercolor_r =
-					   packet_version >= 27 ? fr.unsigned_8() : kPlayerColors[i - 1].r;
+					   packet_version >= 28 ? fr.unsigned_8() : kPlayerColors[i - 1].r;
 					const uint8_t playercolor_g =
-					   packet_version >= 27 ? fr.unsigned_8() : kPlayerColors[i - 1].g;
+					   packet_version >= 28 ? fr.unsigned_8() : kPlayerColors[i - 1].g;
 					const uint8_t playercolor_b =
-					   packet_version >= 27 ? fr.unsigned_8() : kPlayerColors[i - 1].b;
+					   packet_version >= 28 ? fr.unsigned_8() : kPlayerColors[i - 1].b;
 
 					Widelands::TeamNumber team = fr.unsigned_8();
 					char const* const tribe_name = fr.c_string();


### PR DESCRIPTION
Fixes #4579 
This necessity was overlooked in #4549 so it has to be done now.

**Please review this urgently** because savegames created with a9cdcfb0a2fa9fd9a3d77837509e74900b663910 or later may be incompatible after this fix.