### PR TITLE
Add option to skip datadir version check

### DIFF
--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1272,7 +1272,12 @@ void WLApplication::handle_commandline_parameters() {
 		commandline_.erase("localedir");
 	}
 
-	auto checkdatadirversion = [](const std::string& dd) {
+	const bool skip_check_datadir_version = commandline_.count("skip_check_datadir_version");
+	commandline_.erase("skip_check_datadir_version");
+	auto checkdatadirversion = [skip_check_datadir_version](const std::string& dd) {
+		if (skip_check_datadir_version) {
+			return std::string();
+		}
 		try {
 			std::unique_ptr<FileSystem> fs(&FileSystem::create(dd));
 			if (!fs.get()) {

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -62,7 +62,8 @@ void fill_parameter_vector() {
 		 */
 		_("[de_DE|sv_SE|...]"), _("The locale to use"), false},
 	  {"", "skip_check_datadir_version", "",
-		_("Do not check whether the data directory to use is compatible with this Widelands version"), true},
+		_("Do not check whether the data directory to use is compatible with this Widelands version"),
+		true},
 	  /// Game setup
 	  {"", "new_game_from_template", _("FILENAME"),
 		_("Directly create a new singleplayer game configured in the given file. An example can be "

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -61,6 +61,8 @@ void fill_parameter_vector() {
 		/** TRANSLATORS: The … is not used on purpose to increase readability on monospaced terminals
 		 */
 		_("[de_DE|sv_SE|...]"), _("The locale to use"), false},
+	  {"", "skip_check_datadir_version", "",
+		_("Do not check whether the data directory to use is compatible with this Widelands version"), true},
 	  /// Game setup
 	  {"", "new_game_from_template", _("FILENAME"),
 		_("Directly create a new singleplayer game configured in the given file. An example can be "


### PR DESCRIPTION
Fixes https://github.com/widelands/widelands/pull/4853#issuecomment-871942873: `./widelands --skip_check_datadir_version` allows using an arbitrary data directory.