### PR TITLE
Update defaultai_warfare.cc

### DIFF
--- a/src/ai/defaultai_warfare.cc
+++ b/src/ai/defaultai_warfare.cc
@@ -714,7 +714,7 @@ bool DefaultAI::check_trainingsites(const Time& gametime) {
 
 	const Widelands::DescriptionIndex enhancement = ts->descr().enhancement();
 
-	if (enhancement != Widelands::INVALID_INDEX && ts_without_trainers_ == 0 && mines_.size() > 3 &&
+	if (enhancement != Widelands::INVALID_INDEX && ts_without_trainers_ == 0 &&
 	    ts_finished_count_ > 1 && ts_in_const_count_ == 0) {
 
 		// Make sure that:

--- a/src/ai/defaultai_warfare.cc
+++ b/src/ai/defaultai_warfare.cc
@@ -714,8 +714,7 @@ bool DefaultAI::check_trainingsites(const Time& gametime) {
 
 	const Widelands::DescriptionIndex enhancement = ts->descr().enhancement();
 
-	if (enhancement != Widelands::INVALID_INDEX && ts_without_trainers_ == 0 &&
-	    ts_finished_count_ > 1 && ts_in_const_count_ == 0) {
+	if (enhancement != Widelands::INVALID_INDEX && ts_without_trainers_ == 0 && ts_finished_count_ > 2 && ts_in_const_count_ == 0) {
 
 		// Make sure that:
 		// 1. Building is allowed


### PR DESCRIPTION
It does not make sense to check the amount of mines to determine whether a trainingsite should be enhanced or not. 

Only the Empire has expandable training buildings (Arena -> Colosseum), no other tribe. So I'm guessing the author of this line wanted to make sure the Empire had enough marble and gold before an arena was upgraded to a colosseum. On the other hand the Colosseum used no weapons and therefore no metals for training. 

But for all other tribe developers it's an unnecessary limitation. For example, the Amazons could not get upgradeable trainingsites because they do not have iron mines and therefore will never obtain this requirement.

If it doesn't cause any side effects, this condition should removed permanently.