### PR TITLE
Don't jump to undefined landmarks

### DIFF
--- a/src/wui/quicknavigation.cc
+++ b/src/wui/quicknavigation.cc
@@ -70,7 +70,8 @@ bool QuickNavigation::handle_key(bool down, SDL_Keysym key) {
 			set_landmark(i, current_);
 			return true;
 		}
-		if (landmarks_[i].set && matches_shortcut(
+		if (landmarks_[i].set &&
+		    matches_shortcut(
 		       static_cast<KeyboardShortcut>(
 		          static_cast<uint16_t>(KeyboardShortcut::kInGameQuicknavGoto1) + 2 * i),
 		       key)) {

--- a/src/wui/quicknavigation.cc
+++ b/src/wui/quicknavigation.cc
@@ -70,7 +70,7 @@ bool QuickNavigation::handle_key(bool down, SDL_Keysym key) {
 			set_landmark(i, current_);
 			return true;
 		}
-		if (matches_shortcut(
+		if (landmarks_[i].set && matches_shortcut(
 		       static_cast<KeyboardShortcut>(
 		          static_cast<uint16_t>(KeyboardShortcut::kInGameQuicknavGoto1) + 2 * i),
 		       key)) {


### PR DESCRIPTION
Fixes #4854
This was introduced by accident during the configurable keyboard shortcuts refactoring. If reviewed before winter-time freeze (15.5.) we can have this fix in v1.0.