### PR TITLE
Fix Lua `(n|p)gettext` Ignoring Textdomains

### DIFF
--- a/src/scripting/lua_globals.cc
+++ b/src/scripting/lua_globals.cc
@@ -274,10 +274,10 @@ static int L_ngettext(lua_State* L) {
 		if (td->second) {
 			std::unique_ptr<i18n::GenericTextdomain> dom(
 			   AddOns::create_textdomain_for_addon(td->first));
-			lua_pushstring(L, dngettext(td->first.c_str(), msgid, msgid_plural, n));
+			lua_pushstring(L, ngettext(msgid, msgid_plural, n));
 		} else {
 			i18n::Textdomain dom(td->first);
-			lua_pushstring(L, dngettext(td->first.c_str(), msgid, msgid_plural, n));
+			lua_pushstring(L, ngettext(msgid, msgid_plural, n));
 		}
 	} else {
 		lua_pushstring(L, ngettext(msgid, msgid_plural, n));
@@ -307,10 +307,10 @@ static int L_pgettext(lua_State* L) {
 		if (td->second) {
 			std::unique_ptr<i18n::GenericTextdomain> dom(
 			   AddOns::create_textdomain_for_addon(td->first));
-			lua_pushstring(L, dpgettext_expr(td->first.c_str(), msgctxt, msgid));
+			lua_pushstring(L, pgettext_expr(msgctxt, msgid));
 		} else {
 			i18n::Textdomain dom(td->first);
-			lua_pushstring(L, dpgettext_expr(td->first.c_str(), msgctxt, msgid));
+			lua_pushstring(L, pgettext_expr(msgctxt, msgid));
 		}
 	} else {
 		lua_pushstring(L, pgettext_expr(msgctxt, msgid));
@@ -349,10 +349,10 @@ static int L_npgettext(lua_State* L) {
 		if (td->second) {
 			std::unique_ptr<i18n::GenericTextdomain> dom(
 			   AddOns::create_textdomain_for_addon(td->first));
-			lua_pushstring(L, dnpgettext_expr(td->first.c_str(), msgctxt, msgid, msgid_plural, n));
+			lua_pushstring(L, npgettext_expr(msgctxt, msgid, msgid_plural, n));
 		} else {
 			i18n::Textdomain dom(td->first);
-			lua_pushstring(L, dnpgettext_expr(td->first.c_str(), msgctxt, msgid, msgid_plural, n));
+			lua_pushstring(L, npgettext_expr(msgctxt, msgid, msgid_plural, n));
 		}
 	} else {
 		lua_pushstring(L, npgettext_expr(msgctxt, msgid, msgid_plural, n));


### PR DESCRIPTION
Fixes https://www.widelands.org/forum/post/38084/

The `d*gettext` family of functions ignore the current textdomain in favour of an argument. Since we want it to use the global textdomain stack we need to use the standard `{np}gettext` function instead.