### PR TITLE
Fix textdomain for keyboard shortcuts

### DIFF
--- a/src/wlapplication_options.cc
+++ b/src/wlapplication_options.cc
@@ -748,6 +748,7 @@ std::string shortcut_string_for(const KeyboardShortcut id, const bool rt_escape)
 }
 
 std::string shortcut_string_for(const SDL_Keysym sym, const bool rt_escape) {
+	i18n::Textdomain textdomain("widelands");
 	std::vector<std::string> mods;
 	if (sym.mod & KMOD_SHIFT) {
 		mods.push_back(pgettext("hotkey", "Shift"));


### PR DESCRIPTION
The shortcut-related game tips shown during game loading use the wrong textdomain on master