### PR TITLE
Clarify AppVeyor fork limitations with Travis gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,6 @@ For helping with issue management, see https://www.widelands.org/wiki/TriagingBu
 
 ## Obtaining MacOS and MS-Windows builds and testsuite runs
 
-All pushes to master will be built on AppVeyor. Pull request branches are deployed for MS-Windows using a GitHub action. To obtain MS-Windows builds if you do not wish to open a pull request, temporarily add the name of your branch to the `branches` section in `appveyor.yml`. This also does not work for branches in forks.
+All pushes to master will be built on AppVeyor. Pull request branches are deployed for MS-Windows using a GitHub action. To obtain MS-Windows builds if you do not wish to open a pull request, temporarily add the name of your branch to the `branches` section in `appveyor.yml`. This will not work if the branch is in a fork though.
 
 All pull request branches as well as master are additionally deployed for MacOS, and a testsuite checks them under various compilers. To obtain MacOS builds or testsuite results, temporarily add the name of your branch to the `branches` section in `.github/workflows/build.yaml`. This *does* work for branches in forks as well.


### PR DESCRIPTION
In #5042 I removed the section about Travis from the README but it was
accurately pointed out that the section about AppVeyor no longer made as
much sense because it was the section about Travis that introduced the
limitations with forks.

I've copy pasted the last sentence from the Travis section to replace
the AppVeyor section and now this makes much more sense to me.