### PR TITLE
Set Win logging dir in all main functions

### DIFF
--- a/src/website/map_info.cc
+++ b/src/website/map_info.cc
@@ -35,6 +35,9 @@
 #include "website/website_common.h"
 
 int main(int argc, char** argv) {
+#ifdef _WIN32
+	set_logging_dir();
+#endif
 	if (!(2 <= argc && argc <= 3)) {
 		log_err("Usage: %s <map file>\n", argv[0]);
 		return 1;

--- a/src/website/map_object_info.cc
+++ b/src/website/map_object_info.cc
@@ -285,6 +285,9 @@ void write_tribes(const Widelands::EditorGameBase& egbase, FileSystem* out_files
  */
 
 int main(int argc, char** argv) {
+#ifdef _WIN32
+	set_logging_dir();
+#endif
 	if (argc != 2) {
 		log_err("Usage: %s <existing-output-path>\n", argv[0]);
 		return 1;


### PR DESCRIPTION
Re #4919 
Adds the `set_logging_dir` call to the tools missed in #4935