### PR TITLE
Add ordered iteration for lua tables

### DIFF
--- a/data/scripting/table.lua
+++ b/data/scripting/table.lua
@@ -31,3 +31,71 @@ function array_combine(...)
    end
    return t
 end
+
+
+-- RST
+-- .. function:: __gen_ordered_index(t)
+--
+--    Generate a sorted index from a table
+--    Taken from http://lua-users.org/wiki/SortedIteration
+--
+--    :arg t: a table
+--    :returns: a table containing t's keys in alphabetic order
+function __gen_ordered_index( t )
+    local ordered_index = {}
+    for key in pairs(t) do
+        table.insert( ordered_index, key )
+    end
+    table.sort( ordered_index )
+    return ordered_index
+end
+
+-- RST
+-- .. function:: ordered_next(t, state)
+--
+--    Equivalent of the next function, but returns the keys in the alphabetic
+--    order. We use a temporary ordered key table that is stored in the
+--    table being iterated.
+--    Taken from http://lua-users.org/wiki/SortedIteration
+--
+--    :arg t: a table
+--    :arg state: current iteration state
+--    :returns: the next key,value pair
+function ordered_next(t, state)
+
+    local key = nil
+    if state == nil then
+        -- the first time, generate the index
+        t.__ordered_index = __gen_ordered_index( t )
+        key = t.__ordered_index[1]
+    else
+        -- fetch the next value
+        for i = 1,#t.__ordered_index do
+            if t.__ordered_index[i] == state then
+                key = t.__ordered_index[i+1]
+            end
+        end
+    end
+
+    if key then
+        return key, t[key]
+    end
+
+    -- no more value to return, cleanup
+    t.__ordered_index = nil
+    return
+end
+
+-- RST
+-- .. function:: ordered_pairs(t)
+--
+--    Equivalent of the pairs() function on tables. 
+--    Allows to iterate in deterministic order.
+--    Taken from http://lua-users.org/wiki/SortedIteration
+--
+--    :arg t: a table
+--    :returns: a key,value iterator
+function ordered_pairs(t)
+    return ordered_next, t, nil
+end
+

--- a/data/scripting/table.lua
+++ b/data/scripting/table.lua
@@ -45,7 +45,7 @@ function __gen_ordered_index(t)
 end
 
 -- Helper function for ordered_pairs(t)
--- Equivalent of the next function, but returns the keys in the alphabetic
+-- Equivalent of the Lua-function ``next()``, but returns the keys in the alphabetic
 -- order. We use a temporary ordered key table that is stored in the
 -- table being iterated.
 -- Taken from http://lua-users.org/wiki/SortedIteration
@@ -77,7 +77,7 @@ end
 -- RST
 -- .. function:: ordered_pairs(t)
 --
---    Equivalent of the :func:`pairs()` function on tables.
+--    Equivalent of the Lua-function ``pairs()`` on tables.
 --    Allows to iterate in deterministic order.
 --    Taken from http://lua-users.org/wiki/SortedIteration
 --

--- a/data/scripting/table.lua
+++ b/data/scripting/table.lua
@@ -32,16 +32,10 @@ function array_combine(...)
    return t
 end
 
-
--- RST
--- .. function:: __gen_ordered_index(t)
---
---    Generate a sorted index from a table
---    Taken from http://lua-users.org/wiki/SortedIteration
---
---    :arg t: a table
---    :returns: a table containing t's keys in alphabetic order
-function __gen_ordered_index( t )
+-- Helper function for ordered_pairs(t)
+-- Generate a sorted index from a table
+-- Taken from http://lua-users.org/wiki/SortedIteration
+function __gen_ordered_index(t)
     local ordered_index = {}
     for key in pairs(t) do
         table.insert( ordered_index, key )
@@ -50,17 +44,11 @@ function __gen_ordered_index( t )
     return ordered_index
 end
 
--- RST
--- .. function:: ordered_next(t, state)
---
---    Equivalent of the next function, but returns the keys in the alphabetic
---    order. We use a temporary ordered key table that is stored in the
---    table being iterated.
---    Taken from http://lua-users.org/wiki/SortedIteration
---
---    :arg t: a table
---    :arg state: current iteration state
---    :returns: the next key,value pair
+-- Helper function for ordered_pairs(t)
+-- Equivalent of the next function, but returns the keys in the alphabetic
+-- order. We use a temporary ordered key table that is stored in the
+-- table being iterated.
+-- Taken from http://lua-users.org/wiki/SortedIteration
 function ordered_next(t, state)
 
     local key = nil
@@ -89,11 +77,11 @@ end
 -- RST
 -- .. function:: ordered_pairs(t)
 --
---    Equivalent of the pairs() function on tables. 
+--    Equivalent of the :func:`pairs()` function on tables. 
 --    Allows to iterate in deterministic order.
 --    Taken from http://lua-users.org/wiki/SortedIteration
 --
---    :arg t: a table
+--    :arg table t: The table to iterate over
 --    :returns: a key,value iterator
 function ordered_pairs(t)
     return ordered_next, t, nil

--- a/data/scripting/table.lua
+++ b/data/scripting/table.lua
@@ -77,7 +77,7 @@ end
 -- RST
 -- .. function:: ordered_pairs(t)
 --
---    Equivalent of the :func:`pairs()` function on tables. 
+--    Equivalent of the :func:`pairs()` function on tables.
 --    Allows to iterate in deterministic order.
 --    Taken from http://lua-users.org/wiki/SortedIteration
 --
@@ -86,4 +86,3 @@ end
 function ordered_pairs(t)
     return ordered_next, t, nil
 end
-

--- a/data/scripting/win_conditions/hq_hunter.lua
+++ b/data/scripting/win_conditions/hq_hunter.lua
@@ -38,7 +38,7 @@ local r = {
             for j, building in ipairs(p.tribe.buildings) do
                if building.type_name == "warehouse" then
                   if building.conquers == 0 or building.is_port then
-                     for i,site in pairs(p:get_buildings(building.name)) do
+                     for i,site in ipairs(p:get_buildings(building.name)) do
                         table.insert(warehouses_and_ports, site.fields[1])
                      end
                   else
@@ -47,7 +47,7 @@ local r = {
                end
             end
             if #headquarters == 0 then
-               for idx,f in pairs(warehouses_and_ports) do
+               for idx,f in ipairs(warehouses_and_ports) do
                   if f.immovable then
                      f.immovable:destroy()
                   end

--- a/data/scripting/win_conditions/win_condition_functions.lua
+++ b/data/scripting/win_conditions/win_condition_functions.lua
@@ -91,17 +91,17 @@ function check_player_defeated(plrs, heading, msg, wc_name, wc_ver)
          end
          -- now collect the warehouses/ports/milsites including constructionsites a player has
          for name,allowed in ordered_pairs(p.allowed_buildings) do
-            for i,site in pairs(p:get_constructionsites(name)) do
+            for i,site in ipairs(p:get_constructionsites(name)) do
                table.insert(fields_to_destroy, site.fields[1])
             end
-            for i,site in pairs(p:get_buildings(name)) do
+            for i,site in ipairs(p:get_buildings(name)) do
                if site.descr.type_name == "militarysite" then
                   table.insert(fields_to_destroy, site.fields[1])
                end
             end
          end
          -- destroy the collected sites
-         for idx,f in pairs(fields_to_destroy) do
+         for idx,f in ipairs(fields_to_destroy) do
             if f.immovable then
                f.immovable:destroy()
                -- add some delay to the destruction for dramaturgical reason

--- a/data/scripting/win_conditions/win_condition_functions.lua
+++ b/data/scripting/win_conditions/win_condition_functions.lua
@@ -1,5 +1,6 @@
 include "scripting/richtext.lua"
 include "scripting/messages.lua"
+include "scripting/table.lua"
 
 -- RST
 -- win_condition_functions.lua
@@ -89,7 +90,7 @@ function check_player_defeated(plrs, heading, msg, wc_name, wc_ver)
             s:destroy()
          end
          -- now collect the warehouses/ports/milsites including constructionsites a player has
-         for name,allowed in pairs(p.allowed_buildings) do
+         for name,allowed in ordered_pairs(p.allowed_buildings) do
             for i,site in pairs(p:get_constructionsites(name)) do
                table.insert(fields_to_destroy, site.fields[1])
             end


### PR DESCRIPTION
Fixes #4816 
Implements an `ordered_pairs` function, to iterate lua tables deterministically.
Taken from http://lua-users.org/wiki/SortedIteration
There might be more occurences, there an ordered iteration should be used to prevent similar issues, but I'm not familiar with the lua code.

To verify the fix:
- Start a pure AI game on crater with HQ Hunter
- Let it finish
- Save
- Run the replay
- On master it desyncs, with `ordered_pairs` it works fine

Note: This is my first lua code submission, so I hope I matched the style.