### PR TITLE
Select text via mouse

### DIFF
--- a/src/ui_basic/editbox.cc
+++ b/src/ui_basic/editbox.cc
@@ -200,7 +200,7 @@ bool EditBox::handle_mousepress(const uint8_t btn, int32_t x, int32_t) {
 }
 
 bool EditBox::handle_mousemove(uint8_t state, int32_t x, int32_t, int32_t, int32_t) {
-	//	state != 0 -> mouse button is pressed
+	// state != 0 -> mouse button is pressed
 	if (state && get_can_focus()) {
 		select_until(m_->caret);
 		set_caret_to_cursor_pos(x);

--- a/src/ui_basic/editbox.cc
+++ b/src/ui_basic/editbox.cc
@@ -608,7 +608,7 @@ void EditBox::draw(RenderTarget& dst) {
 
 		const Image* caret_image =
 		   g_image_cache->get(panel_style_ == PanelStyle::kWui ? "images/ui_basic/caret_wui.png" :
-                                                               "images/ui_basic/caret_fs.png");
+		                                                         "images/ui_basic/caret_fs.png");
 		Vector2i caretpt = Vector2i::zero();
 		caretpt.x = point.x + m_->scrolloffset + caret_x - caret_image->width() + kLineMargin;
 		caretpt.y = point.y + (fontheight - caret_image->height()) / 2;

--- a/src/ui_basic/editbox.cc
+++ b/src/ui_basic/editbox.cc
@@ -189,9 +189,22 @@ void EditBox::set_font_scale(float scale) {
  */
 bool EditBox::handle_mousepress(const uint8_t btn, int32_t x, int32_t) {
 	if (btn == SDL_BUTTON_LEFT && get_can_focus()) {
+		reset_selection();
 		set_caret_to_cursor_pos(x);
 		focus();
 		clicked();
+		return true;
+	}
+
+	return false;
+}
+
+bool EditBox::handle_mousemove(uint8_t state, int32_t x, int32_t, int32_t, int32_t) {
+	//	state != 0 -> mouse button is pressed
+	if (state && get_can_focus()) {
+		select_until(m_->caret);
+		set_caret_to_cursor_pos(x);
+		select_until(m_->caret);
 		return true;
 	}
 
@@ -595,7 +608,7 @@ void EditBox::draw(RenderTarget& dst) {
 
 		const Image* caret_image =
 		   g_image_cache->get(panel_style_ == PanelStyle::kWui ? "images/ui_basic/caret_wui.png" :
-		                                                         "images/ui_basic/caret_fs.png");
+                                                               "images/ui_basic/caret_fs.png");
 		Vector2i caretpt = Vector2i::zero();
 		caretpt.x = point.x + m_->scrolloffset + caret_x - caret_image->width() + kLineMargin;
 		caretpt.y = point.y + (fontheight - caret_image->height()) / 2;

--- a/src/ui_basic/editbox.h
+++ b/src/ui_basic/editbox.h
@@ -57,6 +57,8 @@ struct EditBox : public Panel {
 	}
 
 	bool handle_mousepress(uint8_t btn, int32_t x, int32_t y) override;
+	bool
+	handle_mousemove(uint8_t state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) override;
 	bool handle_key(bool down, SDL_Keysym) override;
 	bool handle_textinput(const std::string& text) override;
 

--- a/src/ui_basic/multilineeditbox.cc
+++ b/src/ui_basic/multilineeditbox.cc
@@ -264,10 +264,22 @@ uint32_t MultilineEditbox::Data::snap_to_char(std::string& txt, uint32_t cursor)
  */
 bool MultilineEditbox::handle_mousepress(const uint8_t btn, int32_t x, int32_t y) {
 	if (btn == SDL_BUTTON_LEFT && get_can_focus()) {
+		d_->reset_selection();
 		set_caret_to_cursor_pos(x, y);
 		focus();
 		return true;
 	}
+	return false;
+}
+bool MultilineEditbox::handle_mousemove(uint8_t state, int32_t x, int32_t y, int32_t, int32_t) {
+	//	state != 0 -> mouse button is pressed
+	if (state && get_can_focus()) {
+		select_until(d_->cursor_pos);
+		set_caret_to_cursor_pos(x, y);
+		select_until(d_->cursor_pos);
+		return true;
+	}
+
 	return false;
 }
 void MultilineEditbox::set_caret_to_cursor_pos(int32_t x, int32_t y) {

--- a/src/ui_basic/multilineeditbox.cc
+++ b/src/ui_basic/multilineeditbox.cc
@@ -272,7 +272,7 @@ bool MultilineEditbox::handle_mousepress(const uint8_t btn, int32_t x, int32_t y
 	return false;
 }
 bool MultilineEditbox::handle_mousemove(uint8_t state, int32_t x, int32_t y, int32_t, int32_t) {
-	//	state != 0 -> mouse button is pressed
+	// state != 0 -> mouse button is pressed
 	if (state && get_can_focus()) {
 		select_until(d_->cursor_pos);
 		set_caret_to_cursor_pos(x, y);

--- a/src/ui_basic/multilineeditbox.h
+++ b/src/ui_basic/multilineeditbox.h
@@ -48,6 +48,7 @@ protected:
 	void draw(RenderTarget&) override;
 
 	bool handle_mousepress(uint8_t btn, int32_t x, int32_t y) override;
+	bool handle_mousemove(uint8_t state, int32_t x, int32_t, int32_t, int32_t) override;
 	bool handle_key(bool down, SDL_Keysym) override;
 	bool handle_textinput(const std::string& text) override;
 


### PR DESCRIPTION
select text with mouse (left button must be pressed while cursor is moved)
also fixes a  not-yet reported bug regarding selecting text and then clicking with mouse in master -> cursor is repositioned but selection is still active