### PR TITLE
Fix static initialisation order in unit tests

### DIFF
--- a/src/base/test.cc
+++ b/src/base/test.cc
@@ -17,4 +17,11 @@
  *
  */
 
-// Dummy file as cmake cannot handle header only libraries.
+#include "base/test.h"
+
+namespace WLTestsuite {
+Testsuite& all_testsuites() {
+	static Testsuite* t = new Testsuite;
+	return *t;
+}
+}  // namespace WLTestsuite

--- a/src/base/test.h
+++ b/src/base/test.h
@@ -80,7 +80,7 @@
 namespace WLTestsuite {
 using Testcases = std::map<std::string, void (*)()>;
 using Testsuite = std::map<std::string, Testcases>;
-extern Testsuite all_testsuites_;
+Testsuite& all_testsuites();
 
 struct InternalTestcaseInserter {
 	explicit InternalTestcaseInserter(Testcases& tc, const std::string& name, void (*fn)()) {
@@ -158,13 +158,13 @@ inline void do_check_equal(const char* f, uint32_t l, const T1& a, const T2& b) 
 
 #define TEST_EXECUTABLE(name)                                                                      \
 	namespace WLTestsuite {                                                                         \
-	Testsuite all_testsuites_;                                                                      \
 	namespace WLTestsuite_##name {                                                                  \
 		static int main() {                                                                          \
 			bool errors = false;                                                                      \
-			for (const auto& suite : all_testsuites_) {                                               \
+			for (const auto& suite : all_testsuites()) {                                              \
 				for (const auto& test : suite.second) {                                                \
 					try {                                                                               \
+						std::cout << "Running " << suite.first << "::" << test.first << std::endl;       \
 						test.second();                                                                   \
 					} catch (const std::exception& e) {                                                 \
 						errors = true;                                                                   \
@@ -184,7 +184,7 @@ inline void do_check_equal(const char* f, uint32_t l, const T1& a, const T2& b) 
 #define TESTSUITE_START(name)                                                                      \
 	namespace WLTestsuite {                                                                         \
 	namespace WLTestsuite_##name {                                                                  \
-		static Testcases& all_testcases_ = all_testsuites_[#name];
+		static Testcases& all_testcases_ = all_testsuites()[#name];
 
 #define TESTCASE(name)                                                                             \
 	static void testcase_##name();                                                                  \


### PR DESCRIPTION
Fixes #5135