### PR TITLE
Prevent defining sprintf to libintl_sprintf

### DIFF
--- a/src/base/i18n.h
+++ b/src/base/i18n.h
@@ -25,8 +25,11 @@
 
 #include "third_party/gettext/gettext.h"  // For ngettext and pgettext.
 
-// prevent defining snprintf / vsnprintf to libintl_snprintf / libintl_vsnprintf in libintl.h
-// libintl.h is included by getext.h
+// prevent defining sprintf / snprintf / vsnprintf to libintl_sprintf / libintl_snprintf / libintl_vsnprintf
+// in libintl.h, libintl.h is included by getext.h
+#ifdef sprintf
+#undef sprintf
+#endif
 #ifdef snprintf
 #undef snprintf
 #endif

--- a/src/base/i18n.h
+++ b/src/base/i18n.h
@@ -25,8 +25,8 @@
 
 #include "third_party/gettext/gettext.h"  // For ngettext and pgettext.
 
-// prevent defining sprintf / snprintf / vsnprintf to libintl_sprintf / libintl_snprintf / libintl_vsnprintf
-// in libintl.h, libintl.h is included by getext.h
+// prevent defining sprintf / snprintf / vsnprintf to libintl_sprintf / libintl_snprintf /
+// libintl_vsnprintf in libintl.h, libintl.h is included by getext.h
 #ifdef sprintf
 #undef sprintf
 #endif


### PR DESCRIPTION
Fix Windows mingw builds
(see https://github.com/widelands/widelands/runs/4528487004?check_suite_focus=true)