### PR TITLE
Replace `boost::signals2`

### DIFF
--- a/cmake/codecheck/rules/deprecate_boost.py
+++ b/cmake/codecheck/rules/deprecate_boost.py
@@ -6,7 +6,6 @@ strip_comments_and_strings = True
 whitelist = [
     'boost::format',
     'boost::io::format_error',
-    'boost::signals2',
     'boost::uuids',
     'boost::asio',
     'boost::system::error_code',
@@ -14,7 +13,6 @@ whitelist = [
 ]
 whitelist_headers = [
     'boost/format',
-    'boost/signals2',
     'boost/uuid',
     'boost/asio',
     'boost/version',

--- a/src/logic/map_objects/map_object.h
+++ b/src/logic/map_objects/map_object.h
@@ -21,7 +21,6 @@
 #define WL_LOGIC_MAP_OBJECTS_MAP_OBJECT_H
 
 #include <atomic>
-#include <boost/signals2/signal.hpp>
 
 #include "base/macros.h"
 #include "graphic/animation/animation.h"
@@ -33,6 +32,7 @@
 #include "logic/map_objects/map_object_type.h"
 #include "logic/map_objects/tribes/training_attribute.h"
 #include "logic/widelands.h"
+#include "notifications/signal.h"
 #include "scripting/lua_table.h"
 
 class RenderTarget;
@@ -213,7 +213,7 @@ public:
 	 *
 	 * param serial : the object serial (cannot use param comment as this is a callback)
 	 */
-	boost::signals2::signal<void(uint32_t serial)> removed;
+	Notifications::Signal<uint32_t /* serial */> removed;
 
 	/**
 	 * Attributes are fixed boolean properties of an object.

--- a/src/logic/map_objects/tribes/building.h
+++ b/src/logic/map_objects/tribes/building.h
@@ -276,7 +276,7 @@ public:
 	 *
 	 * param serial : the building serial
 	 */
-	boost::signals2::signal<void(uint32_t serial)> muted;
+	Notifications::Signal<uint32_t /* serial */> muted;
 
 	PositionList get_positions(const EditorGameBase&) const override;
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -68,6 +68,7 @@ wl_library(network
     logic_game_settings
     logic_tribe_basic_info
     map_io_map_loader
+    notifications
     scripting_lua_interface
     scripting_lua_table
     ui_basic

--- a/src/network/participantlist.cc
+++ b/src/network/participantlist.cc
@@ -19,7 +19,8 @@ ParticipantList::ParticipantList(const GameSettings* settings,
 	update_participant_counts();
 
 	// When the update signal is called, re-calculate the participant counts
-	participants_updated.connect([this]() { update_participant_counts(); }, true);
+	participants_updated.connect(
+	   [this]() { update_participant_counts(); }, Notifications::SubscriberPosition::kFront);
 }
 
 const ParticipantList::ParticipantCounts& ParticipantList::get_participant_counts() const {

--- a/src/network/participantlist.cc
+++ b/src/network/participantlist.cc
@@ -19,8 +19,7 @@ ParticipantList::ParticipantList(const GameSettings* settings,
 	update_participant_counts();
 
 	// When the update signal is called, re-calculate the participant counts
-	participants_updated.connect(
-	   [this]() { update_participant_counts(); }, boost::signals2::connect_position::at_front);
+	participants_updated.connect([this]() { update_participant_counts(); }, true);
 }
 
 const ParticipantList::ParticipantCounts& ParticipantList::get_participant_counts() const {

--- a/src/network/participantlist.h
+++ b/src/network/participantlist.h
@@ -22,9 +22,8 @@
 
 #include <string>
 
-#include <boost/signals2/signal.hpp>
-
 #include "logic/widelands.h"
+#include "notifications/signal.h"
 
 // Avoid as many includes as possible
 struct GameSettings;
@@ -183,13 +182,13 @@ public:
 	uint8_t get_participant_rtt(int16_t participant) const;
 
 	/// Called when the underlying data was updated and should be re-fetched.
-	boost::signals2::signal<void()> participants_updated;
+	Notifications::Signal<> participants_updated;
 
 	/**
 	 * Called when the RTT for a participant changed.
 	 * Passed parameters are the participant index and the new RTT.
 	 */
-	boost::signals2::signal<void(int16_t, uint8_t)> participant_updated_rtt;
+	Notifications::Signal<int16_t, uint8_t> participant_updated_rtt;
 
 private:
 	/**

--- a/src/notifications/CMakeLists.txt
+++ b/src/notifications/CMakeLists.txt
@@ -6,7 +6,9 @@ wl_library(notifications
     notifications.h
     notifications_impl.h
     note_ids.h
+    signal.h
   DEPENDS
+    base_exceptions
     base_log
     base_macros
 )

--- a/src/notifications/signal.h
+++ b/src/notifications/signal.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 by the Widelands Development Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+
+#ifndef WL_NOTIFICATIONS_SIGNAL_H
+#define WL_NOTIFICATIONS_SIGNAL_H
+
+#include <cassert>
+#include <functional>
+#include <list>
+#include <memory>
+#include <set>
+
+#include "base/macros.h"
+#include "base/wexception.h"
+
+namespace Notifications {
+
+/** Class that allows attaching callback functions to an object. */
+template <typename... Args> class Signal {
+public:
+	/** Wrapper around a callback function. */
+	struct SignalSubscriber {
+		explicit SignalSubscriber(const Signal& p, const std::function<void(Args...)>& c)
+		: parent_(p), callback_(c) {
+		}
+		~SignalSubscriber() {
+			parent_.unsubscribe(this);
+		}
+
+		const Signal& parent_;
+		const std::function<void(Args...)> callback_;
+
+		DISALLOW_COPY_AND_ASSIGN(SignalSubscriber);
+	};
+
+	/** Invoke all the signal's subscribers' callback functions. */
+	void operator()(Args... args) const {
+		for (const auto& s : all_subscribers_) {
+			s->callback_(args...);
+		}
+	}
+
+	/** Create a subscriber with a user-defined lifetime. */
+	std::unique_ptr<SignalSubscriber>
+	subscribe(const std::function<void(Args...)>& callback, bool at_front = false) const {
+		SignalSubscriber* s = new SignalSubscriber(*this, callback);
+		if (at_front) {
+			all_subscribers_.push_front(s);
+		} else {
+			all_subscribers_.push_back(s);
+		}
+		return std::unique_ptr<SignalSubscriber>(s);
+	}
+
+	/** Create a subscriber with the same lifetime as the signal. */
+	inline void connect(const std::function<void(Args...)>& callback, bool at_front = false) const {
+		owned_subscribers_.insert(subscribe(callback, at_front));
+	}
+
+	/** Create a subscriber that echoes the signal's invokations to another signal. */
+	inline std::unique_ptr<SignalSubscriber>
+	subscribe(const Signal& s, bool at_front = false) const {
+		return subscribe([&s](Args... args) { s(args...); }, at_front);
+	}
+	inline void connect(const Signal& s, bool at_front = false) const {
+		connect([&s](Args... args) { s(args...); }, at_front);
+	}
+
+	/** Called by a subscriber at the end of its lifetime. */
+	void unsubscribe(const SignalSubscriber* s) const {
+		for (auto it = all_subscribers_.begin(); it != all_subscribers_.end(); ++it) {
+			if (*it == s) {
+				all_subscribers_.erase(it);
+				return;
+			}
+		}
+		NEVER_HERE();
+	}
+
+	Signal() = default;
+	~Signal() {
+		owned_subscribers_.clear();
+		// Any subscribers not owned by us should have been destroyed by their owner by now
+		assert(all_subscribers_.empty());
+	}
+
+private:
+	mutable std::set<std::unique_ptr<SignalSubscriber>> owned_subscribers_;
+	mutable std::list<SignalSubscriber*> all_subscribers_;
+
+	DISALLOW_COPY_AND_ASSIGN(Signal);
+};
+}  // namespace Notifications
+
+#endif  // end of include guard: WL_NOTIFICATIONS_SIGNAL_H

--- a/src/notifications/signal.h
+++ b/src/notifications/signal.h
@@ -37,7 +37,7 @@ public:
 	/** Wrapper around a callback function. */
 	struct SignalSubscriber {
 		explicit SignalSubscriber(const Signal& p, const std::function<void(Args...)>& c)
-		: parent_(p), callback_(c) {
+		   : parent_(p), callback_(c) {
 		}
 		~SignalSubscriber() {
 			parent_.unsubscribe(this);
@@ -57,8 +57,8 @@ public:
 	}
 
 	/** Create a subscriber with a user-defined lifetime. */
-	std::unique_ptr<SignalSubscriber>
-	subscribe(const std::function<void(Args...)>& callback, bool at_front = false) const {
+	std::unique_ptr<SignalSubscriber> subscribe(const std::function<void(Args...)>& callback,
+	                                            bool at_front = false) const {
 		SignalSubscriber* s = new SignalSubscriber(*this, callback);
 		if (at_front) {
 			all_subscribers_.push_front(s);
@@ -74,8 +74,8 @@ public:
 	}
 
 	/** Create a subscriber that echoes the signal's invokations to another signal. */
-	inline std::unique_ptr<SignalSubscriber>
-	subscribe(const Signal& s, bool at_front = false) const {
+	inline std::unique_ptr<SignalSubscriber> subscribe(const Signal& s,
+	                                                   bool at_front = false) const {
 		return subscribe([&s](Args... args) { s(args...); }, at_front);
 	}
 	inline void connect(const Signal& s, bool at_front = false) const {

--- a/src/notifications/signal.h
+++ b/src/notifications/signal.h
@@ -43,7 +43,7 @@ public:
 	/** Wrapper around a callback function. */
 	class SignalSubscriber {
 	public:
-		explicit SignalSubscriber(const Signal& p, const std::function<void(Args...)> c)
+		SignalSubscriber(const Signal& p, const std::function<void(Args...)> c)
 		   : callback_(c), parent_(p) {
 		}
 		~SignalSubscriber() {

--- a/src/ui_basic/button.h
+++ b/src/ui_basic/button.h
@@ -150,9 +150,9 @@ public:
 	/// Convenience function. Toggles between raised and permpressed style
 	void toggle();
 
-	boost::signals2::signal<void()> sigclicked;
-	boost::signals2::signal<void()> sigmousein;
-	boost::signals2::signal<void()> sigmouseout;
+	Notifications::Signal<> sigclicked;
+	Notifications::Signal<> sigmousein;
+	Notifications::Signal<> sigmouseout;
 
 protected:
 	bool highlighted_;  //  mouse is over the button

--- a/src/ui_basic/checkbox.h
+++ b/src/ui_basic/checkbox.h
@@ -56,9 +56,9 @@ struct Statebox : public Panel {
 	         const std::string& tooltip_text = std::string(),
 	         int width = 0);
 
-	boost::signals2::signal<void()> changed;
-	boost::signals2::signal<void(bool)> changedto;
-	boost::signals2::signal<void(bool)> clickedto;  // same as changedto but only called when clicked
+	Notifications::Signal<> changed;
+	Notifications::Signal<bool> changedto;
+	Notifications::Signal<bool> clickedto;  // same as changedto but only called when clicked
 
 	void set_enabled(bool enabled);
 

--- a/src/ui_basic/dropdown.h
+++ b/src/ui_basic/dropdown.h
@@ -83,7 +83,7 @@ protected:
 
 public:
 	/// An entry was selected
-	boost::signals2::signal<void()> selected;
+	Notifications::Signal<> selected;
 
 	/// \return true if an element has been selected from the list
 	bool has_selection() const;

--- a/src/ui_basic/editbox.h
+++ b/src/ui_basic/editbox.h
@@ -44,9 +44,9 @@ struct EditBox : public Panel {
 	EditBox(Panel*, int32_t x, int32_t y, uint32_t w, UI::PanelStyle style);
 	~EditBox() override;
 
-	boost::signals2::signal<void()> changed;
-	boost::signals2::signal<void()> ok;
-	boost::signals2::signal<void()> cancel;
+	Notifications::Signal<> changed;
+	Notifications::Signal<> ok;
+	Notifications::Signal<> cancel;
 
 	const std::string& text() const;
 	void set_text(const std::string&);

--- a/src/ui_basic/icongrid.h
+++ b/src/ui_basic/icongrid.h
@@ -34,9 +34,9 @@ struct IconGrid : public Panel {
 	IconGrid(
 	   Panel* parent, PanelStyle, int32_t x, int32_t y, int32_t cellw, int32_t cellh, int32_t cols);
 
-	boost::signals2::signal<void(int32_t)> icon_clicked;
-	boost::signals2::signal<void(int32_t)> mouseout;
-	boost::signals2::signal<void(int32_t)> mousein;
+	Notifications::Signal<int32_t> icon_clicked;
+	Notifications::Signal<int32_t> mouseout;
+	Notifications::Signal<int32_t> mousein;
 
 	int32_t
 	add(const std::string& name, const Image* pic, void* data, const std::string& tooltip_text = "");

--- a/src/ui_basic/listselect.h
+++ b/src/ui_basic/listselect.h
@@ -54,8 +54,8 @@ struct BaseListselect : public Panel {
 	               ListselectLayout selection_mode = ListselectLayout::kPlain);
 	~BaseListselect() override;
 
-	boost::signals2::signal<void(uint32_t)> selected;
-	boost::signals2::signal<void(uint32_t)> double_clicked;
+	Notifications::Signal<uint32_t> selected;
+	Notifications::Signal<uint32_t> double_clicked;
 
 	void clear();
 	void sort(const uint32_t Begin = 0, uint32_t End = std::numeric_limits<uint32_t>::max());

--- a/src/ui_basic/messagebox.h
+++ b/src/ui_basic/messagebox.h
@@ -60,8 +60,8 @@ struct WLMessageBox : public Window {
 	             MBoxType,
 	             Align = UI::Align::kCenter);
 
-	boost::signals2::signal<void()> ok;
-	boost::signals2::signal<void()> cancel;
+	Notifications::Signal<> ok;
+	Notifications::Signal<> cancel;
 
 	bool handle_mousepress(uint8_t btn, int32_t mx, int32_t my) override;
 	bool handle_mouserelease(uint8_t btn, int32_t mx, int32_t my) override;

--- a/src/ui_basic/multilineeditbox.h
+++ b/src/ui_basic/multilineeditbox.h
@@ -35,7 +35,7 @@ namespace UI {
 struct MultilineEditbox : public Panel {
 	MultilineEditbox(Panel*, int32_t x, int32_t y, uint32_t w, uint32_t h, PanelStyle style);
 
-	boost::signals2::signal<void()> changed;
+	Notifications::Signal<> changed;
 
 	const std::string& get_text() const;
 	void set_text(const std::string&);

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -28,8 +28,6 @@
 #include <vector>
 
 #include <SDL_keyboard.h>
-#include <boost/signals2/signal.hpp>
-#include <boost/signals2/trackable.hpp>
 
 #include "base/macros.h"
 #include "base/multithreading.h"
@@ -37,6 +35,7 @@
 #include "base/vector.h"
 #include "base/wexception.h"
 #include "graphic/styles/panel_styles.h"
+#include "notifications/signal.h"
 #include "sound/constants.h"
 
 class FileWrite;
@@ -67,7 +66,7 @@ namespace UI {
  * its desired size changes, this automatically changes the actual size (which then invokes
  * \ref layout and \ref move_inside_parent).
  */
-class Panel : public boost::signals2::trackable {
+class Panel {
 public:
 	// Panel flags. The `Panel::flags_` attribute is a bitset of these flags.
 	enum {
@@ -103,8 +102,8 @@ public:
 	      const std::string& tooltip_text = std::string());
 	virtual ~Panel();
 
-	boost::signals2::signal<void()> clicked;
-	boost::signals2::signal<void()> position_changed;
+	Notifications::Signal<> clicked;
+	Notifications::Signal<> position_changed;
 
 	Panel* get_parent() const {
 		return parent_;

--- a/src/ui_basic/radiobutton.h
+++ b/src/ui_basic/radiobutton.h
@@ -57,9 +57,9 @@ struct Radiogroup {
 	Radiogroup();
 	~Radiogroup();
 
-	boost::signals2::signal<void()> changed;
-	boost::signals2::signal<void(int32_t)> changedto;
-	boost::signals2::signal<void()> clicked;  //  clicked without things changed
+	Notifications::Signal<> changed;
+	Notifications::Signal<int32_t> changedto;
+	Notifications::Signal<> clicked;  //  clicked without things changed
 
 	/**
 	 * Text conventions: Sentence case for the 'tooltip'

--- a/src/ui_basic/scrollbar.h
+++ b/src/ui_basic/scrollbar.h
@@ -43,7 +43,7 @@ public:
 	          UI::PanelStyle style,
 	          bool horiz = false);
 
-	boost::signals2::signal<void(int32_t)> moved;
+	Notifications::Signal<int32_t> moved;
 
 	void set_steps(int32_t steps);
 	void set_singlestepsize(uint32_t singlestepsize);

--- a/src/ui_basic/slider.h
+++ b/src/ui_basic/slider.h
@@ -111,8 +111,8 @@ private:
 	void set_highlighted(bool highlighted);
 
 public:
-	boost::signals2::signal<void()> changed;
-	boost::signals2::signal<void(int32_t)> changedto;
+	Notifications::Signal<> changed;
+	Notifications::Signal<int32_t> changedto;
 
 private:
 	int32_t min_value_;  //  cursor values
@@ -236,8 +236,8 @@ struct DiscreteSlider : public Panel {
 
 	void set_labels(const std::vector<std::string>&);
 
-	boost::signals2::signal<void()> changed;
-	boost::signals2::signal<void(int32_t)> changedto;
+	Notifications::Signal<> changed;
+	Notifications::Signal<int32_t> changedto;
 
 	Slider& get_slider() {
 		return slider;

--- a/src/ui_basic/spinbox.h
+++ b/src/ui_basic/spinbox.h
@@ -62,7 +62,7 @@ public:
 	        int32_t big_step_size = 10);
 	~SpinBox() override;
 
-	boost::signals2::signal<void()> changed;
+	Notifications::Signal<> changed;
 
 	void set_value(int32_t);
 	// For spinboxes of type kValueList. The vector needs to be sorted in ascending order,

--- a/src/ui_basic/table.h
+++ b/src/ui_basic/table.h
@@ -59,9 +59,9 @@ public:
 	      TableRows rowtype = TableRows::kSingle);
 	~Table();
 
-	boost::signals2::signal<void()> cancel;
-	boost::signals2::signal<void(uint32_t)> selected;
-	boost::signals2::signal<void(uint32_t)> double_clicked;
+	Notifications::Signal<> cancel;
+	Notifications::Signal<uint32_t> selected;
+	Notifications::Signal<uint32_t> double_clicked;
 
 	/// A column that has a title is sortable (by clicking on the title).
 	///
@@ -186,9 +186,9 @@ public:
 	 */
 	using CompareFn = std::function<bool(uint32_t, uint32_t)>;
 
-	boost::signals2::signal<void()> cancel;
-	boost::signals2::signal<void(uint32_t)> selected;
-	boost::signals2::signal<void(uint32_t)> double_clicked;
+	Notifications::Signal<> cancel;
+	Notifications::Signal<uint32_t> selected;
+	Notifications::Signal<uint32_t> double_clicked;
 
 	void add_column(uint32_t width,
 	                const std::string& title = std::string(),

--- a/src/ui_basic/tabpanel.h
+++ b/src/ui_basic/tabpanel.h
@@ -128,7 +128,7 @@ struct TabPanel : public Panel {
 	// We use the tabname as a safety precaution to prevent acidentally removing the wrong tab.
 	bool remove_last_tab(const std::string& tabname);
 
-	boost::signals2::signal<void()> sigclicked;
+	Notifications::Signal<> sigclicked;
 
 	bool handle_key(bool, SDL_Keysym) override;
 	bool handle_mousewheel(int32_t x, int32_t y, uint16_t modstate) override;

--- a/src/ui_basic/unique_window.h
+++ b/src/ui_basic/unique_window.h
@@ -41,9 +41,9 @@ struct UniqueWindow : public Window {
 		std::function<void()> open_window;
 
 		// Triggered when the window opens
-		boost::signals2::signal<void()> opened;
+		Notifications::Signal<> opened;
 		// Triggered when the window closes
-		boost::signals2::signal<void()> closed;
+		Notifications::Signal<> closed;
 
 		void create();
 		void destroy();

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -22,6 +22,8 @@
 #include <cstdlib>
 #include <iomanip>
 #include <memory>
+#include <ostream>
+#include <sstream>
 
 #include <SDL.h>
 

--- a/src/wui/constructionsitewindow.h
+++ b/src/wui/constructionsitewindow.h
@@ -49,7 +49,7 @@ public:
 	void refresh(uint32_t current, uint32_t max, bool enabled);
 	void set_current(uint32_t value);
 	void change_current(int32_t delta);
-	boost::signals2::signal<void()> changed;
+	Notifications::Signal<> changed;
 	uint32_t get_current() {
 		return current_;
 	}

--- a/src/wui/fieldaction.cc
+++ b/src/wui/fieldaction.cc
@@ -59,9 +59,9 @@ constexpr int kBuildGridCellSize = 50;
 struct BuildGrid : public UI::IconGrid {
 	BuildGrid(UI::Panel* parent, Widelands::Player* plr, int32_t x, int32_t y, int32_t cols);
 
-	boost::signals2::signal<void(Widelands::DescriptionIndex)> buildclicked;
-	boost::signals2::signal<void(Widelands::DescriptionIndex)> buildmouseout;
-	boost::signals2::signal<void(Widelands::DescriptionIndex)> buildmousein;
+	Notifications::Signal<Widelands::DescriptionIndex> buildclicked;
+	Notifications::Signal<Widelands::DescriptionIndex> buildmouseout;
+	Notifications::Signal<Widelands::DescriptionIndex> buildmousein;
 
 	void add(Widelands::DescriptionIndex);
 

--- a/src/wui/game_chat_panel.cc
+++ b/src/wui/game_chat_panel.cc
@@ -102,7 +102,7 @@ GameChatPanel::GameChatPanel(UI::Panel* parent,
 		recipient_dropdown_.select(chat_.last_recipient_);
 		// Insert "@playername " into the edit field if the dropdown currently has a selection
 		set_recipient();
-		update_signal_connection = chat_.participants_->participants_updated.connect([this]() {
+		update_signal_connection_ = chat_.participants_->participants_updated.subscribe([this]() {
 			// When the participants change, create new contents for dropdown
 			has_team_ = chat_.participants_->needs_teamchat();
 			prepare_recipients();
@@ -122,12 +122,6 @@ GameChatPanel::GameChatPanel(UI::Panel* parent,
 
 void GameChatPanel::layout() {
 	vbox_.set_size(get_inner_w(), get_inner_h());
-}
-
-GameChatPanel::~GameChatPanel() {
-	if (chat_.participants_ != nullptr) {
-		update_signal_connection.disconnect();
-	}
 }
 
 /**

--- a/src/wui/game_chat_panel.h
+++ b/src/wui/game_chat_panel.h
@@ -41,13 +41,11 @@ struct GameChatPanel : public UI::Panel {
 	              ChatProvider&,
 	              UI::PanelStyle style);
 
-	~GameChatPanel() override;
-
 	// Signal is called when a message has been sent by the user.
-	boost::signals2::signal<void()> sent;
+	Notifications::Signal<> sent;
 
 	// Signal is called when the user has aborted entering a message.
-	boost::signals2::signal<void()> aborted;
+	Notifications::Signal<> aborted;
 
 	const std::string& get_edit_text() const {
 		return editbox.text();
@@ -83,7 +81,7 @@ private:
 	FxId chat_sound;
 	bool has_team_;
 	std::unique_ptr<Notifications::Subscriber<ChatMessage>> chat_message_subscriber_;
-	boost::signals2::connection update_signal_connection;
+	std::unique_ptr<Notifications::Signal<>::SignalSubscriber> update_signal_connection_;
 };
 
 #endif  // end of include guard: WL_WUI_GAME_CHAT_PANEL_H

--- a/src/wui/mapview.h
+++ b/src/wui/mapview.h
@@ -107,18 +107,18 @@ public:
 	~MapView() override = default;
 
 	// Called whenever the view changed, also during automatic animations.
-	boost::signals2::signal<void()> changeview;
+	Notifications::Signal<> changeview;
 
 	// Called whenever the view changed by a call to scroll_to_field or scroll_to_map_pixel, or by
 	// starting to drag the view.
 	// Note: This signal is called *before* the view actually starts to move.
-	boost::signals2::signal<void()> jump;
+	Notifications::Signal<> jump;
 
 	// Called when the user clicked on a field.
-	boost::signals2::signal<void(const Widelands::NodeAndTriangle<>&)> field_clicked;
+	Notifications::Signal<const Widelands::NodeAndTriangle<>&> field_clicked;
 
 	// Called when the field under the mouse cursor has changed.
-	boost::signals2::signal<void(const Widelands::NodeAndTriangle<>&)> track_selection;
+	Notifications::Signal<const Widelands::NodeAndTriangle<>&> track_selection;
 
 	// Defines if an animation should be immediate (one-frame) or nicely
 	// animated for the user to follow.

--- a/src/wui/minimap.h
+++ b/src/wui/minimap.h
@@ -47,7 +47,7 @@ public:
 
 	MiniMap(InteractiveBase& parent, Registry*);
 
-	boost::signals2::signal<void(const Vector2f&)> warpview;
+	Notifications::Signal<const Vector2f&> warpview;
 
 	void set_view(const Rectf& rect) {
 		view_.set_view(rect);

--- a/src/wui/plot_area.h
+++ b/src/wui/plot_area.h
@@ -20,6 +20,7 @@
 #ifndef WL_WUI_PLOT_AREA_H
 #define WL_WUI_PLOT_AREA_H
 
+#include <map>
 #include <memory>
 
 #include "graphic/color.h"

--- a/src/wui/unique_window_handler.h
+++ b/src/wui/unique_window_handler.h
@@ -20,6 +20,8 @@
 #ifndef WL_WUI_UNIQUE_WINDOW_HANDLER_H
 #define WL_WUI_UNIQUE_WINDOW_HANDLER_H
 
+#include <map>
+
 #include "base/macros.h"
 #include "ui_basic/unique_window.h"
 

--- a/src/wui/watchwindow.h
+++ b/src/wui/watchwindow.h
@@ -40,7 +40,7 @@ struct WatchWindow : public UI::Window {
 	            bool single_window_ = false);
 	~WatchWindow() override;
 
-	boost::signals2::signal<void(Vector2f)> warp_mainview;
+	Notifications::Signal<const Vector2f&> warp_mainview;
 
 	void add_view(Widelands::Coords);
 	void follow(Widelands::Bob* bob);


### PR DESCRIPTION
Re #5115 
Re #5100 

The implementation is very lightweight, inspired by the existing Notifications system. I tried making the new class an extension of the system we already have but it's too inflexible, so this way is both easier and more efficient.

The frontend is mostly the same as before, only the class name and the in-depth controls (for the 2 places in the code that need them) differ. The new code is in `src/notifications/signal.h`.