### PR TITLE
Shorten the ripe stage of barley fields

### DIFF
--- a/data/tribes/immovables/barleyfield/ripe/init.lua
+++ b/data/tribes/immovables/barleyfield/ripe/init.lua
@@ -10,7 +10,7 @@ descriptions:new_immovable_type {
    icon = dirname .. "menu.png",
    programs = {
       main = {
-         "animate=idle duration:41m40s",
+         "animate=idle duration:20m50s",
          "remove=",
       },
       harvest = {


### PR DESCRIPTION
This shortens the ripe stage of barley fields by half, from about 40 minutes to about 20 minutes.

See the forum discussion: https://www.widelands.org/forum/topic/4920/?page=1#post-34312