### PR TITLE
Disallow random matches if starting positions are too close

### DIFF
--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -564,7 +564,7 @@ bool MainMenuNewRandomMapPanel::do_generate_map(Widelands::EditorGameBase& egbas
 	}
 	log_info("\n");
 
-	const bool result = gen.create_random_map();
+	bool result = gen.create_random_map();
 
 	egbase.create_tempfile_and_save_mapdata(FileSystem::ZIP);
 
@@ -589,10 +589,19 @@ bool MainMenuNewRandomMapPanel::do_generate_map(Widelands::EditorGameBase& egbas
 		   UI::WLMessageBox::MBoxType::kOk);
 		mbox.run<UI::Panel::Returncodes>();
 	} else {
+		const unsigned nr_players = map->get_nrplayers();
+		if (result) {
+			// Check that the starting positions are not too close
+			for (unsigned i = 1; i <= nr_players && result; ++i) {
+				for (unsigned j = 1; j < i && result; ++j) {
+					result &= (map->calc_distance(map->get_starting_pos(i), map->get_starting_pos(j)) > Widelands::kMinSpaceAroundPlayers);
+				}
+			}
+		}
+
 		if (result) {
 			// Initialize with some good default values
 
-			const unsigned nr_players = map->get_nrplayers();
 			const unsigned plnum = std::rand() % nr_players;  // NOLINT
 
 			map->set_name(_("Random Map"));

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -594,7 +594,8 @@ bool MainMenuNewRandomMapPanel::do_generate_map(Widelands::EditorGameBase& egbas
 			// Check that the starting positions are not too close
 			for (unsigned i = 1; i <= nr_players && result; ++i) {
 				for (unsigned j = 1; j < i && result; ++j) {
-					result &= (map->calc_distance(map->get_starting_pos(i), map->get_starting_pos(j)) > Widelands::kMinSpaceAroundPlayers);
+					result &= (map->calc_distance(map->get_starting_pos(i), map->get_starting_pos(j)) >
+					           Widelands::kMinSpaceAroundPlayers);
 				}
 			}
 		}


### PR DESCRIPTION
Re #1628 
This does not fix the issue (the logic of starting position distribution is unchanged), but the random match setup now disallows matches where the players would start too close to each other.