### PR TITLE
Fix initial info panel text visibility

### DIFF
--- a/src/wui/info_panel.cc
+++ b/src/wui/info_panel.cc
@@ -187,6 +187,7 @@ InfoPanel::InfoPanel(InteractiveBase& ib)
 		display_mode_ = DisplayMode::kPinned;
 	}
 	rebuild_dropdown();
+	update_mode();
 }
 
 void InfoPanel::rebuild_dropdown() {


### PR DESCRIPTION
If a game is started with the info panel initially in Hidden state, the text areas are initially visible even though they're meant to be always invisible when the panel is set to Hidden.