### PR TITLE
Fix two crashes with tribe add-ons

### DIFF
--- a/src/scripting/lua_root.cc
+++ b/src/scripting/lua_root.cc
@@ -729,6 +729,13 @@ void LuaDescriptions::do_modify_tribe(lua_State* L,
 
 		LuaTable t(L);
 		tribe_descr.load_helptexts(descrs.get_mutable_worker_descr(di), t);
+
+		// Update the player's worker statistics
+		iterate_players_existing(p, egbase.map().get_nrplayers(), egbase, player) {
+			if (&player->tribe() == &tribe_descr) {
+				player->init_statistics();
+			}
+		}
 	} else if (property == "add_building") {
 		const std::string buildingname = luaL_checkstring(L, 5);
 		Notifications::publish(Widelands::NoteMapObjectDescription(

--- a/src/wui/ware_statistics_menu.cc
+++ b/src/wui/ware_statistics_menu.cc
@@ -89,9 +89,7 @@ protected:
 	}
 
 	RGBColor info_color_for_ware(Widelands::DescriptionIndex const ware) override {
-		size_t index = static_cast<size_t>(ware);
-
-		return colors[color_map_.at(index)];
+		return colors[color_map_.at(ware)];
 	}
 };
 

--- a/src/wui/ware_statistics_menu.cc
+++ b/src/wui/ware_statistics_menu.cc
@@ -66,7 +66,7 @@ static const uint32_t colors_length = sizeof(colors) / sizeof(RGBColor);
 
 struct StatisticWaresDisplay : public AbstractWaresDisplay {
 private:
-	std::vector<uint8_t>& color_map_;
+	std::map<Widelands::DescriptionIndex, uint8_t>& color_map_;
 
 public:
 	StatisticWaresDisplay(UI::Panel* const parent,
@@ -74,7 +74,7 @@ public:
 	                      int32_t const y,
 	                      const Widelands::TribeDescr& tribe,
 	                      std::function<void(Widelands::DescriptionIndex, bool)> callback_function,
-	                      std::vector<uint8_t>& color_map)
+	                      std::map<Widelands::DescriptionIndex, uint8_t>& color_map)
 	   : AbstractWaresDisplay(
 	        parent, x, y, tribe, Widelands::wwWARE, true, std::move(callback_function)),
 	     color_map_(color_map) {
@@ -91,7 +91,7 @@ protected:
 	RGBColor info_color_for_ware(Widelands::DescriptionIndex const ware) override {
 		size_t index = static_cast<size_t>(ware);
 
-		return colors[color_map_[index]];
+		return colors[color_map_.at(index)];
 	}
 };
 
@@ -112,8 +112,9 @@ WareStatisticsMenu::WareStatisticsMenu(InteractivePlayer& parent,
 	const Widelands::TribeDescr& player_tribe = parent.get_player()->tribe();
 
 	// Init color sets
-	color_map_.resize(player_tribe.get_nrwares());
-	std::fill(color_map_.begin(), color_map_.end(), kInactiveColorIndex);
+	for (Widelands::DescriptionIndex d : player_tribe.wares()) {
+		color_map_[d] = kInactiveColorIndex;
+	}
 	active_colors_.resize(colors_length);
 	std::fill(active_colors_.begin(), active_colors_.end(), 0);
 

--- a/src/wui/ware_statistics_menu.h
+++ b/src/wui/ware_statistics_menu.h
@@ -50,7 +50,7 @@ private:
 	WuiPlotArea* plot_consumption_;
 	WuiPlotArea* plot_stock_;
 	DifferentialPlotArea* plot_economy_;
-	std::vector<uint8_t> color_map_;  // Maps ware index to colors
+	std::map<Widelands::DescriptionIndex, uint8_t> color_map_;  // Maps ware index to colors
 	std::vector<bool> active_colors_;
 
 	void cb_changed_to(Widelands::DescriptionIndex, bool);


### PR DESCRIPTION
- Bug 1: Saving a game with custom workers crashed
- Bug 2: The ware stats menu segfaulted with custom wares

These two bugs can be seen in master with the frisians-economy-ultra addon.