### PR TITLE
Set minimal progress value in add-on packager

### DIFF
--- a/src/ui_fsmenu/addons_packager.cc
+++ b/src/ui_fsmenu/addons_packager.cc
@@ -242,7 +242,7 @@ void AddOnsPackager::rebuild_addon_list(const std::string& select) {
 		pair.second->set_callbacks(
 		   [this](const size_t i) {
 			   progress_window_.progressbar().set_state(0);
-			   progress_window_.progressbar().set_total(i);
+			   progress_window_.progressbar().set_total(std::max<size_t>(i, 1));
 		   },
 		   [this](const size_t i) {
 			   progress_window_.progressbar().set_state(progress_window_.progressbar().get_state() +


### PR DESCRIPTION
Fixes a crash in the add-on packager. 
To reproduce:
1. Create a new maps add-on
2. Save changes (no maps selected)
3. crash
