### PR TITLE
Write config after sound initialization

### DIFF
--- a/src/sound/sound_handler.cc
+++ b/src/sound/sound_handler.cc
@@ -193,29 +193,6 @@ void SoundHandler::initialization_error(const char* const msg, bool quit_sdl) {
  * the constructor.
  */
 void SoundHandler::read_config() {
-	// TODO(GunChleoc): Compatibility code to avoid getting bug reports about unread sections. Remove
-	// after Build 21.
-	if (get_config_section_ptr("sound") == nullptr) {
-		for (auto& option : sound_options_) {
-			switch (option.first) {
-			case SoundType::kMusic:
-				option.second.volume = get_config_int("music_volume", option.second.volume);
-				option.second.enabled = !get_config_bool("disable_music", !option.second.enabled);
-				break;
-			case SoundType::kChat:
-				option.second.volume = get_config_int("fx_volume", option.second.volume);
-				option.second.enabled = get_config_bool("sound_at_message", option.second.enabled);
-				break;
-			default:
-				option.second.volume = get_config_int("fx_volume", option.second.volume);
-				option.second.enabled = !get_config_bool("disable_fx", !option.second.enabled);
-				break;
-			}
-		}
-		save_config();
-	}
-
-	// This is the code that we want to keep
 	for (auto& option : sound_options_) {
 		option.second.volume =
 		   get_config_int("sound", "volume_" + option.second.name, option.second.volume);

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -415,6 +415,10 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 
 	// Make sure we didn't forget to read any global option
 	check_config_used();
+
+	// Save configuration now. Otherwise, the UUID and sound options
+	// are not saved, when the game crashes
+	write_config();
 }
 
 /**
@@ -1094,10 +1098,6 @@ bool WLApplication::init_settings() {
 		set_config_string("uuid", generate_random_uuid());
 	}
 	set_config_int("last_start", now);
-
-	// Save configuration now. Otherwise, the UUID is not saved
-	// when the game crashes, losing part of its advantage
-	write_config();
 
 	return true;
 }


### PR DESCRIPTION
Fixes #4939 
Write config not after reading the global section, but after the sound handler is also initialized.