### PR TITLE
Remove Travis from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,6 @@ For helping with issue management, see https://www.widelands.org/wiki/TriagingBu
 
 ## Obtaining MacOS and MS-Windows builds and testsuite runs
 
-Travis builds are triggered for all pushes to the `master` branch. If you want to get a build without making a pull request, temporarily add the name of your branch to the `branches` section in `.travis.yml`. This will not work if the branch is in a fork though.
-
 All pushes to master will be built on AppVeyor. Pull request branches are deployed for MS-Windows using a GitHub action. To obtain MS-Windows builds if you do not wish to open a pull request, temporarily add the name of your branch to the `branches` section in `appveyor.yml`. This also does not work for branches in forks.
 
 All pull request branches as well as master are additionally deployed for MacOS, and a testsuite checks them under various compilers. To obtain MacOS builds or testsuite results, temporarily add the name of your branch to the `branches` section in `.github/workflows/build.yaml`. This *does* work for branches in forks as well.


### PR DESCRIPTION
It seems like Travis is no longer used, because `.travis.yml` was deleted.

Hopefully this is correct, otherwise feel free to just close the PR.

Thanks!