### PR TITLE
Fix worker reordering stack overflow

### DIFF
--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -627,7 +627,13 @@ std::pair<int32_t, int32_t> ProductionSite::find_worker(OPtr<Worker> w) {
  */
 void ProductionSite::try_replace_worker(const Game* game,
                                         DescriptionIndex worker_index,
-                                        WorkingPosition* wp) {
+                                        WorkingPosition* wp,
+                                        size_t iteration) {
+	if (iteration >= working_positions_.size()) {
+		// cancel recursion, something went wrong
+		log_warn("Aborting try_replace_worker() after %" PRIuS " calls.", iteration);
+		return;
+	}
 	// Search replacement worker in the same building
 	for (auto wp_repl = working_positions_.begin(); wp_repl != working_positions_.end(); ++wp_repl) {
 		if (!wp_repl->worker.is_set()) {
@@ -651,7 +657,7 @@ void ProductionSite::try_replace_worker(const Game* game,
 			molog(owner().egbase().get_gametime(), "%s promoted\n", w_repl->descr().name().c_str());
 			// Request the now missing worker instead and loop again
 			*wp_repl = WorkingPosition(&request_worker(worker_index_repl), nullptr);
-			try_replace_worker(game, worker_index_repl, wp_repl.base());
+			try_replace_worker(game, worker_index_repl, wp_repl.base(), iteration + 1);
 			return;
 		}
 	}
@@ -682,7 +688,7 @@ void ProductionSite::remove_worker(Worker& w) {
 	// If the main worker was evicted, perhaps another worker is
 	// still there to perform basic tasks
 	if (upcast(Game, game, &get_owner()->egbase())) {
-		try_replace_worker(game, worker_index, wp);
+		try_replace_worker(game, worker_index, wp, 0);
 		try_start_working(*game);
 	}
 }

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -378,7 +378,7 @@ public:
 	void act(Game&, uint32_t data) override;
 
 	std::pair<int32_t, int32_t> find_worker(OPtr<Worker>);
-	void try_replace_worker(const Game*, DescriptionIndex, WorkingPosition*, size_t);
+	void try_replace_worker(const Game*, DescriptionIndex, WorkingPosition*);
 	void remove_worker(Worker&) override;
 	bool warp_worker(EditorGameBase&, const WorkerDescr& wd, int32_t slot = -1);
 

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -378,7 +378,7 @@ public:
 	void act(Game&, uint32_t data) override;
 
 	std::pair<int32_t, int32_t> find_worker(OPtr<Worker>);
-	void try_replace_worker(const Game*, DescriptionIndex, WorkingPosition*);
+	void try_replace_worker(const Game*, DescriptionIndex, WorkingPosition*, size_t);
 	void remove_worker(Worker&) override;
 	bool warp_worker(EditorGameBase&, const WorkerDescr& wd, int32_t slot = -1);
 


### PR DESCRIPTION
Hotfix for https://github.com/widelands/widelands/issues/4995#issuecomment-972008401

The problem is, that the reordering does not terminate for the european basic farm, where both slots need the same worker.
This quick fix solves the issue, but I will look, whether there is a better solution.