### PR TITLE
replenish reed in Frisian trading outpost

### DIFF
--- a/data/tribes/initialization/frisians/starting_conditions/trading_outpost.lua
+++ b/data/tribes/initialization/frisians/starting_conditions/trading_outpost.lua
@@ -169,6 +169,10 @@ init = {
             wh:set_wares("granite", wh:get_wares("granite") + 5)
             added = added + 1
          end
+         if wh:get_wares("reed") < 100 then
+            wh:set_wares("reed", wh:get_wares("reed") + 5)
+            added = added + 1
+         end
          if wh:get_wares("coal") < 100 then
             wh:set_wares("coal", wh:get_wares("coal") + 10)
             added = added + 1


### PR DESCRIPTION
It was missing, but it is one of the essential building materials, and it can be the key to a deadlock.

https://www.widelands.org/forum/topic/5293/
