### PR TITLE
Screenshot notification

### DIFF
--- a/src/graphic/graphic.cc
+++ b/src/graphic/graphic.cc
@@ -290,6 +290,15 @@ void Graphic::set_fullscreen(const bool value) {
  * Bring the screen uptodate.
  */
 void Graphic::refresh() {
+	// The backbuffer contains the last frame. If we want a screenshot,
+	// we should better take it now, so the notification is not part of it.
+	if (!screenshot_filename_.empty()) {
+		log_info("Save screenshot to %s\n", screenshot_filename_.c_str());
+		std::unique_ptr<StreamWrite> sw(g_fs->open_stream_write(screenshot_filename_));
+		save_to_png(screen_->to_texture().get(), sw.get(), ColorType::RGB);
+		screenshot_filename_.clear();
+	}
+
 	RenderQueue::instance().draw(screen_->width(), screen_->height());
 
 	if (!fullscreen()) {
@@ -305,16 +314,6 @@ void Graphic::refresh() {
 		}
 		// See the comment in set_window_size().
 		SDL_SetWindowResizable(sdl_window_, SDL_TRUE);
-	}
-
-	// The backbuffer now contains the current frame. If we want a screenshot,
-	// we should better take it now, before this is swapped out to the
-	// frontbuffer and becomes inaccessible to us.
-	if (!screenshot_filename_.empty()) {
-		log_info("Save screenshot to %s\n", screenshot_filename_.c_str());
-		std::unique_ptr<StreamWrite> sw(g_fs->open_stream_write(screenshot_filename_));
-		save_to_png(screen_->to_texture().get(), sw.get(), ColorType::RGB);
-		screenshot_filename_.clear();
 	}
 
 	SDL_GL_SwapWindow(sdl_window_);

--- a/src/io/filesystem/disk_filesystem.cc
+++ b/src/io/filesystem/disk_filesystem.cc
@@ -561,14 +561,14 @@ StreamWrite* RealFSImpl::open_stream_write(const std::string& fname) {
 unsigned long long RealFSImpl::disk_space() {  // NOLINT
 #ifdef _WIN32
 	ULARGE_INTEGER freeavailable;
-	return GetDiskFreeSpaceEx(canonicalize_name(directory_).c_str(), &freeavailable, 0, 0) ?
+	return GetDiskFreeSpaceEx(root_.c_str(), &freeavailable, 0, 0) ?
 	          // If more than 2G free space report that much
 	          freeavailable.HighPart ? std::numeric_limits<unsigned long>::max() :  // NOLINT
 	             freeavailable.LowPart :
 	          0;
 #else
 	struct statvfs svfs;
-	if (statvfs(canonicalize_name(directory_).c_str(), &svfs) != -1) {
+	if (statvfs(root_.c_str(), &svfs) != -1) {
 		return static_cast<unsigned long long>(svfs.f_bsize) * svfs.f_bavail;  // NOLINT
 	}
 #endif

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -867,12 +867,12 @@ bool WLApplication::handle_key(bool down, const SDL_Keycode& keycode, const int 
 					continue;
 				}
 				g_gr->screenshot(filename);
-				// Forward key to the game to show a notification
-				return false;
+				return true;
 			}
 			log_warn("Omitting screenshot because 10000 screenshots are already present");
 		}
-		return true;
+		// Screenshot not taken
+		return false;
 	}
 
 	if (matches_shortcut(KeyboardShortcut::kCommonFullscreen, keycode, modifiers)) {

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -911,7 +911,7 @@ void WLApplication::handle_input(InputCallback const* cb) {
 				handled = handle_key(ev.type == SDL_KEYDOWN, ev.key.keysym.sym, ev.key.keysym.mod);
 			}
 			if (!handled && cb && cb->key) {
-				handled = cb->key(ev.type == SDL_KEYDOWN, ev.key.keysym);
+				cb->key(ev.type == SDL_KEYDOWN, ev.key.keysym);
 			}
 			break;
 		}

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -856,8 +856,8 @@ bool WLApplication::handle_key(bool down, const SDL_Keycode& keycode, const int 
 
 	if (matches_shortcut(KeyboardShortcut::kCommonScreenshot, keycode, modifiers)) {
 		if (g_fs->disk_space() < kMinimumDiskSpace) {
-			log_warn("Omitting screenshot because diskspace is lower than %lluMB\n",
-			         kMinimumDiskSpace / (1000 * 1000));
+			log_warn("Omitting screenshot because diskspace is lower than %lluMiB\n",
+			         kMinimumDiskSpace / (1024 * 1024));
 		} else {
 			g_fs->ensure_directory_exists(kScreenshotsDir);
 			for (uint32_t nr = 0; nr < 10000; ++nr) {
@@ -867,7 +867,8 @@ bool WLApplication::handle_key(bool down, const SDL_Keycode& keycode, const int 
 					continue;
 				}
 				g_gr->screenshot(filename);
-				return true;
+				// Forward key to the game to show a notification
+				return false;
 			}
 			log_warn("Omitting screenshot because 10000 screenshots are already present");
 		}
@@ -906,14 +907,14 @@ void WLApplication::handle_input(InputCallback const* cb) {
 				   std::make_pair(std::make_pair(ev.key.keysym.sym, ev.key.keysym.mod), ev.type));
 				handled = true;
 			}
+			if (!handled) {
+				handled = handle_key(ev.type == SDL_KEYDOWN, ev.key.keysym.sym, ev.key.keysym.mod);
+			}
 			if (!handled && cb && cb->key) {
 				handled = cb->key(ev.type == SDL_KEYDOWN, ev.key.keysym);
 			}
-			if (!handled) {
-				handle_key(ev.type == SDL_KEYDOWN, ev.key.keysym.sym, ev.key.keysym.mod);
-			}
-		} break;
-
+			break;
+		}
 		case SDL_TEXTINPUT:
 			if (cb && cb->textinput) {
 				cb->textinput(ev.text.text);

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -1435,6 +1435,12 @@ bool InteractiveBase::handle_key(bool const down, SDL_Keysym const code) {
 			toggle_minimap();
 			return true;
 		}
+		if (matches_shortcut(KeyboardShortcut::kCommonScreenshot, code)) {
+			// Screenshot taken by topmost handler, just show a notification
+			// after the screenshot is through
+			log_message(_("Screenshot saved"));
+			return true;
+		}
 
 		switch (code.sym) {
 #ifndef NDEBUG  //  only in debug builds

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -138,7 +138,8 @@ InteractiveBase::InteractiveBase(EditorGameBase& the_egbase, Section& global_s, 
      previous_frame_gametime_(0),
      road_building_mode_(nullptr),
      unique_window_handler_(new UniqueWindowHandler()),
-     cheat_mode_enabled_(false) {
+     cheat_mode_enabled_(false),
+     screenshot_failed_(false) {
 
 	// Load the buildhelp icons.
 	{
@@ -1426,6 +1427,20 @@ bool InteractiveBase::handle_key(bool const down, SDL_Keysym const code) {
 		return true;
 	}
 
+	if (matches_shortcut(KeyboardShortcut::kCommonScreenshot, code)) {
+		// Screenshot taken by topmost handler, just show a notification
+		if (down) {
+			log_message(_("Failed saving screenshot!"));
+			screenshot_failed_ = true;
+		} else {
+			if (!screenshot_failed_) {
+				log_message(_("Screenshot saved"));
+			}
+			screenshot_failed_ = false;
+		}
+		return true;
+	}
+
 	if (down) {
 		if (matches_shortcut(KeyboardShortcut::kCommonBuildhelp, code)) {
 			toggle_buildhelp();
@@ -1433,12 +1448,6 @@ bool InteractiveBase::handle_key(bool const down, SDL_Keysym const code) {
 		}
 		if (matches_shortcut(KeyboardShortcut::kCommonMinimap, code)) {
 			toggle_minimap();
-			return true;
-		}
-		if (matches_shortcut(KeyboardShortcut::kCommonScreenshot, code)) {
-			// Screenshot taken by topmost handler, just show a notification
-			// after the screenshot is through
-			log_message(_("Screenshot saved"));
 			return true;
 		}
 

--- a/src/wui/interactive_base.h
+++ b/src/wui/interactive_base.h
@@ -414,6 +414,7 @@ private:
 	BuildhelpOverlay buildhelp_overlays_[Widelands::Field::Buildhelp_None];
 
 	bool cheat_mode_enabled_;
+	bool screenshot_failed_;
 };
 
 #endif  // end of include guard: WL_WUI_INTERACTIVE_BASE_H


### PR DESCRIPTION
Closes #4090
Also fixes an issue in `disk_space()` which prevented me from taking a screenshot in the first place, when the game is started with a relative `--homedir` option.
