### PR TITLE
Fix clang to version 10

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -68,8 +68,8 @@ jobs:
       run: |
         # Ensure version 10.0
         clang-format --version
-        ver=$(clang-format --version | grep 11)
-        if [ -n "$ver" ]
+        ver=$(clang-format --version | grep 10)
+        if [ -z "$ver" ]
         then
           echo "Cancelling run with clang-format 11"
           exit 2

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -64,7 +64,8 @@ jobs:
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
-        clang-format --version
+        # Quit on wrong version
+        clang-format --version | grep 10.0.0
     - name: Invoking fix_formatting.py
       run: python3 ./utils/fix_formatting.py
     - name: Gathering changes

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -57,6 +57,7 @@ jobs:
     - name: Installing formatting tools
       run: |
         sudo apt-get update
+        sudo apt-get purge -y clang clang-format
         sudo apt-get install clang-format-10
         pip install pyformat
         # Use clang-format 10 as default until we choose to migrate to 11

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -60,7 +60,6 @@ jobs:
         sudo apt-get install clang-format-10
         pip install pyformat
         # Use clang-format 10 as default until we choose to migrate to 11
-        sudo update-alternatives --remove-all clang
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -57,6 +57,7 @@ jobs:
     - name: Installing formatting tools
       run: |
         sudo apt-get update
+        sudo apt-get remove clang-format
         sudo apt-get install clang-format-10
         pip install pyformat
         # Use clang-format 10 as default until we choose to migrate to 11
@@ -64,7 +65,11 @@ jobs:
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
     - name: Invoking fix_formatting.py
-      run: python3 ./utils/fix_formatting.py
+      run: |
+        # Ensure version 10.0
+        clang-format --version
+        clang-format --version | grep 11 || exit 2
+        python3 ./utils/fix_formatting.py
     - name: Gathering changes
       run: |
         nrfiles=$(git status -s | wc -l)

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -57,7 +57,6 @@ jobs:
     - name: Installing formatting tools
       run: |
         sudo apt-get update
-        sudo apt-get remove clang-format
         sudo apt-get install clang-format-10
         pip install pyformat
         # Use clang-format 10 as default until we choose to migrate to 11
@@ -68,7 +67,12 @@ jobs:
       run: |
         # Ensure version 10.0
         clang-format --version
-        clang-format --version | grep 11 || exit 2
+        ver=$(clang-format --version | grep 11)
+        if [ -n "$ver" ]
+        then
+          echo "Cancelling run with clang-format 11"
+          exit 2
+        fi
         python3 ./utils/fix_formatting.py
     - name: Gathering changes
       run: |

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Installing formatting tools
       run: |
         sudo apt-get update
-        sudo apt-get purge -y clang clang-format
+        sudo apt-get purge -y clang-11 clang-format-11
         sudo apt-get install clang-format-10
         pip install pyformat
         # Use clang-format 10 as default until we choose to migrate to 11

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -64,17 +64,9 @@ jobs:
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
-    - name: Invoking fix_formatting.py
-      run: |
-        # Ensure version 10.0
         clang-format --version
-        ver=$(clang-format --version | grep 10)
-        if [ -z "$ver" ]
-        then
-          echo "Cancelling run with clang-format 11"
-          exit 2
-        fi
-        python3 ./utils/fix_formatting.py
+    - name: Invoking fix_formatting.py
+      run: python3 ./utils/fix_formatting.py
     - name: Gathering changes
       run: |
         nrfiles=$(git status -s | wc -l)


### PR DESCRIPTION
Re #4598
One line screwed everything up...
This branch is behind master on purpose. Does this help to restore the correct format?