### PR TITLE
linux: only enable backtrace when using glibc

### DIFF
--- a/src/logic/map_objects/backtrace.cc
+++ b/src/logic/map_objects/backtrace.cc
@@ -21,8 +21,10 @@
 
 #ifndef _WIN32
 #ifndef __APPLE__
+#if !defined(__linux__) || defined(__GLIBC__)
 
 #include <execinfo.h>
+#endif
 #endif
 #endif
 
@@ -30,6 +32,7 @@ std::string get_backtrace() {
 	std::string result("Backtrace:\n");
 #ifndef _WIN32
 #ifndef __APPLE__
+#if !defined(__linux__) || defined(__GLIBC__)
 #define BACKTRACE_STACKSIZE 24
 
 	void* stack[BACKTRACE_STACKSIZE];
@@ -40,6 +43,7 @@ std::string get_backtrace() {
 		result += '\n';
 	}
 	free(list);
+#endif
 #endif
 #endif
 	return result;


### PR DESCRIPTION
backtrace and backtrace_symbols are not in glibc, not POSIX-compliant
libc (like musl).