### PR TITLE
Delay AI initalization after scenario init

### DIFF
--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -102,6 +102,8 @@ DefaultAI::DefaultAI(Widelands::Game& ggame, Widelands::PlayerNumber const pid, 
      player_(nullptr),
      tribe_(nullptr),
      attackers_count_(0),
+     // Delay initialization to allow scenario scripts
+     // to load custom units/buildings at gametime 0
      next_ai_think_(1),
      scheduler_delay_counter_(0),
      wood_policy_(WoodPolicy::kAllowRangers),

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -102,7 +102,7 @@ DefaultAI::DefaultAI(Widelands::Game& ggame, Widelands::PlayerNumber const pid, 
      player_(nullptr),
      tribe_(nullptr),
      attackers_count_(0),
-     next_ai_think_(0),
+     next_ai_think_(1),
      scheduler_delay_counter_(0),
      wood_policy_(WoodPolicy::kAllowRangers),
      numof_psites_in_constr(0),
@@ -240,15 +240,14 @@ DefaultAI::~DefaultAI() {
  * General behaviour is defined here.
  */
 void DefaultAI::think() {
-
-	if (tribe_ == nullptr) {
-		late_initialization();
-	}
-
 	const Time& gametime = game().get_gametime();
 
 	if (next_ai_think_ > gametime) {
 		return;
+	}
+
+	if (tribe_ == nullptr) {
+		late_initialization();
 	}
 
 	// AI now thinks twice in a seccond, if the game engine allows this


### PR DESCRIPTION
Fixes #4655 

The scenario script uses some atlantean buildings, which are loaded when the script is executed. The AI does not get the new buildings and is lost:
`[/mnt/storage/Programme/widelands/src/ai/defaultai.cc:6330] Help: I (player 3 / tribe barbarians) do not know what to do with a atlanteans_tower` (Masked by some lua error)
So we wait for the commands at gametime 0 and start AI thinking at gametime 1.