### PR TITLE
Fix game client deletion crash

### DIFF
--- a/src/logic/game_controller.h
+++ b/src/logic/game_controller.h
@@ -102,6 +102,10 @@ public:
 	                           Widelands::PlayerEndResult /*result*/,
 	                           const std::string& /* info */) {
 	}
+
+	/** Callback when the game setup UI is closed before a game was started. */
+	virtual void game_setup_aborted() {
+	}
 };
 
 #endif  // end of include guard: WL_LOGIC_GAME_CONTROLLER_H

--- a/src/network/gameclient.h
+++ b/src/network/gameclient.h
@@ -127,6 +127,11 @@ struct GameClient : public GameController, public GameSettingsProvider, public C
 		return pointer_;
 	}
 
+	void game_setup_aborted() override {
+		GameController::game_setup_aborted();
+		pointer_.reset();
+	}
+
 private:
 	DISALLOW_COPY_AND_ASSIGN(GameClient);
 

--- a/src/network/gamehost.h
+++ b/src/network/gamehost.h
@@ -134,6 +134,11 @@ public:
 		return forced_pause_;
 	}
 
+	void game_setup_aborted() override {
+		GameController::game_setup_aborted();
+		pointer_.reset();
+	}
+
 	void send_system_message_code(const std::string&,
 	                              const std::string& a = "",
 	                              const std::string& b = "",

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -120,7 +120,7 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
 	}
 	ok_.set_title(_("Start game"));
 
-	lua_ = new LuaInterface();
+	lua_.reset(new LuaInterface());
 	add_all_widgets();
 	add_behaviour_to_widgets();
 
@@ -130,7 +130,9 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
 }
 
 LaunchGame::~LaunchGame() {
-	delete lua_;
+	if (ctrl_) {
+		ctrl_->game_setup_aborted();
+	}
 }
 
 void LaunchGame::add_all_widgets() {

--- a/src/ui_fsmenu/launch_game.h
+++ b/src/ui_fsmenu/launch_game.h
@@ -50,7 +50,7 @@ public:
 	void update_custom_starting_positions();
 
 protected:
-	LuaInterface* lua_;
+	std::unique_ptr<LuaInterface> lua_;
 
 	virtual void clicked_select_map() = 0;
 	virtual void clicked_select_savegame() = 0;

--- a/src/ui_fsmenu/launch_mpg.cc
+++ b/src/ui_fsmenu/launch_mpg.cc
@@ -412,7 +412,7 @@ void LaunchMPG::load_map_info() {
 
 /// Show help
 void LaunchMPG::help_clicked() {
-	HelpWindow help(&capsule_.menu(), lua_, "txts/help/multiplayer_help.lua",
+	HelpWindow help(&capsule_.menu(), lua_.get(), "txts/help/multiplayer_help.lua",
 	                /** TRANSLATORS: This is a heading for a help window */
 	                _("Multiplayer Game Setup"));
 	help.run<UI::Panel::Returncodes>();


### PR DESCRIPTION
Fix the crash from https://github.com/widelands/widelands/pull/4968#issuecomment-865875820
The problem was that `GameClient` and `GameHost` are now handled by `shared_ptr`; when you aborted the game setup, one pointer instance remained all the while until a new network game was started, resulting in extra memory usage and the risk of accessing freed memory later. Now the instances are freed as soon as they are no longer needed.