### PR TITLE
Fix Clang 13 Warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ CMakeLists.txt.user*
 /.vs
 CMakeSettings.json
 
+# Profilers
+gmon.out
+
 # Validation checks
 po_validation
 clang-tidy.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,6 @@ if(NOT MSVC)
   # Turn some warnings into errors.
   wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Werror")
   wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=unused-variable")  # This is a false-positive on g++5
-  wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=format")           # Our PPA builds need this
   if (APPLE)  # Our Mac CI needs these
     wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=poison-system-directories")
     wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=disabled-macro-expansion")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,7 @@ if(NOT MSVC)
   # Turn some warnings into errors.
   wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Werror")
   wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=unused-variable")  # This is a false-positive on g++5
+  wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=format")           # Our PPA builds need this
   if (APPLE)  # Our Mac CI needs these
     wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=poison-system-directories")
     wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Wno-error=disabled-macro-expansion")

--- a/src/base/i18n.cc
+++ b/src/base/i18n.cc
@@ -46,9 +46,9 @@
 #endif
 #endif
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 extern int _nl_msg_cat_cntr;
-CLANG_DIAG_ON("-Wreserved-identifier")
+CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 namespace i18n {
 

--- a/src/base/i18n.cc
+++ b/src/base/i18n.cc
@@ -46,7 +46,9 @@
 #endif
 #endif
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 extern int _nl_msg_cat_cntr;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 namespace i18n {
 

--- a/src/base/macros.h
+++ b/src/base/macros.h
@@ -94,12 +94,15 @@
 #endif
 
 // Older clang versions don't have "-Wreserved-identifier" either
-#if defined(__clang__) && __has_warning("-Wreserved-identifier")
-#define CLANG_DIAG_RESERVED_IDENTIFIER_OFF CLANG_DIAG_OFF("-Wreserved-identifier")
-#define CLANG_DIAG_RESERVED_IDENTIFIER_ON CLANG_DIAG_ON("-Wreserved-identifier")
-#else
 #define CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 #define CLANG_DIAG_RESERVED_IDENTIFIER_ON
+#ifdef __clang__
+#if __has_warning("-Wreserved-identifier")
+#undef CLANG_DIAG_RESERVED_IDENTIFIER_OFF
+#undef CLANG_DIAG_RESERVED_IDENTIFIER_ON
+#define CLANG_DIAG_RESERVED_IDENTIFIER_OFF CLANG_DIAG_OFF("-Wreserved-identifier")
+#define CLANG_DIAG_RESERVED_IDENTIFIER_ON CLANG_DIAG_ON("-Wreserved-identifier")
+#endif
 #endif
 
 // disallow copying or assigning a class

--- a/src/base/macros.h
+++ b/src/base/macros.h
@@ -93,6 +93,15 @@
 #define FORMAT_WARNINGS_ON GCC_DIAG_ON("-Wformat")
 #endif
 
+// Older clang versions don't have "-Wreserved-identifier" either
+#if defined(__clang__) && __has_warning("-Wreserved-identifier")
+#define CLANG_DIAG_RESERVED_IDENTIFIER_OFF CLANG_DIAG_OFF("-Wreserved-identifier")
+#define CLANG_DIAG_RESERVED_IDENTIFIER_ON CLANG_DIAG_ON("-Wreserved-identifier")
+#else
+#define CLANG_DIAG_RESERVED_IDENTIFIER_OFF
+#define CLANG_DIAG_RESERVED_IDENTIFIER_ON
+#endif
+
 // disallow copying or assigning a class
 #define DISALLOW_COPY_AND_ASSIGN(TypeName)                                                         \
 	TypeName(const TypeName&) = delete;                                                             \

--- a/src/economy/shipping_schedule.cc
+++ b/src/economy/shipping_schedule.cc
@@ -1096,21 +1096,21 @@ Duration ShippingSchedule::update(Game& game) {
 	 *    start and end port between its two existing targets.
 	 */
 	std::set<PrioritisedPortPair> _open_pairs;
-	for (auto& start__map : items_in_ports) {
-		for (auto& dest__shipsinfos : start__map.second) {
-			assert(dest__shipsinfos.second.second <= 0);
-			if (dest__shipsinfos.second.second < 0) {
-				const int32_t maxprio = start__map.first.get(game)->calc_max_priority(
-				   game, *dest__shipsinfos.first.get(game));
+	for (auto& start_to_map : items_in_ports) {
+		for (auto& dest_to_shipsinfos : start_to_map.second) {
+			assert(dest_to_shipsinfos.second.second <= 0);
+			if (dest_to_shipsinfos.second.second < 0) {
+				const int32_t maxprio = start_to_map.first.get(game)->calc_max_priority(
+				   game, *dest_to_shipsinfos.first.get(game));
 				const int32_t total_waiting =
-				   start__map.first.get(game)->count_waiting(dest__shipsinfos.first.get(game));
-				const int32_t open = -dest__shipsinfos.second.second;
+				   start_to_map.first.get(game)->count_waiting(dest_to_shipsinfos.first.get(game));
+				const int32_t open = -dest_to_shipsinfos.second.second;
 				assert(total_waiting >= open);
 				assert(maxprio >= total_waiting);  // a priority of at least 1 per item
 				const int32_t prio = maxprio * open / total_waiting;
 				assert(prio >= 0);
 				_open_pairs.insert(PrioritisedPortPair(
-				   start__map.first.get(game), dest__shipsinfos.first.get(game), open, prio));
+				   start_to_map.first.get(game), dest_to_shipsinfos.first.get(game), open, prio));
 			}
 		}
 	}

--- a/src/graphic/sdl_utils.cc
+++ b/src/graphic/sdl_utils.cc
@@ -23,7 +23,7 @@
 
 SDL_Surface* empty_sdl_surface(int16_t w, int16_t h) {
 	SDL_Surface* const surface =
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+#if !defined(SDL_BYTEORDER) || SDL_BYTEORDER == SDL_LIL_ENDIAN
 	   SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
 #else
 	   SDL_CreateRGBSurface(SDL_SWSURFACE, w, h, 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);

--- a/src/io/machdep.h
+++ b/src/io/machdep.h
@@ -27,7 +27,7 @@
 // Disable this warning for files where we might use these macros.
 CLANG_DIAG_OFF("-Wself-assign")
 
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+#if !defined(SDL_BYTEORDER) || SDL_BYTEORDER == SDL_LIL_ENDIAN
 #define little_16(x) (x)
 #define little_32(x) (x)
 #define little_float(x) (x)

--- a/src/io/streamread.cc
+++ b/src/io/streamread.cc
@@ -45,8 +45,10 @@ void StreamRead::data_complete(void* const read_data, const size_t size) {
 	size_t read = data(read_data, size);
 
 	if (read != size) {
+		FORMAT_WARNINGS_OFF
 		throw data_error(
 		   "Stream ended unexpectedly (%" PRIuS " bytes read, %" PRIuS " expected)", read, size);
+		FORMAT_WARNINGS_ON
 	}
 }
 

--- a/src/logic/cookie_priority_queue.h
+++ b/src/logic/cookie_priority_queue.h
@@ -28,10 +28,10 @@
 #include "base/macros.h"
 #include "logic/map_objects/tribes/wareworker.h"
 
-template <typename _Type> struct DefaultCookieAccessor;
+template <typename Type> struct DefaultCookieAccessor;
 
-template <typename _Type> struct CookiePriorityQueueBase {
-	using CookieType = _Type;
+template <typename CT> struct CookiePriorityQueueBase {
+	using CookieType = CT;
 	using CookieTypeVector = std::vector<CookieType*>;
 	using CookieSizeType = typename CookieTypeVector::size_type;
 
@@ -47,7 +47,7 @@ template <typename _Type> struct CookiePriorityQueueBase {
 		}
 
 	private:
-		friend struct CookiePriorityQueueBase<_Type>;
+		friend struct CookiePriorityQueueBase<CookieType>;
 
 		CookieSizeType pos;
 
@@ -80,18 +80,18 @@ protected:
  * you have to call \ref decrease_key or \ref increase_key after the change,
  * depending on whether the change caused a decrease or increase, respectively.
  */
-template <typename _Type,
-          typename _Compare = std::less<_Type>,
-          typename _CookieAccessor = DefaultCookieAccessor<_Type>>
-struct CookiePriorityQueue : CookiePriorityQueueBase<_Type> {
-	using CookieType = typename CookiePriorityQueueBase<_Type>::CookieType;
-	using CookieTypeVector = typename CookiePriorityQueueBase<_Type>::CookieTypeVector;
-	using CookieSizeType = typename CookiePriorityQueueBase<_Type>::CookieSizeType;
-	using Cookie = typename CookiePriorityQueueBase<_Type>::Cookie;
+template <typename CPQType,
+          typename Cmp = std::less<CPQType>,
+          typename Cas = DefaultCookieAccessor<CPQType>>
+struct CookiePriorityQueue : CookiePriorityQueueBase<CPQType> {
+	using Compare = Cmp;
+	using CookieAccessor = Cas;
+	using CookieType = typename CookiePriorityQueueBase<CPQType>::CookieType;
+	using CookieTypeVector = typename CookiePriorityQueueBase<CPQType>::CookieTypeVector;
+	using CookieSizeType = typename CookiePriorityQueueBase<CPQType>::CookieSizeType;
+	using Cookie = typename CookiePriorityQueueBase<CPQType>::Cookie;
 
-	using BaseType = CookiePriorityQueueBase<_Type>;
-	using Compare = _Compare;
-	using CookieAccessor = _CookieAccessor;
+	using BaseType = CookiePriorityQueueBase<CPQType>;
 	explicit CookiePriorityQueue(Widelands::WareWorker type,
 	                             const Compare& comparator = Compare(),
 	                             const CookieAccessor& accessor = CookieAccessor());
@@ -137,48 +137,48 @@ private:
 	}
 };
 
-template <typename _Type> struct DefaultCookieAccessor {
-	using Cookie = typename CookiePriorityQueueBase<_Type>::Cookie;
+template <typename DCAType> struct DefaultCookieAccessor {
+	using Cookie = typename CookiePriorityQueueBase<DCAType>::Cookie;
 
-	Cookie& operator()(_Type* t, Widelands::WareWorker type) {
+	Cookie& operator()(DCAType* t, Widelands::WareWorker type) {
 		return t->cookie(type);
 	}
 };
 
-template <typename _T, typename _Cw, typename _CA>
-CookiePriorityQueue<_T, _Cw, _CA>::CookiePriorityQueue(
+template <typename t_T, typename t_Cw, typename t_CA>
+CookiePriorityQueue<t_T, t_Cw, t_CA>::CookiePriorityQueue(
    Widelands::WareWorker wwtype,
-   const typename CookiePriorityQueue<_T, _Cw, _CA>::Compare& comparator,
-   const typename CookiePriorityQueue<_T, _Cw, _CA>::CookieAccessor& accessor)
+   const typename CookiePriorityQueue<t_T, t_Cw, t_CA>::Compare& comparator,
+   const typename CookiePriorityQueue<t_T, t_Cw, t_CA>::CookieAccessor& accessor)
    : type_(wwtype), c(comparator), ca(accessor) {
 }
 
-template <typename _T, typename _Cw, typename _CA>
-CookiePriorityQueue<_T, _Cw, _CA>::~CookiePriorityQueue() {
+template <typename t_T, typename t_Cw, typename t_CA>
+CookiePriorityQueue<t_T, t_Cw, t_CA>::~CookiePriorityQueue() {
 	for (typename CookieTypeVector::iterator it = d.begin(); it != d.end(); ++it)
 		cookie_pos(ca(*it, type_)) = bad_pos();
 }
 
-template <typename _T, typename _Cw, typename _CA>
-typename CookiePriorityQueue<_T, _Cw, _CA>::CookieSizeType
-CookiePriorityQueue<_T, _Cw, _CA>::size() const {
+template <typename t_T, typename t_Cw, typename t_CA>
+typename CookiePriorityQueue<t_T, t_Cw, t_CA>::CookieSizeType
+CookiePriorityQueue<t_T, t_Cw, t_CA>::size() const {
 	return d.size();
 }
 
-template <typename _T, typename _Cw, typename _CA>
-bool CookiePriorityQueue<_T, _Cw, _CA>::empty() const {
+template <typename t_T, typename t_Cw, typename t_CA>
+bool CookiePriorityQueue<t_T, t_Cw, t_CA>::empty() const {
 	return d.empty();
 }
 
-template <typename _T, typename _Cw, typename _CA>
-typename CookiePriorityQueue<_T, _Cw, _CA>::CookieType*
-CookiePriorityQueue<_T, _Cw, _CA>::top() const {
+template <typename t_T, typename t_Cw, typename t_CA>
+typename CookiePriorityQueue<t_T, t_Cw, t_CA>::CookieType*
+CookiePriorityQueue<t_T, t_Cw, t_CA>::top() const {
 	return *d.begin();
 }
 
-template <typename _T, typename _Cw, typename _CA>
-void CookiePriorityQueue<_T, _Cw, _CA>::push(
-   typename CookiePriorityQueue<_T, _Cw, _CA>::CookieType* elt) {
+template <typename t_T, typename t_Cw, typename t_CA>
+void CookiePriorityQueue<t_T, t_Cw, t_CA>::push(
+   typename CookiePriorityQueue<t_T, t_Cw, t_CA>::CookieType* elt) {
 	Cookie& elt_cookie(ca(elt, type_));
 
 	assert(cookie_pos(elt_cookie) == BaseType::bad_pos());
@@ -189,9 +189,9 @@ void CookiePriorityQueue<_T, _Cw, _CA>::push(
 	decrease_key(elt);
 }
 
-template <typename _T, typename _Cw, typename _CA>
-void CookiePriorityQueue<_T, _Cw, _CA>::pop(
-   typename CookiePriorityQueue<_T, _Cw, _CA>::CookieType* elt) {
+template <typename t_T, typename t_Cw, typename t_CA>
+void CookiePriorityQueue<t_T, t_Cw, t_CA>::pop(
+   typename CookiePriorityQueue<t_T, t_Cw, t_CA>::CookieType* elt) {
 	Cookie& elt_cookie(ca(elt, type_));
 
 	assert(cookie_pos(elt_cookie) < d.size());
@@ -212,9 +212,9 @@ void CookiePriorityQueue<_T, _Cw, _CA>::pop(
 		increase_key(*d.begin());
 }
 
-template <typename _T, typename _Cw, typename _CA>
-void CookiePriorityQueue<_T, _Cw, _CA>::decrease_key(
-   typename CookiePriorityQueue<_T, _Cw, _CA>::CookieType* elt) {
+template <typename t_T, typename t_Cw, typename t_CA>
+void CookiePriorityQueue<t_T, t_Cw, t_CA>::decrease_key(
+   typename CookiePriorityQueue<t_T, t_Cw, t_CA>::CookieType* elt) {
 	Cookie& elt_cookie(ca(elt, type_));
 
 	assert(cookie_pos(elt_cookie) < d.size());
@@ -237,9 +237,9 @@ void CookiePriorityQueue<_T, _Cw, _CA>::decrease_key(
 #endif
 }
 
-template <typename _T, typename _Cw, typename _CA>
-void CookiePriorityQueue<_T, _Cw, _CA>::increase_key(
-   typename CookiePriorityQueue<_T, _Cw, _CA>::CookieType* elt) {
+template <typename t_T, typename t_Cw, typename t_CA>
+void CookiePriorityQueue<t_T, t_Cw, t_CA>::increase_key(
+   typename CookiePriorityQueue<t_T, t_Cw, t_CA>::CookieType* elt) {
 	Cookie& elt_cookie(ca(elt, type_));
 
 	assert(cookie_pos(elt_cookie) < d.size());
@@ -281,17 +281,17 @@ void CookiePriorityQueue<_T, _Cw, _CA>::increase_key(
 #endif
 }
 
-template <typename _T, typename _Cw, typename _CA>
-void CookiePriorityQueue<_T, _Cw, _CA>::swap(
-   typename CookiePriorityQueue<_T, _Cw, _CA>::Cookie& a,
-   typename CookiePriorityQueue<_T, _Cw, _CA>::Cookie& b) {
+template <typename t_T, typename t_Cw, typename t_CA>
+void CookiePriorityQueue<t_T, t_Cw, t_CA>::swap(
+   typename CookiePriorityQueue<t_T, t_Cw, t_CA>::Cookie& a,
+   typename CookiePriorityQueue<t_T, t_Cw, t_CA>::Cookie& b) {
 	std::swap(d[cookie_pos(a)], d[cookie_pos(b)]);
 	std::swap(cookie_pos(a), cookie_pos(b));
 }
 
 // Disable in release builds.
-template <typename _T, typename _Cw, typename _CA>
-void CookiePriorityQueue<_T, _Cw, _CA>::selftest() {
+template <typename t_T, typename t_Cw, typename t_CA>
+void CookiePriorityQueue<t_T, t_Cw, t_CA>::selftest() {
 	for (CookieSizeType pos = 0; pos < d.size(); ++pos) {
 		Cookie& elt_cookie(ca(d[pos], type_));
 

--- a/src/logic/widelands_geometry.h
+++ b/src/logic/widelands_geometry.h
@@ -67,13 +67,13 @@ struct Coords {
 };
 static_assert(sizeof(Coords) == 4, "assert(sizeof(Coords) == 4) failed.");
 
-template <typename _CoordsType = Coords, typename _RadiusType = uint16_t>
-struct Area : public _CoordsType {
-	using CoordsType = _CoordsType;
-	using RadiusType = _RadiusType;
+template <typename CT = Coords, typename RT = uint16_t>
+struct Area : public CT {
+	using CoordsType = CT;
+	using RadiusType = RT;
 	Area() {
 	}
-	Area(const CoordsType center, const RadiusType Radius) : CoordsType(center), radius(Radius) {
+	Area(const CoordsType center, const RadiusType rad) : CoordsType(center), radius(rad) {
 	}
 
 	bool operator==(const Area& other) const {

--- a/src/logic/widelands_geometry.h
+++ b/src/logic/widelands_geometry.h
@@ -67,8 +67,7 @@ struct Coords {
 };
 static_assert(sizeof(Coords) == 4, "assert(sizeof(Coords) == 4) failed.");
 
-template <typename CT = Coords, typename RT = uint16_t>
-struct Area : public CT {
+template <typename CT = Coords, typename RT = uint16_t> struct Area : public CT {
 	using CoordsType = CT;
 	using RadiusType = RT;
 	Area() {

--- a/src/scripting/CMakeLists.txt
+++ b/src/scripting/CMakeLists.txt
@@ -25,6 +25,7 @@ wl_library(scripting_luna
     luna_impl.cc
     luna_impl.h
   DEPENDS
+    base_macros
     scripting_base
     scripting_errors
 )

--- a/src/scripting/lua_bases.h
+++ b/src/scripting/lua_bases.h
@@ -49,10 +49,10 @@ public:
 	~LuaEditorGameBase() override {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -99,10 +99,10 @@ public:
 	~LuaPlayerBase() override {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -113,10 +113,10 @@ public:
 	/*
 	 * Lua methods
 	 */
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	int __eq(lua_State* L);
 	int __tostring(lua_State* L);
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 	int place_flag(lua_State* L);
 	int place_road(lua_State* L);
 	int place_building(lua_State* L);

--- a/src/scripting/lua_bases.h
+++ b/src/scripting/lua_bases.h
@@ -49,8 +49,10 @@ public:
 	~LuaEditorGameBase() override {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -97,8 +99,10 @@ public:
 	~LuaPlayerBase() override {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -109,8 +113,10 @@ public:
 	/*
 	 * Lua methods
 	 */
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
 	int __tostring(lua_State* L);
+CLANG_DIAG_ON("-Wreserved-identifier")
 	int place_flag(lua_State* L);
 	int place_road(lua_State* L);
 	int place_building(lua_State* L);

--- a/src/scripting/lua_bases.h
+++ b/src/scripting/lua_bases.h
@@ -49,10 +49,10 @@ public:
 	~LuaEditorGameBase() override {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -99,10 +99,10 @@ public:
 	~LuaPlayerBase() override {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -113,10 +113,10 @@ CLANG_DIAG_ON("-Wreserved-identifier")
 	/*
 	 * Lua methods
 	 */
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
 	int __tostring(lua_State* L);
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 	int place_flag(lua_State* L);
 	int place_road(lua_State* L);
 	int place_building(lua_State* L);

--- a/src/scripting/lua_game.h
+++ b/src/scripting/lua_game.h
@@ -137,10 +137,10 @@ public:
 		report_error(L, "Cannot instantiate a '%s' directly!", className);
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override;
 	void __unpersist(lua_State*) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -159,9 +159,9 @@ CLANG_DIAG_ON("-Wreserved-identifier")
 	 * Lua Methods
 	 */
 	int remove(lua_State* L);
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * C Methods
@@ -185,10 +185,10 @@ public:
 		report_error(L, "Cannot instantiate a '%s' directly!", className);
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override;
 	void __unpersist(lua_State*) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -205,9 +205,9 @@ CLANG_DIAG_ON("-Wreserved-identifier")
 	/*
 	 * Lua Methods
 	 */
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * C Methods

--- a/src/scripting/lua_game.h
+++ b/src/scripting/lua_game.h
@@ -137,8 +137,10 @@ public:
 		report_error(L, "Cannot instantiate a '%s' directly!", className);
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override;
 	void __unpersist(lua_State*) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -157,7 +159,9 @@ public:
 	 * Lua Methods
 	 */
 	int remove(lua_State* L);
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * C Methods
@@ -181,8 +185,10 @@ public:
 		report_error(L, "Cannot instantiate a '%s' directly!", className);
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override;
 	void __unpersist(lua_State*) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -199,7 +205,9 @@ public:
 	/*
 	 * Lua Methods
 	 */
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * C Methods

--- a/src/scripting/lua_game.h
+++ b/src/scripting/lua_game.h
@@ -137,10 +137,10 @@ public:
 		report_error(L, "Cannot instantiate a '%s' directly!", className);
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State*) override;
 	void __unpersist(lua_State*) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -159,9 +159,9 @@ public:
 	 * Lua Methods
 	 */
 	int remove(lua_State* L);
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	int __eq(lua_State* L);
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * C Methods
@@ -185,10 +185,10 @@ public:
 		report_error(L, "Cannot instantiate a '%s' directly!", className);
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State*) override;
 	void __unpersist(lua_State*) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -205,9 +205,9 @@ public:
 	/*
 	 * Lua Methods
 	 */
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	int __eq(lua_State* L);
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * C Methods

--- a/src/scripting/lua_globals.cc
+++ b/src/scripting/lua_globals.cc
@@ -230,9 +230,9 @@ void write_textdomain_stack(FileWrite& fw, const lua_State* L) {
       :type str: :class:`string`
       :returns: The translated string.
 */
-CLANG_DIAG_OFF("-Wreserved-identifier")
+CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 static int L__(lua_State* L) {
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 	if (const TextdomainInfo* td = current_textdomain(L)) {
 		if (td->second) {
 			std::unique_ptr<i18n::GenericTextdomain> dom(

--- a/src/scripting/lua_globals.cc
+++ b/src/scripting/lua_globals.cc
@@ -230,7 +230,9 @@ void write_textdomain_stack(FileWrite& fw, const lua_State* L) {
       :type str: :class:`string`
       :returns: The translated string.
 */
+CLANG_DIAG_OFF("-Wreserved-identifier")
 static int L__(lua_State* L) {
+CLANG_DIAG_ON("-Wreserved-identifier")
 	if (const TextdomainInfo* td = current_textdomain(L)) {
 		if (td->second) {
 			std::unique_ptr<i18n::GenericTextdomain> dom(

--- a/src/scripting/lua_globals.cc
+++ b/src/scripting/lua_globals.cc
@@ -232,7 +232,7 @@ void write_textdomain_stack(FileWrite& fw, const lua_State* L) {
 */
 CLANG_DIAG_OFF("-Wreserved-identifier")
 static int L__(lua_State* L) {
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 	if (const TextdomainInfo* td = current_textdomain(L)) {
 		if (td->second) {
 			std::unique_ptr<i18n::GenericTextdomain> dom(

--- a/src/scripting/lua_map.h
+++ b/src/scripting/lua_map.h
@@ -75,8 +75,10 @@ public:
 		report_error(L, "Cannot instantiate a 'Map' directly!");
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -126,8 +128,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaTribeDescription' directly!");
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -191,8 +195,10 @@ public:
 		report_error(L, "Cannot instantiate a 'MapObjectDescription' directly!");
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -244,8 +250,10 @@ public:
 	explicit LuaImmovableDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -285,8 +293,10 @@ public:
 	explicit LuaBuildingDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -568,8 +578,10 @@ public:
 	explicit LuaWareDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -605,8 +617,10 @@ public:
 	explicit LuaWorkerDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -688,8 +702,10 @@ public:
 	explicit LuaShipDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -725,8 +741,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaResourceDescription' directly!");
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -776,8 +794,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaTerrainDescription' directly!");
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -829,8 +849,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaEconomy' directly!");
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -882,20 +904,26 @@ public:
 		ptr_ = nullptr;
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * attributes
 	 */
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	int get___hash(lua_State*);
+CLANG_DIAG_ON("-Wreserved-identifier")
 	int get_descr(lua_State*);
 	int get_serial(lua_State*);
 
 	/*
 	 * Lua Methods
 	 */
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
+CLANG_DIAG_ON("-Wreserved-identifier")
 	int remove(lua_State* L);
 	int destroy(lua_State* L);
 	int has_attribute(lua_State* L);
@@ -1499,13 +1527,17 @@ public:
 	~LuaField() override {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
 	 */
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	int get___hash(lua_State*);
+CLANG_DIAG_ON("-Wreserved-identifier")
 	int get_x(lua_State* L);
 	int get_y(lua_State* L);
 	int get_viewpoint_x(lua_State* L);
@@ -1539,8 +1571,10 @@ public:
 	/*
 	 * Lua methods
 	 */
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __tostring(lua_State* L);
 	int __eq(lua_State* L);
+CLANG_DIAG_ON("-Wreserved-identifier")
 	int region(lua_State* L);
 	int has_caps(lua_State*);
 	int has_max_caps(lua_State*);
@@ -1577,8 +1611,10 @@ public:
 	~LuaPlayerSlot() override {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties

--- a/src/scripting/lua_map.h
+++ b/src/scripting/lua_map.h
@@ -75,10 +75,10 @@ public:
 		report_error(L, "Cannot instantiate a 'Map' directly!");
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -128,10 +128,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaTribeDescription' directly!");
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -195,10 +195,10 @@ public:
 		report_error(L, "Cannot instantiate a 'MapObjectDescription' directly!");
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -250,10 +250,10 @@ public:
 	explicit LuaImmovableDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -293,10 +293,10 @@ public:
 	explicit LuaBuildingDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -578,10 +578,10 @@ public:
 	explicit LuaWareDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -617,10 +617,10 @@ public:
 	explicit LuaWorkerDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -702,10 +702,10 @@ public:
 	explicit LuaShipDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -741,10 +741,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaResourceDescription' directly!");
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -794,10 +794,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaTerrainDescription' directly!");
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -849,10 +849,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaEconomy' directly!");
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -904,26 +904,26 @@ public:
 		ptr_ = nullptr;
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * attributes
 	 */
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	int get___hash(lua_State*);
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 	int get_descr(lua_State*);
 	int get_serial(lua_State*);
 
 	/*
 	 * Lua Methods
 	 */
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	int __eq(lua_State* L);
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 	int remove(lua_State* L);
 	int destroy(lua_State* L);
 	int has_attribute(lua_State* L);
@@ -1527,17 +1527,17 @@ public:
 	~LuaField() override {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
 	 */
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	int get___hash(lua_State*);
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 	int get_x(lua_State* L);
 	int get_y(lua_State* L);
 	int get_viewpoint_x(lua_State* L);
@@ -1571,10 +1571,10 @@ public:
 	/*
 	 * Lua methods
 	 */
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	int __tostring(lua_State* L);
 	int __eq(lua_State* L);
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 	int region(lua_State* L);
 	int has_caps(lua_State*);
 	int has_max_caps(lua_State*);
@@ -1611,10 +1611,10 @@ public:
 	~LuaPlayerSlot() override {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties

--- a/src/scripting/lua_map.h
+++ b/src/scripting/lua_map.h
@@ -75,10 +75,10 @@ public:
 		report_error(L, "Cannot instantiate a 'Map' directly!");
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -128,10 +128,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaTribeDescription' directly!");
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -195,10 +195,10 @@ public:
 		report_error(L, "Cannot instantiate a 'MapObjectDescription' directly!");
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -250,10 +250,10 @@ public:
 	explicit LuaImmovableDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -293,10 +293,10 @@ public:
 	explicit LuaBuildingDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -578,10 +578,10 @@ public:
 	explicit LuaWareDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -617,10 +617,10 @@ public:
 	explicit LuaWorkerDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -702,10 +702,10 @@ public:
 	explicit LuaShipDescription(lua_State* L) : LuaMapObjectDescription(L) {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -741,10 +741,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaResourceDescription' directly!");
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -794,10 +794,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaTerrainDescription' directly!");
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -849,10 +849,10 @@ public:
 		report_error(L, "Cannot instantiate a 'LuaEconomy' directly!");
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -904,26 +904,26 @@ public:
 		ptr_ = nullptr;
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * attributes
 	 */
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	int get___hash(lua_State*);
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 	int get_descr(lua_State*);
 	int get_serial(lua_State*);
 
 	/*
 	 * Lua Methods
 	 */
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __eq(lua_State* L);
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 	int remove(lua_State* L);
 	int destroy(lua_State* L);
 	int has_attribute(lua_State* L);
@@ -1527,17 +1527,17 @@ public:
 	~LuaField() override {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
 	 */
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	int get___hash(lua_State*);
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 	int get_x(lua_State* L);
 	int get_y(lua_State* L);
 	int get_viewpoint_x(lua_State* L);
@@ -1571,10 +1571,10 @@ CLANG_DIAG_ON("-Wreserved-identifier")
 	/*
 	 * Lua methods
 	 */
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	int __tostring(lua_State* L);
 	int __eq(lua_State* L);
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 	int region(lua_State* L);
 	int has_caps(lua_State*);
 	int has_max_caps(lua_State*);
@@ -1611,10 +1611,10 @@ public:
 	~LuaPlayerSlot() override {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties

--- a/src/scripting/lua_root.h
+++ b/src/scripting/lua_root.h
@@ -47,10 +47,10 @@ public:
 	}
 	explicit LuaGame(lua_State* L);
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -91,10 +91,10 @@ public:
 	~LuaEditor() override {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -120,10 +120,10 @@ public:
 	}
 	explicit LuaDescriptions(lua_State* L);
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -186,12 +186,12 @@ public:
 	explicit LuaWorld(lua_State*) {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State*) override {
 	}
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 };
 
 // TODO(GunChleoc): This class is here for saveloading compatibility only. We'll get a SIGABRT from
@@ -206,12 +206,12 @@ public:
 	explicit LuaTribes(lua_State*) {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State*) override {
 	}
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 };
 
 void luaopen_wlroot(lua_State*, bool in_editor);

--- a/src/scripting/lua_root.h
+++ b/src/scripting/lua_root.h
@@ -47,10 +47,10 @@ public:
 	}
 	explicit LuaGame(lua_State* L);
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -91,10 +91,10 @@ public:
 	~LuaEditor() override {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -120,10 +120,10 @@ public:
 	}
 	explicit LuaDescriptions(lua_State* L);
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -186,12 +186,12 @@ public:
 	explicit LuaWorld(lua_State*) {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State*) override {
 	}
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 };
 
 // TODO(GunChleoc): This class is here for saveloading compatibility only. We'll get a SIGABRT from
@@ -206,12 +206,12 @@ public:
 	explicit LuaTribes(lua_State*) {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State*) override {
 	}
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 };
 
 void luaopen_wlroot(lua_State*, bool in_editor);

--- a/src/scripting/lua_root.h
+++ b/src/scripting/lua_root.h
@@ -47,8 +47,10 @@ public:
 	}
 	explicit LuaGame(lua_State* L);
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -89,8 +91,10 @@ public:
 	~LuaEditor() override {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -116,8 +120,10 @@ public:
 	}
 	explicit LuaDescriptions(lua_State* L);
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override;
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -179,10 +185,13 @@ public:
 	LuaWorld() = default;
 	explicit LuaWorld(lua_State*) {
 	}
+
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State*) override {
 	}
+CLANG_DIAG_ON("-Wreserved-identifier")
 };
 
 // TODO(GunChleoc): This class is here for saveloading compatibility only. We'll get a SIGABRT from
@@ -196,10 +205,13 @@ public:
 	LuaTribes() = default;
 	explicit LuaTribes(lua_State*) {
 	}
+
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State*) override {
 	}
+CLANG_DIAG_ON("-Wreserved-identifier")
 };
 
 void luaopen_wlroot(lua_State*, bool in_editor);

--- a/src/scripting/lua_ui.h
+++ b/src/scripting/lua_ui.h
@@ -57,7 +57,7 @@ public:
 	~LuaPanel() override {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override {
 		report_error(L, "Trying to persist a User Interface Panel which is not supported!");
 	}
@@ -65,7 +65,7 @@ CLANG_DIAG_OFF("-Wreserved-identifier")
 		report_error(L, "Trying to unpersist a User Interface Panel which is "
 		                "not supported!");
 	}
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -239,11 +239,11 @@ public:
 	~LuaMapView() override {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State* L) override;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties

--- a/src/scripting/lua_ui.h
+++ b/src/scripting/lua_ui.h
@@ -57,6 +57,7 @@ public:
 	~LuaPanel() override {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* L) override {
 		report_error(L, "Trying to persist a User Interface Panel which is not supported!");
 	}
@@ -64,6 +65,7 @@ public:
 		report_error(L, "Trying to unpersist a User Interface Panel which is "
 		                "not supported!");
 	}
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties
@@ -237,9 +239,11 @@ public:
 	~LuaMapView() override {
 	}
 
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State* L) override;
+CLANG_DIAG_ON("-Wreserved-identifier")
 
 	/*
 	 * Properties

--- a/src/scripting/lua_ui.h
+++ b/src/scripting/lua_ui.h
@@ -57,7 +57,7 @@ public:
 	~LuaPanel() override {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* L) override {
 		report_error(L, "Trying to persist a User Interface Panel which is not supported!");
 	}
@@ -65,7 +65,7 @@ public:
 		report_error(L, "Trying to unpersist a User Interface Panel which is "
 		                "not supported!");
 	}
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties
@@ -239,11 +239,11 @@ public:
 	~LuaMapView() override {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State*) override {
 	}
 	void __unpersist(lua_State* L) override;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	/*
 	 * Properties

--- a/src/scripting/luna.h
+++ b/src/scripting/luna.h
@@ -64,6 +64,7 @@
 
 #include <cstring>
 
+#include "base/macros.h"
 #include "scripting/lua.h"
 #include "scripting/luna_impl.h"
 
@@ -74,8 +75,12 @@ class LunaClass {
 public:
 	virtual ~LunaClass() {
 	}
+
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	virtual void __persist(lua_State*) = 0;
 	virtual void __unpersist(lua_State*) = 0;
+CLANG_DIAG_ON("-Wreserved-identifier")
+
 	virtual const char* get_modulename() = 0;
 };
 

--- a/src/scripting/luna.h
+++ b/src/scripting/luna.h
@@ -76,10 +76,10 @@ public:
 	virtual ~LunaClass() {
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	virtual void __persist(lua_State*) = 0;
 	virtual void __unpersist(lua_State*) = 0;
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 
 	virtual const char* get_modulename() = 0;
 };

--- a/src/scripting/luna.h
+++ b/src/scripting/luna.h
@@ -76,10 +76,10 @@ public:
 	virtual ~LunaClass() {
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	virtual void __persist(lua_State*) = 0;
 	virtual void __unpersist(lua_State*) = 0;
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 
 	virtual const char* get_modulename() = 0;
 };

--- a/src/scripting/test/test_luna.cc
+++ b/src/scripting/test/test_luna.cc
@@ -78,12 +78,12 @@ public:
 		return 0;
 	}
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 };
 
 const char LuaClass::className[] = "Class";
@@ -107,12 +107,12 @@ public:
 	}
 	virtual int subtest(lua_State* L);
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 };
 const char LuaSubClass::className[] = "SubClass";
 const MethodType<LuaSubClass> LuaSubClass::Methods[] = {
@@ -138,12 +138,12 @@ public:
 	}
 	virtual int virtualtest(lua_State* L);
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 };
 const char LuaVirtualClass::className[] = "VirtualClass";
 const MethodType<LuaVirtualClass> LuaVirtualClass::Methods[] = {
@@ -182,12 +182,12 @@ public:
 	}
 	virtual int virtualtest(lua_State* L);
 
-	CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_OFF
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-	CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_RESERVED_IDENTIFIER_ON
 };
 const char LuaMultiClass::className[] = "MultiClass";
 const MethodType<LuaMultiClass> LuaMultiClass::Methods[] = {

--- a/src/scripting/test/test_luna.cc
+++ b/src/scripting/test/test_luna.cc
@@ -77,10 +77,13 @@ public:
 		prop = lua_tointeger(L, -1);
 		return 0;
 	}
+
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
+CLANG_DIAG_ON("-Wreserved-identifier")
 };
 
 const char LuaClass::className[] = "Class";
@@ -103,10 +106,13 @@ public:
 	explicit LuaSubClass(lua_State* L) : LuaClass(L), y(1240) {
 	}
 	virtual int subtest(lua_State* L);
+
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
+CLANG_DIAG_ON("-Wreserved-identifier")
 };
 const char LuaSubClass::className[] = "SubClass";
 const MethodType<LuaSubClass> LuaSubClass::Methods[] = {
@@ -131,10 +137,13 @@ public:
 	explicit LuaVirtualClass(lua_State* L) : LuaClass(L), z(12400) {
 	}
 	virtual int virtualtest(lua_State* L);
+
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
+CLANG_DIAG_ON("-Wreserved-identifier")
 };
 const char LuaVirtualClass::className[] = "VirtualClass";
 const MethodType<LuaVirtualClass> LuaVirtualClass::Methods[] = {
@@ -172,10 +181,13 @@ public:
 	explicit LuaMultiClass(lua_State* L) : LuaClass(L), z(12400) {
 	}
 	virtual int virtualtest(lua_State* L);
+
+CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
+CLANG_DIAG_ON("-Wreserved-identifier")
 };
 const char LuaMultiClass::className[] = "MultiClass";
 const MethodType<LuaMultiClass> LuaMultiClass::Methods[] = {

--- a/src/scripting/test/test_luna.cc
+++ b/src/scripting/test/test_luna.cc
@@ -78,12 +78,12 @@ public:
 		return 0;
 	}
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 };
 
 const char LuaClass::className[] = "Class";
@@ -107,12 +107,12 @@ public:
 	}
 	virtual int subtest(lua_State* L);
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 };
 const char LuaSubClass::className[] = "SubClass";
 const MethodType<LuaSubClass> LuaSubClass::Methods[] = {
@@ -138,12 +138,12 @@ public:
 	}
 	virtual int virtualtest(lua_State* L);
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 };
 const char LuaVirtualClass::className[] = "VirtualClass";
 const MethodType<LuaVirtualClass> LuaVirtualClass::Methods[] = {
@@ -182,12 +182,12 @@ public:
 	}
 	virtual int virtualtest(lua_State* L);
 
-CLANG_DIAG_OFF("-Wreserved-identifier")
+	CLANG_DIAG_OFF("-Wreserved-identifier")
 	void __persist(lua_State* /* L */) override {
 	}
 	void __unpersist(lua_State* /* L */) override {
 	}
-CLANG_DIAG_ON("-Wreserved-identifier")
+	CLANG_DIAG_ON("-Wreserved-identifier")
 };
 const char LuaMultiClass::className[] = "MultiClass";
 const MethodType<LuaMultiClass> LuaMultiClass::Methods[] = {

--- a/src/ui_fsmenu/keyboard_options.cc
+++ b/src/ui_fsmenu/keyboard_options.cc
@@ -320,8 +320,7 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 	create_tab(_("Game"), KeyboardShortcut::kInGame_Begin, KeyboardShortcut::kInGame_End);
 
 	const size_t fastplace_tab_index = tabs_.tabs().size();
-	create_tab(
-	   _("Fastplace"), KeyboardShortcut::kFastplace_Begin, KeyboardShortcut::kFastplace_End);
+	create_tab(_("Fastplace"), KeyboardShortcut::kFastplace_Begin, KeyboardShortcut::kFastplace_End);
 
 	tabs_.add("options_scroll", _("Mouse Scrolling"), &mousewheel_options_, "");
 

--- a/src/ui_fsmenu/keyboard_options.cc
+++ b/src/ui_fsmenu/keyboard_options.cc
@@ -200,7 +200,7 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 
 	auto generate_title = [this](const KeyboardShortcut key) {
 		const std::string shortcut = shortcut_string_for(key, false);
-		if (key < KeyboardShortcut::kFastplace__Begin || key > KeyboardShortcut::kFastplace__End ||
+		if (key < KeyboardShortcut::kFastplace_Begin || key > KeyboardShortcut::kFastplace_End ||
 		    game_.get() == nullptr) {
 			return (boost::format(
 			           /** TRANSLATORS: This is a button label for a keyboard shortcut in the form
@@ -314,14 +314,14 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 		tabs_.add(title, title, b, "");
 		boxes_.push_back(b);
 	};
-	create_tab(_("General"), KeyboardShortcut::kCommon__Begin, KeyboardShortcut::kCommon__End);
-	create_tab(_("Main Menu"), KeyboardShortcut::kMainMenu__Begin, KeyboardShortcut::kMainMenu__End);
-	create_tab(_("Editor"), KeyboardShortcut::kEditor__Begin, KeyboardShortcut::kEditor__End);
-	create_tab(_("Game"), KeyboardShortcut::kInGame__Begin, KeyboardShortcut::kInGame__End);
+	create_tab(_("General"), KeyboardShortcut::kCommon_Begin, KeyboardShortcut::kCommon_End);
+	create_tab(_("Main Menu"), KeyboardShortcut::kMainMenu_Begin, KeyboardShortcut::kMainMenu_End);
+	create_tab(_("Editor"), KeyboardShortcut::kEditor_Begin, KeyboardShortcut::kEditor_End);
+	create_tab(_("Game"), KeyboardShortcut::kInGame_Begin, KeyboardShortcut::kInGame_End);
 
 	const size_t fastplace_tab_index = tabs_.tabs().size();
 	create_tab(
-	   _("Fastplace"), KeyboardShortcut::kFastplace__Begin, KeyboardShortcut::kFastplace__End);
+	   _("Fastplace"), KeyboardShortcut::kFastplace_Begin, KeyboardShortcut::kFastplace_End);
 
 	tabs_.add("options_scroll", _("Mouse Scrolling"), &mousewheel_options_, "");
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -394,7 +394,9 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 	cleanup_temp_files();
 	cleanup_temp_backups();
 
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+#ifndef SDL_BYTEORDER
+	log_info("Byte order: unknown, assuming little-endian\n");
+#elif SDL_BYTEORDER == SDL_LIL_ENDIAN
 	log_info("Byte order: little-endian\n");
 #else
 	log_info("Byte order: big-endian\n");

--- a/src/wlapplication_mousewheel_options.cc
+++ b/src/wlapplication_mousewheel_options.cc
@@ -276,15 +276,15 @@ Vector2i get_mousewheel_change_2D(MousewheelHandlerConfigID handler_id,
 }
 
 void update_mousewheel_settings() {
-	for (MousewheelHandlerConfigID i = MousewheelHandlerConfigID::k__Begin;
-	     i <= MousewheelHandlerConfigID::k__End;
+	for (MousewheelHandlerConfigID i = MousewheelHandlerConfigID::k_Begin;
+	     i <= MousewheelHandlerConfigID::k_End;
 	     i = static_cast<MousewheelHandlerConfigID>(static_cast<uint16_t>(i) + 1)) {
 		mousewheel_handlers.at(i).update_settings();
 	}
 }
 
 void reset_mousewheel_settings() {
-	for (MousewheelOptionID i = MousewheelOptionID::k__Begin; i <= MousewheelOptionID::k__End;
+	for (MousewheelOptionID i = MousewheelOptionID::k_Begin; i <= MousewheelOptionID::k_End;
 	     i = static_cast<MousewheelOptionID>(static_cast<uint16_t>(i) + 1)) {
 		mousewheel_options.at(i).reset();
 	}

--- a/src/wlapplication_mousewheel_options.h
+++ b/src/wlapplication_mousewheel_options.h
@@ -30,9 +30,9 @@
 
 // Config file options
 enum class MousewheelOptionID : uint16_t {
-	k__Begin = 0,
+	k_Begin = 0,
 
-	kUIChangeValueInvertX = k__Begin,
+	kUIChangeValueInvertX = k_Begin,
 	kUIChangeValueInvertY,
 	kUITabInvertX,
 	kUITabInvertY,
@@ -50,7 +50,7 @@ enum class MousewheelOptionID : uint16_t {
 	kEditorToolsizeX,
 	kEditorToolsizeY,
 
-	k__End = kEditorToolsizeY,
+	k_End = kEditorToolsizeY,
 
 	kAlwaysOn,
 	kDisabled,
@@ -65,9 +65,9 @@ uint16_t get_mousewheel_keymod(MousewheelOptionID);
 
 // Map config options to handlers
 enum class MousewheelHandlerConfigID : uint16_t {
-	k__Begin = 0,
+	k_Begin = 0,
 
-	kChangeValue = k__Begin,
+	kChangeValue = k_Begin,
 	kTabBar,
 	kZoom,
 	kMapScroll,
@@ -77,7 +77,7 @@ enum class MousewheelHandlerConfigID : uint16_t {
 	                     // Horizontal will have to be configurable, because we can't determine
 	                     // whether the hardware has 2D scrolling capability.
 
-	k__End = kScrollbarVertical
+	k_End = kScrollbarVertical
 };
 
 // Read settings and apply them to handlers

--- a/src/wlapplication_options.cc
+++ b/src/wlapplication_options.cc
@@ -821,8 +821,8 @@ bool matches_shortcut(const KeyboardShortcut id, const SDL_Keycode code, const i
 
 std::set<std::string> matching_fastplace_shortcut(const SDL_Keysym key) {
 	std::set<std::string> result;
-	for (int i = static_cast<int>(KeyboardShortcut::kFastplace__Begin);
-	     i < static_cast<int>(KeyboardShortcut::kFastplace__End); ++i) {
+	for (int i = static_cast<int>(KeyboardShortcut::kFastplace_Begin);
+	     i < static_cast<int>(KeyboardShortcut::kFastplace_End); ++i) {
 		const KeyboardShortcut id = static_cast<KeyboardShortcut>(i);
 		const std::string& str = shortcuts_.at(id).fastplace_name;
 		if (!str.empty() && matches_shortcut(id, key)) {
@@ -969,15 +969,15 @@ std::string shortcut_string_for(const SDL_Keysym sym, const bool rt_escape) {
 }
 
 static void init_fastplace_shortcuts(const bool force_defaults) {
-	for (KeyboardShortcut k = KeyboardShortcut::kFastplace__Begin;
-	     k <= KeyboardShortcut::kFastplace__End;
+	for (KeyboardShortcut k = KeyboardShortcut::kFastplace_Begin;
+	     k <= KeyboardShortcut::kFastplace_End;
 	     k = static_cast<KeyboardShortcut>(static_cast<uint16_t>(k) + 1)) {
 		if (force_defaults) {
 			shortcuts_.erase(k);
 		}
 		if (shortcuts_.count(k) == 0) {
 			const int off =
-			   static_cast<int>(k) - static_cast<int>(KeyboardShortcut::kFastplace__Begin) + 1;
+			   static_cast<int>(k) - static_cast<int>(KeyboardShortcut::kFastplace_Begin) + 1;
 			shortcuts_.emplace(
 			   k, KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame}, keysym(SDLK_UNKNOWN),
 			                           (boost::format("fastplace_%i") % off).str(), [off]() {
@@ -989,7 +989,7 @@ static void init_fastplace_shortcuts(const bool force_defaults) {
 
 void init_shortcuts(const bool force_defaults) {
 	init_fastplace_shortcuts(force_defaults);
-	for (KeyboardShortcut k = KeyboardShortcut::k__Begin; k <= KeyboardShortcut::k__End;
+	for (KeyboardShortcut k = KeyboardShortcut::k_Begin; k <= KeyboardShortcut::k_End;
 	     k = static_cast<KeyboardShortcut>(static_cast<uint16_t>(k) + 1)) {
 		shortcuts_.at(k).current_shortcut = get_default_shortcut(k);
 		if (force_defaults) {

--- a/src/wlapplication_options.h
+++ b/src/wlapplication_options.h
@@ -82,10 +82,10 @@ void set_config_string(const std::string& section,
 // Keyboard shortcuts. The order in which they are defined here
 // defines the order in which they appear in the options menu.
 enum class KeyboardShortcut : uint16_t {
-	k__Begin = 0,
+	k_Begin = 0,
 
-	kMainMenu__Begin = k__Begin,
-	kMainMenuSP = kMainMenu__Begin,
+	kMainMenu_Begin = k_Begin,
+	kMainMenuSP = kMainMenu_Begin,
 	kMainMenuNew,
 	kMainMenuRandomMatch,
 	kMainMenuCampaign,
@@ -106,10 +106,10 @@ enum class KeyboardShortcut : uint16_t {
 	kMainMenuAddons,
 	kMainMenuAbout,
 	kMainMenuQuit,
-	kMainMenu__End = kMainMenuQuit,
+	kMainMenu_End = kMainMenuQuit,
 
-	kCommon__Begin = kMainMenu__End + 1,
-	kCommonFullscreen = kCommon__Begin,
+	kCommon_Begin = kMainMenu_End + 1,
+	kCommonFullscreen = kCommon_Begin,
 	kCommonScreenshot,
 	kCommonTextCut,
 	kCommonTextCopy,
@@ -125,10 +125,10 @@ enum class KeyboardShortcut : uint16_t {
 	kCommonZoomReset,
 	kCommonQuicknavPrev,
 	kCommonQuicknavNext,
-	kCommon__End = kCommonQuicknavNext,
+	kCommon_End = kCommonQuicknavNext,
 
-	kEditor__Begin = kCommon__End + 1,
-	kEditorMenu = kEditor__Begin,
+	kEditor_Begin = kCommon_End + 1,
+	kEditorMenu = kEditor_Begin,
 	kEditorSave,
 	kEditorLoad,
 	kEditorUndo,
@@ -150,10 +150,10 @@ enum class KeyboardShortcut : uint16_t {
 	kEditorToolsize8,
 	kEditorToolsize9,
 	kEditorToolsize10,
-	kEditor__End = kEditorToolsize10,
+	kEditor_End = kEditorToolsize10,
 
-	kInGame__Begin = kEditor__End + 1,
-	kInGameSave = kInGame__Begin,
+	kInGame_Begin = kEditor_End + 1,
+	kInGameSave = kInGame_Begin,
 	kInGameLoad,
 	kInGameChat,
 	kInGameMessages,
@@ -213,17 +213,17 @@ enum class KeyboardShortcut : uint16_t {
 	kInGameQuicknavGoto8,
 	kInGameQuicknavSet9,
 	kInGameQuicknavGoto9,
-	kInGame__End = kInGameQuicknavGoto9,
+	kInGame_End = kInGameQuicknavGoto9,
 
-	kFastplace__Begin = kInGame__End + 1,
-	kFastplace__End = kFastplace__Begin + 127,  // Arbitrary limit of 128 fastplace shortcuts.
+	kFastplace_Begin = kInGame_End + 1,
+	kFastplace_End = kFastplace_Begin + 127,  // Arbitrary limit of 128 fastplace shortcuts.
 
-	k__End = kFastplace__End
+	k_End = kFastplace_End
 };
 
 /** Check whether a given shortcut is reserved for a fastplace shortcut slot. */
 inline bool is_fastplace(const KeyboardShortcut id) {
-	return id >= KeyboardShortcut::kFastplace__Begin && id <= KeyboardShortcut::kFastplace__End;
+	return id >= KeyboardShortcut::kFastplace_Begin && id <= KeyboardShortcut::kFastplace_End;
 }
 
 /**

--- a/utils/check_clang_tidy_results.py
+++ b/utils/check_clang_tidy_results.py
@@ -35,8 +35,6 @@ SUPPRESSED_CHECKS = {
     '[clang-analyzer-optin.cplusplus.UninitializedObject]',
     '[clang-analyzer-optin.cplusplus.VirtualCall]',
     '[clang-diagnostic-documentation-unknown-command]',
-    # Needed to suppress compiler warnings not known to older clang versions
-    '[clang-diagnostic-unknown-warning-option]',
     '[cppcoreguidelines-avoid-c-arrays]',
     '[cppcoreguidelines-avoid-goto]',
     '[cppcoreguidelines-avoid-magic-numbers]',

--- a/utils/check_clang_tidy_results.py
+++ b/utils/check_clang_tidy_results.py
@@ -35,6 +35,7 @@ SUPPRESSED_CHECKS = {
     '[clang-analyzer-optin.cplusplus.UninitializedObject]',
     '[clang-analyzer-optin.cplusplus.VirtualCall]',
     '[clang-diagnostic-documentation-unknown-command]',
+    '[clang-diagnostic-unknown-warning-option]',  # Needed to suppress compiler warnings not known to older clang versions
     '[cppcoreguidelines-avoid-c-arrays]',
     '[cppcoreguidelines-avoid-goto]',
     '[cppcoreguidelines-avoid-magic-numbers]',

--- a/utils/check_clang_tidy_results.py
+++ b/utils/check_clang_tidy_results.py
@@ -35,7 +35,8 @@ SUPPRESSED_CHECKS = {
     '[clang-analyzer-optin.cplusplus.UninitializedObject]',
     '[clang-analyzer-optin.cplusplus.VirtualCall]',
     '[clang-diagnostic-documentation-unknown-command]',
-    '[clang-diagnostic-unknown-warning-option]',  # Needed to suppress compiler warnings not known to older clang versions
+    # Needed to suppress compiler warnings not known to older clang versions
+    '[clang-diagnostic-unknown-warning-option]',
     '[cppcoreguidelines-avoid-c-arrays]',
     '[cppcoreguidelines-avoid-goto]',
     '[cppcoreguidelines-avoid-magic-numbers]',


### PR DESCRIPTION
Fixes a lot of new `-Wreserved-identifier` warnings thrown by Clang 13.

The `base/i18n.cc` one is a false positive; the ones in `scripting/` are required by Eris. These warnings are therefore silenced without changes.

Everything else is fixed by renaming some variables and types without logic changes.