### PR TITLE
Speed up add-on remote interaction window

### DIFF
--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -960,7 +960,7 @@ void AddOnsCtrl::refresh_remotes(const bool showall) {
 		                                         "the server!<br>Error Message: %s")) %
 		                         e.what())
 		                           .str();
-		AddOns::AddOnInfo* i = new AddOns::AddOnInfo();
+		std::shared_ptr<AddOns::AddOnInfo> i = std::make_shared<AddOns::AddOnInfo>();
 		i->unlocalized_descname = title;
 		i->unlocalized_description = err;
 		i->unlocalized_author = bug;
@@ -971,7 +971,7 @@ void AddOnsCtrl::refresh_remotes(const bool showall) {
 		i->upload_timestamp = std::time(nullptr);
 		i->icon = g_image_cache->get(AddOns::kAddOnCategories.at(AddOns::AddOnCategory::kNone).icon);
 		i->sync_safe = true;  // suppress useless warning
-		remotes_ = {std::shared_ptr<AddOns::AddOnInfo>(i)};
+		remotes_ = {i};
 	}
 
 	progress.step((boost::format(step_message) % 100).str());

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -35,6 +35,8 @@
 namespace FsMenu {
 namespace AddOnsUI {
 
+static const std::string kVotingTabName("votes");
+
 std::map<std::pair<std::string, std::string>, std::string>
    RemoteInteractionWindow::downloaded_screenshots_cache_;
 
@@ -663,7 +665,8 @@ RemoteInteractionWindow::RemoteInteractionWindow(AddOnsCtrl& parent,
 	} else {
 		box_screenies_.set_visible(false);
 	}
-	tabs_.add("votes", "", &box_votes_);
+	tabs_.add(kVotingTabName, "", &box_votes_);
+	tabs_.sigclicked.connect([this]() { update_current_vote_on_demand(); });
 
 	main_box_.add(&tabs_, UI::Box::Resizing::kExpandBoth);
 	main_box_.add_space(kRowButtonSpacing);
@@ -888,20 +891,26 @@ void RemoteInteractionWindow::next_screenshot(int8_t delta) {
 	}
 }
 
+void RemoteInteractionWindow::update_current_vote_on_demand() {
+	if (current_vote_ < 0 && !parent_.username().empty() && tabs_.tabs()[tabs_.active()]->get_name() == kVotingTabName) {
+		current_vote_ = parent_.net().get_vote(info_->internal_name);
+	}
+	own_voting_.select(std::max(0, current_vote_));
+}
+
 void RemoteInteractionWindow::login_changed() {
-	current_vote_ = parent_.net().get_vote(info_->internal_name);
-	if (current_vote_ < 0) {
+	current_vote_ = -1;
+	update_current_vote_on_demand();
+	if (parent_.username().empty()) {
 		write_comment_.set_enabled(false);
 		write_comment_.set_tooltip(_("Please log in to comment"));
 		own_voting_.set_enabled(false);
 		own_voting_.set_tooltip(_("Please log in to vote"));
-		own_voting_.select(0);
 	} else {
 		write_comment_.set_enabled(true);
 		write_comment_.set_tooltip("");
 		own_voting_.set_enabled(true);
 		own_voting_.set_tooltip("");
-		own_voting_.select(current_vote_);
 	}
 	for (auto& cr : comment_rows_) {
 		cr->update_edit_enabled();

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -892,7 +892,8 @@ void RemoteInteractionWindow::next_screenshot(int8_t delta) {
 }
 
 void RemoteInteractionWindow::update_current_vote_on_demand() {
-	if (current_vote_ < 0 && !parent_.username().empty() && tabs_.tabs()[tabs_.active()]->get_name() == kVotingTabName) {
+	if (current_vote_ < 0 && !parent_.username().empty() &&
+	    tabs_.tabs()[tabs_.active()]->get_name() == kVotingTabName) {
 		current_vote_ = parent_.net().get_vote(info_->internal_name);
 	}
 	own_voting_.select(std::max(0, current_vote_));

--- a/src/ui_fsmenu/addons/remote_interaction.h
+++ b/src/ui_fsmenu/addons/remote_interaction.h
@@ -123,7 +123,10 @@ private:
 	int32_t current_screenshot_, nr_screenshots_;
 	std::vector<const Image*> screenshot_cache_;
 
+	/** How the user voted the current add-on (1-10; 0 for not voted; -1 for unknown). */
 	int current_vote_;
+
+	void update_current_vote_on_demand();
 
 	UI::Box main_box_;
 	UI::TabPanel tabs_;


### PR DESCRIPTION
Slight performance tweak by fetching the user's vote on demand rather than in advance, and skipping it for not-logged-in users.