### PR TITLE
Enable ASan in the Testsuite

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,6 +135,10 @@ jobs:
     env:
       SDL_VIDEODRIVER: 'x11'
       DISPLAY: ':99.0'
+      # TODO: Under Xvfb, the usual X11 memory leaks show up as an unsymbolized
+      # <unknown module> making them impossible to suppress. So we disable all
+      # memory leaks checking in the testsuite for now.
+      ASAN_OPTIONS: 'detect_leaks=0'
       LSAN_OPTIONS: 'suppressions=${{ github.workspace }}/asan_3rd_party_leaks'
     steps:
     - name: Installing dependencies
@@ -167,8 +171,8 @@ jobs:
         sleep 1m
         # Ignore transient SDL errors (exit code 2)
         mkdir temp_web
-        build/src/website/wl_map_object_info temp_web || true # [ $? -eq 2 ]  NOCOM
-        build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf || true # [ $? -eq 2 ]  NOCOM
+        build/src/website/wl_map_object_info temp_web || [ $? -eq 2 ]
+        build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf || [ $? -eq 2 ]
     - name: Testsuite
       run: ./regression_test.py -b build/src/widelands
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,6 +141,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install git cmake ${{ matrix.compiler }} gettext libboost-dev libboost-system-dev libboost-test-dev libglew-dev libpng-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev python3 zlib1g-dev mesa-utils linux-generic xserver-xorg-core xserver-xorg xserver-xorg-video-all xserver-xorg-input-all libwayland-egl1-mesa -y
+        # Set the ASan symlink to an arbitrary symbolizer
+        for s in /usr/bin/llvm-symbolizer-*
+        do
+          sudo ln -s "$s" /usr/bin/llvm-symbolizer
+          break
+        done
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,6 +132,10 @@ jobs:
             os: ubuntu-18.04
             config: Release
     runs-on: ${{ matrix.os }}
+    env:
+      LSAN_OPTIONS: 'suppressions=asan_3rd_party_leaks'
+      SDL_VIDEODRIVER: 'x11'
+      DISPLAY: ':99.0'
     steps:
     - name: Installing dependencies
       run: |
@@ -154,24 +158,19 @@ jobs:
         fi
         mkdir build
         pushd build
-        cmake .. -DCMAKE_BUILD_TYPE:STRING="${{ matrix.config }}" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_BUILD_WEBSITE_TOOLS="ON" -DOPTION_ASAN="OFF" -DOPTION_BUILD_CODECHECK="OFF"
+        cmake .. -DCMAKE_BUILD_TYPE:STRING="${{ matrix.config }}" -DOPTION_BUILD_TRANSLATIONS="ON" -DOPTION_BUILD_WEBSITE_TOOLS="ON" -DOPTION_ASAN="ON" -DOPTION_BUILD_CODECHECK="OFF"
         make -k -j$(nproc)
         cd ..
     - name: Website Binaries
       run: |
         /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 800x600x24 -ac +extension GLX
         sleep 1m
-        export SDL_VIDEODRIVER=x11
-        export DISPLAY=:99.0
         # Ignore transient SDL errors (exit code 2)
         mkdir temp_web
         build/src/website/wl_map_object_info temp_web || [ $? -eq 2 ]
         build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf || [ $? -eq 2 ]
     - name: Testsuite
-      run: |
-        export SDL_VIDEODRIVER=x11
-        export DISPLAY=:99.0
-        ./regression_test.py -b build/src/widelands
+      run: ./regression_test.py -b build/src/widelands
 
 
   windows:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,9 +133,9 @@ jobs:
             config: Release
     runs-on: ${{ matrix.os }}
     env:
-      LSAN_OPTIONS: 'suppressions=asan_3rd_party_leaks'
       SDL_VIDEODRIVER: 'x11'
       DISPLAY: ':99.0'
+      LSAN_OPTIONS: 'suppressions=${{ github.workspace }}/asan_3rd_party_leaks'
     steps:
     - name: Installing dependencies
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,12 +141,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install git cmake ${{ matrix.compiler }} gettext libboost-dev libboost-system-dev libboost-test-dev libglew-dev libpng-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev python3 zlib1g-dev mesa-utils linux-generic xserver-xorg-core xserver-xorg xserver-xorg-video-all xserver-xorg-input-all libwayland-egl1-mesa -y
-        # Set the ASan symlink to an arbitrary symbolizer
-        for s in /usr/bin/llvm-symbolizer-*
-        do
-          sudo ln -s "$s" /usr/bin/llvm-symbolizer
-          break
-        done
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -173,8 +167,8 @@ jobs:
         sleep 1m
         # Ignore transient SDL errors (exit code 2)
         mkdir temp_web
-        build/src/website/wl_map_object_info temp_web || [ $? -eq 2 ]
-        build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf || [ $? -eq 2 ]
+        build/src/website/wl_map_object_info temp_web || true # [ $? -eq 2 ]  NOCOM
+        build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf || true # [ $? -eq 2 ]  NOCOM
     - name: Testsuite
       run: ./regression_test.py -b build/src/widelands
 

--- a/asan_3rd_party_leaks
+++ b/asan_3rd_party_leaks
@@ -8,3 +8,4 @@ leak:src/scripting/persistence.cc
 
 # Various graphics drivers
 leak:radeonsi_dri
+leak:libdbus

--- a/asan_3rd_party_leaks
+++ b/asan_3rd_party_leaks
@@ -7,5 +7,6 @@ leak:libSDL2
 leak:src/scripting/persistence.cc
 
 # Various graphics drivers and X11 stuff.
-leak:radeonsi_dri
 leak:libdbus
+leak:libnvidia-glcore
+leak:radeonsi_dri

--- a/asan_3rd_party_leaks
+++ b/asan_3rd_party_leaks
@@ -1,0 +1,10 @@
+# List of known memory leaks in 3rd party libraries which we do not want ASan to report.
+
+# SDL2
+leak:libSDL2
+
+# Eris
+leak:src/scripting/persistence.cc
+
+# Various graphics drivers
+leak:radeonsi_dri

--- a/asan_3rd_party_leaks
+++ b/asan_3rd_party_leaks
@@ -6,6 +6,6 @@ leak:libSDL2
 # Eris
 leak:src/scripting/persistence.cc
 
-# Various graphics drivers
+# Various graphics drivers and X11 stuff.
 leak:radeonsi_dri
 leak:libdbus


### PR DESCRIPTION
Adds a suppression file with a list of known 3rd party leaks. This can be used by calling
```
LSAN_OPTIONS=suppressions=asan_3rd_party_leaks ./widelands
```
It is not possible to link the suppression list into the executable, ASan only support this environment variable.

If you have 3rd party leaks not caught by this file, please post them so they can be added to the list.

Note that Xvfb breaks the symbolizer, so leaks from there can apparently not be suppressed. For the testsuite we therefore need to suppress checking *all* memory leaks (other ASan features are enabled though).