### PR TITLE
Rename `bformat` → `format`

### DIFF
--- a/src/base/format/tree.h
+++ b/src/base/format/tree.h
@@ -310,7 +310,7 @@ std::string format(const bool localize, const std::string& format_string, Args..
 		MutexLock m(MutexLock::ID::kI18N);
 		return format_impl::Tree::get(format_string).format(false, args...);
 	} catch (const std::exception& e) {
-		log_err("bformat error: A string contains invalid printf placeholders");
+		log_err("format error: A string contains invalid printf placeholders");
 		log_err("Error: %s", e.what());
 		log_err("String: %s", format_string.c_str());
 		throw;

--- a/src/base/i18n.cc
+++ b/src/base/i18n.cc
@@ -407,24 +407,24 @@ std::string localize_list(const std::vector<std::string>& items, ConcatenateWith
 			if (listtype == ConcatenateWith::AMPERSAND) {
 				/** TRANSLATORS: Concatenate the last 2 items on a list. */
 				/** TRANSLATORS: RTL languages might want to change the word order here. */
-				result = bformat(_("%1$s & %2$s"), result, (*it));
+				result = format(_("%1$s & %2$s"), result, (*it));
 			} else if (listtype == ConcatenateWith::OR) {
 				/** TRANSLATORS: Join the last 2 items on a list with "or". */
 				/** TRANSLATORS: RTL languages might want to change the word order here. */
-				result = bformat(_("%1$s or %2$s"), result, (*it));
+				result = format(_("%1$s or %2$s"), result, (*it));
 			} else if (listtype == ConcatenateWith::COMMA) {
 				/** TRANSLATORS: Join the last 2 items on a list with a comma. */
 				/** TRANSLATORS: RTL languages might want to change the word order here. */
-				result = bformat(_("%1$s, %2$s"), result, (*it));
+				result = format(_("%1$s, %2$s"), result, (*it));
 			} else {
 				/** TRANSLATORS: Concatenate the last 2 items on a list. */
 				/** TRANSLATORS: RTL languages might want to change the word order here. */
-				result = bformat(_("%1$s and %2$s"), result, (*it));
+				result = format(_("%1$s and %2$s"), result, (*it));
 			}
 		} else {
 			/** TRANSLATORS: Concatenate 2 items at in the middle of a list. */
 			/** TRANSLATORS: RTL languages might want to change the word order here. */
-			result = bformat(_("%1$s, %2$s"), result, (*it));
+			result = format(_("%1$s, %2$s"), result, (*it));
 		}
 	}
 	return result;
@@ -434,7 +434,7 @@ std::string join_sentences(const std::string& sentence1, const std::string& sent
 	i18n::Textdomain td("widelands");
 	/** TRANSLATORS: Put 2 sentences one after the other. Languages using Chinese script probably
 	 * want to lose the blank space here. */
-	return bformat(pgettext("sentence_separator", "%1% %2%"), sentence1, sentence2);
+	return format(pgettext("sentence_separator", "%1% %2%"), sentence1, sentence2);
 }
 
 }  // namespace i18n

--- a/src/base/scoped_timer.cc
+++ b/src/base/scoped_timer.cc
@@ -32,7 +32,7 @@ ScopedTimer::ScopedTimer(const std::string& message, bool v) : message_(message)
 ScopedTimer::~ScopedTimer() {
 	if ((!only_verbose_ || g_verbose) && !message_.empty()) {
 		uint32_t ms_in_existance = SDL_GetTicks() - startime_;
-		log_info("%s", bformat(message_, ms_in_existance).c_str());
+		log_info("%s", format(message_, ms_in_existance).c_str());
 	}
 }
 

--- a/src/base/scoped_timer.h
+++ b/src/base/scoped_timer.h
@@ -30,7 +30,7 @@
  */
 class ScopedTimer {
 public:
-	// Takes the output message that will be bformat()ted with the total time
+	// Takes the output message that will be format()ted with the total time
 	// this object existed (in ms, use %u).
 	explicit ScopedTimer(const std::string& message, bool only_verbose = false);
 

--- a/src/base/string.h
+++ b/src/base/string.h
@@ -131,11 +131,11 @@ inline std::string as_string(const char c) {
 
 /** String formatting function, without or with localized substitutions. */
 template <typename... Args>
-inline std::string bformat(const std::string& format_string, Args... args) {
+inline std::string format(const std::string& format_string, Args... args) {
 	return format_impl::format(false, format_string, args...);
 }
 template <typename... Args>
-inline std::string bformat_l(const std::string& format_string, Args... args) {
+inline std::string format_l(const std::string& format_string, Args... args) {
 	return format_impl::format(true, format_string, args...);
 }
 

--- a/src/base/test/test_string.cc
+++ b/src/base/test/test_string.cc
@@ -116,72 +116,72 @@ TESTCASE(trim_split_replace) {
 }
 
 TESTCASE(string_formatting) {
-	check_equal("Hello World", bformat("%s", "Hello World"));
-	check_equal("Hello World", bformat("%s %s", "Hello", "World"));
-	check_equal("Hello World", bformat("%1$s %2%", "Hello", "World"));
-	check_equal("Hello World", bformat("%2% %1%", "World", "Hello"));
-	check_equal("   Hello World", bformat("%1$14s", "Hello World"));
-	check_equal("Hello World   ", bformat("%-14s", "Hello World"));
-	check_equal("         Hello", bformat("%14.5s", "Hello World"));
-	check_equal("Hello         ", bformat("%1$-14.5s", "Hello World"));
+	check_equal("Hello World", format("%s", "Hello World"));
+	check_equal("Hello World", format("%s %s", "Hello", "World"));
+	check_equal("Hello World", format("%1$s %2%", "Hello", "World"));
+	check_equal("Hello World", format("%2% %1%", "World", "Hello"));
+	check_equal("   Hello World", format("%1$14s", "Hello World"));
+	check_equal("Hello World   ", format("%-14s", "Hello World"));
+	check_equal("         Hello", format("%14.5s", "Hello World"));
+	check_equal("Hello         ", format("%1$-14.5s", "Hello World"));
 
-	check_equal("A123X", bformat("A%dX", 123));
-	check_equal("A-1X", bformat("A%dX", -1));
-	check_equal("A+123X", bformat("A%0+2dX", 123));
-	check_equal("A+123    X", bformat("A%+-8dX", 123));
-	check_equal("A+123    X", bformat("A%-+8dX", 123));
-	check_equal("A123     X", bformat("A%-8dX", 123));
-	check_equal("A     123X", bformat("A%8dX", 123));
-	check_equal("A00000123X", bformat("A%08dX", 123));
-	check_equal("A    +123X", bformat("A%+8dX", 123));
-	check_equal("A+0000123X", bformat("A%+08dX", 123));
-	check_equal("A    -123X", bformat("A%+8dX", -123));
-	check_equal("A      +0X", bformat("A%+8dX", 0));
-	check_equal("A0123X", bformat("A%d%u%d%uX", 0, 1, 2, 3));
+	check_equal("A123X", format("A%dX", 123));
+	check_equal("A-1X", format("A%dX", -1));
+	check_equal("A+123X", format("A%0+2dX", 123));
+	check_equal("A+123    X", format("A%+-8dX", 123));
+	check_equal("A+123    X", format("A%-+8dX", 123));
+	check_equal("A123     X", format("A%-8dX", 123));
+	check_equal("A     123X", format("A%8dX", 123));
+	check_equal("A00000123X", format("A%08dX", 123));
+	check_equal("A    +123X", format("A%+8dX", 123));
+	check_equal("A+0000123X", format("A%+08dX", 123));
+	check_equal("A    -123X", format("A%+8dX", -123));
+	check_equal("A      +0X", format("A%+8dX", 0));
+	check_equal("A0123X", format("A%d%u%d%uX", 0, 1, 2, 3));
 
-	check_equal("AfalsetrueX", bformat("A%b%bX", 0, 1));
-	check_equal("Aw77X", bformat("A%2$c%1$iX", 77, 'w'));
-	check_equal("A^@X", bformat("A%1$cX", '\0'));
-	check_equal("A^MX", bformat("A%cX", '\r'));
-	check_equal("A^[X", bformat("A%1%X", '\x1b'));
+	check_equal("AfalsetrueX", format("A%b%bX", 0, 1));
+	check_equal("Aw77X", format("A%2$c%1$iX", 77, 'w'));
+	check_equal("A^@X", format("A%1$cX", '\0'));
+	check_equal("A^MX", format("A%cX", '\r'));
+	check_equal("A^[X", format("A%1%X", '\x1b'));
 
-	check_equal("AnullptrX", bformat("A%PX", nullptr));
-	check_equal("A0x123abcX", bformat("A%pX", reinterpret_cast<int*>(0x123abc)));
-	check_equal("A0x123abcX", bformat("A%1%X", reinterpret_cast<int*>(0x123abc)));
-	check_equal("A+0xABC123X", bformat("A%+PX", 0xabc123));
-	check_equal("A-ABC123X", bformat("A%XX", -0xabc123));
-	check_equal("A1194684X", bformat("A%1%X", 0x123abc));
+	check_equal("AnullptrX", format("A%PX", nullptr));
+	check_equal("A0x123abcX", format("A%pX", reinterpret_cast<int*>(0x123abc)));
+	check_equal("A0x123abcX", format("A%1%X", reinterpret_cast<int*>(0x123abc)));
+	check_equal("A+0xABC123X", format("A%+PX", 0xabc123));
+	check_equal("A-ABC123X", format("A%XX", -0xabc123));
+	check_equal("A1194684X", format("A%1%X", 0x123abc));
 
-	check_equal("A123.456X", bformat("A%.3fX", 123.456));
-	check_equal("A-0.45600000X", bformat("A%2.8fX", -0.456));
-	check_equal("A-0.300X", bformat("A%2.3fX", -0.2999));
-	check_equal("A      12.3X", bformat("A%10.1fX", 12.34567));
-	check_equal("A123      X", bformat("A%-9.0fX", 123.456));
-	check_equal("A+123.5   X", bformat("A%+-9.1fX", 123.456));
-	check_equal("A+00123.46X", bformat("A%0+9.2fX", 123.456));
+	check_equal("A123.456X", format("A%.3fX", 123.456));
+	check_equal("A-0.45600000X", format("A%2.8fX", -0.456));
+	check_equal("A-0.300X", format("A%2.3fX", -0.2999));
+	check_equal("A      12.3X", format("A%10.1fX", 12.34567));
+	check_equal("A123      X", format("A%-9.0fX", 123.456));
+	check_equal("A+123.5   X", format("A%+-9.1fX", 123.456));
+	check_equal("A+00123.46X", format("A%0+9.2fX", 123.456));
 
 	format_impl::ArgsPair p1, p2;
 	p1.first = p2.first = format_impl::AbstractNode::ArgType::kString;
 	p1.second.string_val = "World";
 	p2.second.string_val = "Hello";
-	check_equal("Hello World", bformat("%2% %1%", format_impl::ArgsVector{p1, p2}));
-	check_equal("World Hello", bformat("%2% %1%", format_impl::ArgsVector{p2, p1}));
+	check_equal("Hello World", format("%2% %1%", format_impl::ArgsVector{p1, p2}));
+	check_equal("World Hello", format("%2% %1%", format_impl::ArgsVector{p2, p1}));
 
-	check_error("invalid placeholder", []() { bformat("%q", 1); });
-	check_error("invalid placeholder", []() { bformat("%lf", 1); });
-	check_error("invalid character after %", []() { bformat("%|1$d|", 1); });
-	check_error("end of string", []() { bformat("%02.7", 4); });
-	check_error("missing placeholder", []() { bformat("%2% %3$i", 2, 3); });
-	check_error("duplicate placeholder", []() { bformat("%1% %1$d", 1, 1); });
-	check_error("mixed placeholders", []() { bformat("%4d %2%", 123, 123); });
-	check_error("too many args", []() { bformat("%u %li %lld", 1, 2, 3, 4); });
-	check_error("too few args", []() { bformat("%lu %llu %lli", 1, 2); });
-	check_error("wrong arg type", []() { bformat("%s", 1); });
-	check_error("wrong arg type", []() { bformat("%i", "foo"); });
-	check_error("float too large", []() { bformat("%f", 12345678901234567890.f); });
-	check_error("int too large", []() { bformat("%ld", 0x876543210fedcba9); });
-	check_error("invalid flag combination", []() { bformat("%-05d", 123); });
-	check_error("repeated flag", []() { bformat("%+0+5d", 123); });
+	check_error("invalid placeholder", []() { format("%q", 1); });
+	check_error("invalid placeholder", []() { format("%lf", 1); });
+	check_error("invalid character after %", []() { format("%|1$d|", 1); });
+	check_error("end of string", []() { format("%02.7", 4); });
+	check_error("missing placeholder", []() { format("%2% %3$i", 2, 3); });
+	check_error("duplicate placeholder", []() { format("%1% %1$d", 1, 1); });
+	check_error("mixed placeholders", []() { format("%4d %2%", 123, 123); });
+	check_error("too many args", []() { format("%u %li %lld", 1, 2, 3, 4); });
+	check_error("too few args", []() { format("%lu %llu %lli", 1, 2); });
+	check_error("wrong arg type", []() { format("%s", 1); });
+	check_error("wrong arg type", []() { format("%i", "foo"); });
+	check_error("float too large", []() { format("%f", 12345678901234567890.f); });
+	check_error("int too large", []() { format("%ld", 0x876543210fedcba9); });
+	check_error("invalid flag combination", []() { format("%-05d", 123); });
+	check_error("repeated flag", []() { format("%+0+5d", 123); });
 }
 
 TESTSUITE_END()

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -933,7 +933,7 @@ void EditorInteractive::run_editor(UI::Panel* error_message_parent,
 		// during winter time freeze. We can consider rephrasing it after v1.0.
 		UI::WLMessageBox m(
 		   error_message_parent, UI::WindowStyle::kFsMenu, _("Error"),
-		   bformat(
+		   format(
 		      _("An error has occured. The error message is:\n\n%1$s\n\nPlease report "
 		        "this problem to help us improve Widelands. You will find related messages in the "
 		        "standard output (stdout.txt on Windows). You are using build %2$s "
@@ -968,7 +968,7 @@ void EditorInteractive::do_run_editor(const EditorInteractive::Init init,
 			throw wexception("EditorInteractive::run_editor: Empty map file name");
 		}
 
-		Notifications::publish(UI::NoteLoadingMessage(bformat(_("Loading map “%s”…"), filename)));
+		Notifications::publish(UI::NoteLoadingMessage(format(_("Loading map “%s”…"), filename)));
 		eia.load(filename);
 
 		egbase.postload_addons();

--- a/src/editor/tools/info_tool.cc
+++ b/src/editor/tools/info_tool.cc
@@ -36,7 +36,7 @@ int32_t EditorInfoTool::handle_click_impl(const Widelands::NodeAndTriangle<>& ce
 	const Widelands::Coords& coords = center.node;
 
 	UI::UniqueWindow::Registry& registry =
-	   parent.unique_windows().get_registry(bformat("fieldinfo_%d_%d", coords.x, coords.y));
+	   parent.unique_windows().get_registry(format("fieldinfo_%d_%d", coords.x, coords.y));
 
 	registry.open_window = [this, &parent, &registry, &center, &f, &tf, map]() {
 		// if window reaches bottom right corner, start from top left corner again

--- a/src/editor/ui_menus/categorized_item_selection_menu.h
+++ b/src/editor/ui_menus/categorized_item_selection_menu.h
@@ -172,13 +172,13 @@ void CategorizedItemSelectionMenu<DescriptionType, ToolType>::update_label() {
 	}
 	if (buf.size() > max_string_size) {
 		/** TRANSLATORS: %s are the currently selected items in an editor tool */
-		buf = bformat(_("Current: %s …"), buf);
+		buf = format(_("Current: %s …"), buf);
 	} else if (buf.empty()) {
 		/** TRANSLATORS: Help text in an editor tool */
 		buf = _("Click to select an item. Use the Ctrl key to select multiple items.");
 	} else {
 		/** TRANSLATORS: %s are the currently selected items in an editor tool */
-		buf = bformat(_("Current: %s"), buf);
+		buf = format(_("Current: %s"), buf);
 	}
 	current_selection_names_.set_text(buf);
 }

--- a/src/editor/ui_menus/field_info_window.cc
+++ b/src/editor/ui_menus/field_info_window.cc
@@ -75,7 +75,7 @@ void FieldInfoWindow::update() {
 void FieldInfoWindow::add_node_info(std::string& buf) const {
 	buf += as_heading(_("Node"), UI::PanelStyle::kWui, true);
 	buf += as_listitem(
-	   bformat(_("Coordinates: (%1$i, %2$i)"), center_.node.x, center_.node.y), font_style);
+	   format(_("Coordinates: (%1$i, %2$i)"), center_.node.x, center_.node.y), font_style);
 }
 
 void FieldInfoWindow::add_caps_info(std::string& buf) const {
@@ -122,14 +122,14 @@ void FieldInfoWindow::add_caps_info(std::string& buf) const {
 	}
 
 	buf += as_listitem(
-	   bformat(_("Caps: %s"), i18n::localize_list(caps_strings, i18n::ConcatenateWith::COMMA)),
+	   format(_("Caps: %s"), i18n::localize_list(caps_strings, i18n::ConcatenateWith::COMMA)),
 	   font_style);
 }
 
 void FieldInfoWindow::add_owner_info(std::string& buf) const {
 	if (f_.get_owned_by() > 0) {
 		buf += as_listitem(
-		   bformat(_("Owned by: Player %u"), static_cast<unsigned int>(f_.get_owned_by())),
+		   format(_("Owned by: Player %u"), static_cast<unsigned int>(f_.get_owned_by())),
 		   font_style);
 	} else {
 		buf += as_listitem(_("Owned by: —"), font_style);
@@ -142,7 +142,7 @@ void FieldInfoWindow::add_terrain_info(std::string& buf) const {
 	const Widelands::TerrainDescription* ter = parent_.egbase().descriptions().get_terrain_descr(
 	   center_.triangle.t == Widelands::TriangleIndex::D ? tf_.terrain_d() : tf_.terrain_r());
 
-	buf += as_listitem(bformat(pgettext("terrain_name", "Name: %s"), ter->descname()), font_style);
+	buf += as_listitem(format(pgettext("terrain_name", "Name: %s"), ter->descname()), font_style);
 
 	std::vector<std::string> terrain_is_strings;
 	for (const Widelands::TerrainDescription::Type& terrain_type : ter->get_types()) {
@@ -150,7 +150,7 @@ void FieldInfoWindow::add_terrain_info(std::string& buf) const {
 	}
 
 	buf += as_listitem(
-	   bformat(
+	   format(
 	      /** TRANSLATORS: "Is" is a list of terrain properties, e.g. "arable, unreachable and
 	       * unwalkable". You can also translate this as "Category: %s" or "Property: %s" */
 	      _("Is: %s"), i18n::localize_list(terrain_is_strings, i18n::ConcatenateWith::AMPERSAND)),
@@ -164,7 +164,7 @@ void FieldInfoWindow::add_mapobject_info(std::string& buf) const {
 		/** TRANSLATORS: Heading for immovables and animals in editor info tool */
 		buf += as_heading(_("Objects"), UI::PanelStyle::kWui);
 		if (immovable) {
-			buf += as_listitem(bformat(_("Immovable: %s"), immovable->descr().descname()), font_style);
+			buf += as_listitem(format(_("Immovable: %s"), immovable->descr().descname()), font_style);
 		}
 
 		if (bob) {
@@ -196,18 +196,18 @@ void FieldInfoWindow::add_mapobject_info(std::string& buf) const {
 			// Add bobs
 			if (!critternames.empty()) {
 				buf +=
-				   as_listitem(bformat(_("Animals: %s"),
+				   as_listitem(format(_("Animals: %s"),
 				                       i18n::localize_list(critternames, i18n::ConcatenateWith::COMMA)),
 				               font_style);
 			}
 			if (!workernames.empty()) {
 				buf +=
-				   as_listitem(bformat(_("Workers: %s"),
+				   as_listitem(format(_("Workers: %s"),
 				                       i18n::localize_list(workernames, i18n::ConcatenateWith::COMMA)),
 				               font_style);
 			}
 			if (!shipnames.empty()) {
-				buf += as_listitem(bformat(_("Ships: %s"), i18n::localize_list(
+				buf += as_listitem(format(_("Ships: %s"), i18n::localize_list(
 				                                              shipnames, i18n::ConcatenateWith::COMMA)),
 				                   font_style);
 			}
@@ -220,7 +220,7 @@ void FieldInfoWindow::add_resources_info(std::string& buf) const {
 	if (ramount > 0) {
 		buf += as_heading(_("Resources"), UI::PanelStyle::kWui);
 		buf += as_listitem(
-		   bformat(
+		   format(
 		      pgettext("resources", "%1%× %2%"), static_cast<unsigned int>(ramount),
 		      parent_.egbase().descriptions().get_resource_descr(f_.get_resources())->descname()),
 		   font_style);
@@ -230,20 +230,20 @@ void FieldInfoWindow::add_resources_info(std::string& buf) const {
 void FieldInfoWindow::add_map_info(std::string& buf) const {
 	buf += as_heading(_("Map"), UI::PanelStyle::kWui);
 	buf += as_listitem(
-	   bformat(pgettext("map_name", "Name: %s"), richtext_escape(map_->get_name())), font_style);
+	   format(pgettext("map_name", "Name: %s"), richtext_escape(map_->get_name())), font_style);
 	buf +=
-	   as_listitem(bformat(_("Size: %1% × %2%"), map_->get_width(), map_->get_height()), font_style);
+	   as_listitem(format(_("Size: %1% × %2%"), map_->get_width(), map_->get_height()), font_style);
 
 	if (map_->get_nrplayers() > 0) {
 		buf += as_listitem(
-		   bformat(_("Players: %u"), static_cast<unsigned int>(map_->get_nrplayers())), font_style);
+		   format(_("Players: %u"), static_cast<unsigned int>(map_->get_nrplayers())), font_style);
 	} else {
 		buf += as_listitem(_("Players: –"), font_style);
 	}
 
-	buf += as_listitem(bformat(_("Author: %s"), richtext_escape(map_->get_author())), font_style);
+	buf += as_listitem(format(_("Author: %s"), richtext_escape(map_->get_author())), font_style);
 	buf += as_listitem(
-	   bformat(_("Description: %s"), richtext_escape(map_->get_description())), font_style);
+	   format(_("Description: %s"), richtext_escape(map_->get_description())), font_style);
 
 	{
 		std::string addons;
@@ -256,12 +256,12 @@ void FieldInfoWindow::add_map_info(std::string& buf) const {
 				if (addons.empty()) {
 					addons = parent_.egbase().enabled_addons()[i]->descname();
 				} else {
-					addons = bformat(
+					addons = format(
 					   _("%1$s; %2$s"), addons, parent_.egbase().enabled_addons()[i]->descname());
 				}
 			}
 		}
-		buf += as_listitem(bformat(_("Enabled Add-Ons: %s"), richtext_escape(addons)), font_style);
+		buf += as_listitem(format(_("Enabled Add-Ons: %s"), richtext_escape(addons)), font_style);
 	}
 }
 

--- a/src/editor/ui_menus/field_info_window.cc
+++ b/src/editor/ui_menus/field_info_window.cc
@@ -128,9 +128,9 @@ void FieldInfoWindow::add_caps_info(std::string& buf) const {
 
 void FieldInfoWindow::add_owner_info(std::string& buf) const {
 	if (f_.get_owned_by() > 0) {
-		buf += as_listitem(
-		   format(_("Owned by: Player %u"), static_cast<unsigned int>(f_.get_owned_by())),
-		   font_style);
+		buf +=
+		   as_listitem(format(_("Owned by: Player %u"), static_cast<unsigned int>(f_.get_owned_by())),
+		               font_style);
 	} else {
 		buf += as_listitem(_("Owned by: —"), font_style);
 	}
@@ -197,19 +197,19 @@ void FieldInfoWindow::add_mapobject_info(std::string& buf) const {
 			if (!critternames.empty()) {
 				buf +=
 				   as_listitem(format(_("Animals: %s"),
-				                       i18n::localize_list(critternames, i18n::ConcatenateWith::COMMA)),
+				                      i18n::localize_list(critternames, i18n::ConcatenateWith::COMMA)),
 				               font_style);
 			}
 			if (!workernames.empty()) {
 				buf +=
 				   as_listitem(format(_("Workers: %s"),
-				                       i18n::localize_list(workernames, i18n::ConcatenateWith::COMMA)),
+				                      i18n::localize_list(workernames, i18n::ConcatenateWith::COMMA)),
 				               font_style);
 			}
 			if (!shipnames.empty()) {
-				buf += as_listitem(format(_("Ships: %s"), i18n::localize_list(
-				                                              shipnames, i18n::ConcatenateWith::COMMA)),
-				                   font_style);
+				buf += as_listitem(
+				   format(_("Ships: %s"), i18n::localize_list(shipnames, i18n::ConcatenateWith::COMMA)),
+				   font_style);
 			}
 		}
 	}
@@ -220,9 +220,8 @@ void FieldInfoWindow::add_resources_info(std::string& buf) const {
 	if (ramount > 0) {
 		buf += as_heading(_("Resources"), UI::PanelStyle::kWui);
 		buf += as_listitem(
-		   format(
-		      pgettext("resources", "%1%× %2%"), static_cast<unsigned int>(ramount),
-		      parent_.egbase().descriptions().get_resource_descr(f_.get_resources())->descname()),
+		   format(pgettext("resources", "%1%× %2%"), static_cast<unsigned int>(ramount),
+		          parent_.egbase().descriptions().get_resource_descr(f_.get_resources())->descname()),
 		   font_style);
 	}
 }
@@ -256,8 +255,8 @@ void FieldInfoWindow::add_map_info(std::string& buf) const {
 				if (addons.empty()) {
 					addons = parent_.egbase().enabled_addons()[i]->descname();
 				} else {
-					addons = format(
-					   _("%1$s; %2$s"), addons, parent_.egbase().enabled_addons()[i]->descname());
+					addons =
+					   format(_("%1$s; %2$s"), addons, parent_.egbase().enabled_addons()[i]->descname());
 				}
 			}
 		}

--- a/src/editor/ui_menus/help.cc
+++ b/src/editor/ui_menus/help.cc
@@ -36,7 +36,7 @@ EditorHelp::EditorHelp(EditorInteractive& parent,
 	} catch (LuaError& err) {
 		log_err("Error loading script for editor help:\n%s\n", err.what());
 		UI::WLMessageBox wmb(&parent, UI::WindowStyle::kWui, _("Error!"),
-		                     bformat("Error loading script for editor help:\n%s", err.what()),
+		                     format("Error loading script for editor help:\n%s", err.what()),
 		                     UI::WLMessageBox::MBoxType::kOk);
 		wmb.run<UI::Panel::Returncodes>();
 	}

--- a/src/editor/ui_menus/main_menu_load_map.cc
+++ b/src/editor/ui_menus/main_menu_load_map.cc
@@ -85,7 +85,7 @@ void MainMenuLoadMap::set_current_directory(const std::string& filename) {
 		replace_first(display_dir, "Downloaded", _("Downloaded Maps"));
 	}
 	/** TRANSLATORS: The folder that a file will be saved to. */
-	directory_info_.set_text(bformat(_("Current directory: %s"), display_dir));
+	directory_info_.set_text(format(_("Current directory: %s"), display_dir));
 }
 
 /**

--- a/src/editor/ui_menus/main_menu_map_options.cc
+++ b/src/editor/ui_menus/main_menu_map_options.cc
@@ -427,7 +427,7 @@ MainMenuMapOptions::MainMenuMapOptions(EditorInteractive& parent, Registry& regi
 	const unsigned nr_players = eia().egbase().map().get_nrplayers();
 	teams_box_.add(new UI::Textarea(
 	   &teams_box_, UI::PanelStyle::kWui, UI::FontStyle::kWuiLabel, 0, 0, max_w_, labelh_,
-	   bformat(ngettext("%u Player", "%u Players", nr_players), nr_players)));
+	   format(ngettext("%u Player", "%u Players", nr_players), nr_players)));
 	teams_box_.add_space(padding_);
 	teams_box_.add(new UI::Textarea(&teams_box_, UI::PanelStyle::kWui, UI::FontStyle::kWuiLabel, 0,
 	                                0, max_w_, labelh_, _("Suggested Teams:")));
@@ -489,7 +489,7 @@ void MainMenuMapOptions::update_waterway_length_warning() {
 	if (len > kMaxRecommendedWaterwayLengthLimit) {
 		waterway_length_warning_->set_icon(g_image_cache->get("images/ui_basic/stop.png"));
 		waterway_length_warning_->set_tooltip(
-		   bformat(_("It is not recommended to permit waterway lengths greater than %u"),
+		   format(_("It is not recommended to permit waterway lengths greater than %u"),
 		           kMaxRecommendedWaterwayLengthLimit));
 	} else {
 		waterway_length_warning_->set_icon(nullptr);
@@ -505,7 +505,7 @@ void MainMenuMapOptions::update() {
 	const Widelands::Map& map = eia().egbase().map();
 	author_.set_text(map.get_author());
 	name_.set_text(map.get_name());
-	size_.set_text(bformat(_("Size: %1% x %2%"), map.get_width(), map.get_height()));
+	size_.set_text(format(_("Size: %1% x %2%"), map.get_width(), map.get_height()));
 	descr_->set_text(map.get_description());
 	hint_->set_text(map.get_hint());
 	waterway_length_box_->set_value(map.get_waterway_max_length());

--- a/src/editor/ui_menus/main_menu_map_options.cc
+++ b/src/editor/ui_menus/main_menu_map_options.cc
@@ -490,7 +490,7 @@ void MainMenuMapOptions::update_waterway_length_warning() {
 		waterway_length_warning_->set_icon(g_image_cache->get("images/ui_basic/stop.png"));
 		waterway_length_warning_->set_tooltip(
 		   format(_("It is not recommended to permit waterway lengths greater than %u"),
-		           kMaxRecommendedWaterwayLengthLimit));
+		          kMaxRecommendedWaterwayLengthLimit));
 	} else {
 		waterway_length_warning_->set_icon(nullptr);
 		waterway_length_warning_->set_tooltip("");

--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -165,7 +165,7 @@ MainMenuNewRandomMapPanel::MainMenuNewRandomMapPanel(
                 0,
                 inner_w / 3,
                 mountains_label_.get_h(),
-                bformat(_("%i %%"), mountainsval_),
+                format(_("%i %%"), mountainsval_),
                 UI::Align::kCenter),
      island_mode_(this, panel_style_, Vector2i::zero(), _("Island mode")),
      // Geeky stuff
@@ -415,7 +415,7 @@ void MainMenuNewRandomMapPanel::normalize_landmass(ButtonId clicked_button) {
 	water_.set_value(waterval_);
 	land_.set_value(landval_);
 	wasteland_.set_value(wastelandval_);
-	mountains_.set_text(bformat(_("%i %%"), mountainsval_));
+	mountains_.set_text(format(_("%i %%"), mountainsval_));
 }
 
 void MainMenuNewRandomMapPanel::select_terrains_distribution() {
@@ -619,7 +619,7 @@ bool MainMenuNewRandomMapPanel::do_generate_map(Widelands::EditorGameBase& egbas
 
 			for (unsigned p = 0; p < nr_players; ++p) {
 				sp->set_player_name(
-				   p, p == plnum ? _("Player") : bformat(_("Computer %u"), (p > plnum ? p : p + 1)));
+				   p, p == plnum ? _("Player") : format(_("Computer %u"), (p > plnum ? p : p + 1)));
 				sp->set_player_tribe(p, "", true);
 				sp->set_player_team(p, p == plnum ? 0 : 1);
 				sp->set_player_init(p, 0);

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -182,7 +182,7 @@ void MainMenuSaveMap::clicked_make_directory() {
 					log_err("directory creation failed in MainMenuSaveMap::"
 					        "clicked_make_directory: %s\n",
 					        e.what());
-					const std::string s = bformat(_("Error while creating directory ‘%s’."), fullname);
+					const std::string s = format(_("Error while creating directory ‘%s’."), fullname);
 					UI::WLMessageBox mbox(this, UI::WindowStyle::kWui, _("Error Creating Directory!"), s,
 					                      UI::WLMessageBox::MBoxType::kOk);
 					mbox.run<UI::Panel::Returncodes>();
@@ -275,7 +275,7 @@ void MainMenuSaveMap::set_current_directory(const std::string& filename) {
 	curdir_ = filename;
 	directory_info_.set_text(
 	   /** TRANSLATORS: The folder that a file will be saved to. */
-	   bformat(_("Current directory: %s"), (_("My Maps") + curdir_.substr(basedir_.size()))));
+	   format(_("Current directory: %s"), (_("My Maps") + curdir_.substr(basedir_.size()))));
 }
 
 void MainMenuSaveMap::layout() {
@@ -304,7 +304,7 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 
 	//  Check if file exists. If so, show a warning.
 	if (g_fs->file_exists(complete_filename)) {
-		const std::string s = bformat(_("A file with the name ‘%s’ already exists. Overwrite?"),
+		const std::string s = format(_("A file with the name ‘%s’ already exists. Overwrite?"),
 		                              FileSystem::fs_filename(filename.c_str()));
 		UI::WLMessageBox mbox(this, UI::WindowStyle::kWui, _("Error Saving Map!"), s,
 		                      UI::WLMessageBox::MBoxType::kOkCancel);

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -305,7 +305,7 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 	//  Check if file exists. If so, show a warning.
 	if (g_fs->file_exists(complete_filename)) {
 		const std::string s = format(_("A file with the name ‘%s’ already exists. Overwrite?"),
-		                              FileSystem::fs_filename(filename.c_str()));
+		                             FileSystem::fs_filename(filename.c_str()));
 		UI::WLMessageBox mbox(this, UI::WindowStyle::kWui, _("Error Saving Map!"), s,
 		                      UI::WLMessageBox::MBoxType::kOkCancel);
 		if (mbox.run<UI::Panel::Returncodes>() == UI::Panel::Returncodes::kBack) {

--- a/src/editor/ui_menus/player_menu.cc
+++ b/src/editor/ui_menus/player_menu.cc
@@ -158,7 +158,7 @@ EditorPlayerMenu::EditorPlayerMenu(EditorInteractive& parent,
 		mutable_map->set_scenario_player_ai(1, "");
 		mutable_map->set_scenario_player_closeable(1, false);
 		/** TRANSLATORS: Default player name, e.g. Player 1 */
-		mutable_map->set_scenario_player_name(1, bformat(_("Player %u"), 1));
+		mutable_map->set_scenario_player_name(1, format(_("Player %u"), 1));
 		mutable_map->set_scenario_player_tribe(1, "");
 		eia().set_need_save(true);
 	}
@@ -181,7 +181,7 @@ EditorPlayerMenu::EditorPlayerMenu(EditorInteractive& parent,
 
 		// Tribe
 		UI::Dropdown<std::string>* plr_tribe = new UI::Dropdown<std::string>(
-		   row, bformat("dropdown_tribe%d", static_cast<unsigned int>(p)), 0, 0, 50, 16,
+		   row, format("dropdown_tribe%d", static_cast<unsigned int>(p)), 0, 0, 50, 16,
 		   plr_name->get_h(), _("Tribe"), UI::DropdownType::kPictorial, UI::PanelStyle::kWui,
 		   UI::ButtonStyle::kWuiSecondary);
 
@@ -286,7 +286,7 @@ void EditorPlayerMenu::no_of_players_clicked() {
 			// Register new default name and tribe for these players
 			const std::string name =
 			   /** TRANSLATORS: Default player name, e.g. Player 1 */
-			   bformat(_("Player %u"), static_cast<unsigned int>(pn));
+			   format(_("Player %u"), static_cast<unsigned int>(pn));
 			map->set_scenario_player_name(pn, name);
 			rows_.at(pn - 1)->name->set_text(name);
 

--- a/src/editor/ui_menus/tool_change_resources_options_menu.cc
+++ b/src/editor/ui_menus/tool_change_resources_options_menu.cc
@@ -155,8 +155,8 @@ void EditorToolChangeResourcesOptionsMenu::change_resource() {
 void EditorToolChangeResourcesOptionsMenu::update() {
 	cur_selection_.set_text(
 	   format(_("Current: %s"), eia()
-	                                .egbase()
-	                                .descriptions()
-	                                .get_resource_descr(increase_tool_.set_tool().get_cur_res())
-	                                ->descname()));
+	                               .egbase()
+	                               .descriptions()
+	                               .get_resource_descr(increase_tool_.set_tool().get_cur_res())
+	                               ->descname()));
 }

--- a/src/editor/ui_menus/tool_change_resources_options_menu.cc
+++ b/src/editor/ui_menus/tool_change_resources_options_menu.cc
@@ -154,7 +154,7 @@ void EditorToolChangeResourcesOptionsMenu::change_resource() {
  */
 void EditorToolChangeResourcesOptionsMenu::update() {
 	cur_selection_.set_text(
-	   bformat(_("Current: %s"), eia()
+	   format(_("Current: %s"), eia()
 	                                .egbase()
 	                                .descriptions()
 	                                .get_resource_descr(increase_tool_.set_tool().get_cur_res())

--- a/src/editor/ui_menus/tool_set_terrain_options_menu.cc
+++ b/src/editor/ui_menus/tool_set_terrain_options_menu.cc
@@ -73,7 +73,7 @@ UI::Checkbox* create_terrain_checkbox(UI::Panel* parent,
 	offscreen_images->emplace_back(texture);
 
 	/** TRANSLATORS: %1% = terrain name, %2% = list of terrain types  */
-	const std::string tooltip = (bformat(_("%1%: %2%"), terrain_descr.descname(),
+	const std::string tooltip = (format(_("%1%: %2%"), terrain_descr.descname(),
 	                                     i18n::localize_list(tooltips, i18n::ConcatenateWith::AND)))
 
 	                               .append(treeinfo);

--- a/src/editor/ui_menus/tool_set_terrain_options_menu.cc
+++ b/src/editor/ui_menus/tool_set_terrain_options_menu.cc
@@ -74,7 +74,7 @@ UI::Checkbox* create_terrain_checkbox(UI::Panel* parent,
 
 	/** TRANSLATORS: %1% = terrain name, %2% = list of terrain types  */
 	const std::string tooltip = (format(_("%1%: %2%"), terrain_descr.descname(),
-	                                     i18n::localize_list(tooltips, i18n::ConcatenateWith::AND)))
+	                                    i18n::localize_list(tooltips, i18n::ConcatenateWith::AND)))
 
 	                               .append(treeinfo);
 

--- a/src/game_io/game_loader.cc
+++ b/src/game_io/game_loader.cc
@@ -67,7 +67,7 @@ int32_t GameLoader::load_game(bool const multiplayer) {
 	assert(game_.has_loader_ui());
 	auto set_progress_message = [](const std::string& text, unsigned step) {
 		Notifications::publish(
-		   UI::NoteLoadingMessage(bformat(_("Loading game: %1$s (%2$u/%3$d)"), text, step, 6)));
+		   UI::NoteLoadingMessage(format(_("Loading game: %1$s (%2$u/%3$d)"), text, step, 6)));
 	};
 	set_progress_message(_("Elemental data"), 1);
 	verb_log_info("Game: Reading Preload Data ... ");

--- a/src/game_io/game_saver.cc
+++ b/src/game_io/game_saver.cc
@@ -48,7 +48,7 @@ void GameSaver::save() {
 	// We also don't want it for game objectives.
 	auto set_progress_message = [](std::string text, int step) {
 		Notifications::publish(UI::NoteLoadingMessage(
-		   step < 0 ? text : bformat(_("Saving game: %1$s (%2$d/%3$d)"), text, step, 5)));
+		   step < 0 ? text : format(_("Saving game: %1$s (%2$d/%3$d)"), text, step, 5)));
 	};
 	set_progress_message(_("Autosaving game…"), -1);
 

--- a/src/graphic/color.cc
+++ b/src/graphic/color.cc
@@ -32,7 +32,7 @@ RGBColor::RGBColor(const uint32_t hex)
 }
 
 std::string RGBColor::hex_value() const {
-	return bformat("%02x%02x%02x", int(r), int(g), int(b));
+	return format("%02x%02x%02x", int(r), int(g), int(b));
 }
 
 uint32_t RGBColor::map(const SDL_PixelFormat& fmt) const {
@@ -71,7 +71,7 @@ RGBAColor::RGBAColor(uint32_t hex)
 }
 
 std::string RGBAColor::hex_value() const {
-	return bformat("%02x%02x%02x%02x>", int(r), int(g), int(b), int(a));
+	return format("%02x%02x%02x%02x>", int(r), int(g), int(b), int(a));
 }
 
 uint32_t RGBAColor::map(const SDL_PixelFormat& fmt) const {

--- a/src/graphic/gl/initialize.cc
+++ b/src/graphic/gl/initialize.cc
@@ -167,27 +167,27 @@ SDL_GLContext initialize(
 		   "Widelands won't work because we were unable to detect the shading language version.\n"
 		   "There is an unknown problem with reading the information from the graphics driver.",
 		   format("%s\n%s",
-		           /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
-		              support is limited here, so do not use advanced typography **/
-		           _("Widelands won't work because we were unable to detect the shading language "
-		             "version."),
-		           /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
-		              support is limited here, so do not use advanced typography **/
-		           _("There is an unknown problem with reading the information from the graphics "
-		             "driver.")));
+		          /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
+		             support is limited here, so do not use advanced typography **/
+		          _("Widelands won't work because we were unable to detect the shading language "
+		            "version."),
+		          /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
+		             support is limited here, so do not use advanced typography **/
+		          _("There is an unknown problem with reading the information from the graphics "
+		            "driver.")));
 	};
 	auto handle_unreadable_opengl_version = [show_opengl_error_and_exit]() {
 		show_opengl_error_and_exit(
 		   "Widelands won't work because we were unable to detect the OpenGL version.\n"
 		   "There is an unknown problem with reading the information from the graphics driver.",
 		   format("%s\n%s",
-		           /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
-		              support is limited here, so do not use advanced typography **/
-		           _("Widelands won't work because we were unable to detect the OpenGL version."),
-		           /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
-		              support is limited here, so do not use advanced typography **/
-		           _("There is an unknown problem with reading the information from the graphics "
-		             "driver.")));
+		          /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
+		             support is limited here, so do not use advanced typography **/
+		          _("Widelands won't work because we were unable to detect the OpenGL version."),
+		          /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
+		             support is limited here, so do not use advanced typography **/
+		          _("There is an unknown problem with reading the information from the graphics "
+		            "driver.")));
 	};
 	auto check_version = [show_opengl_error_and_exit](
 	                        const std::string& version_string, const std::string& name,
@@ -208,17 +208,16 @@ SDL_GLContext initialize(
 			    (major_version == required_major_version && minor_version < required_minor_version)) {
 				show_opengl_error_and_exit(
 				   format("Widelands won’t work because your graphics driver is too old.\n"
-				           "The %u version needs to be version %u.%u or newer.",
-				           name, required_major_version, required_minor_version),
-				   format(
-				      "%s\n%s",
-				      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
-				         Font support is limited here, so do not use advanced typography **/
-				      _("Widelands won’t work because your graphics driver is too old."),
-				      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
-				         Font support is limited here, so do not use advanced typography **/
-				      format(_("The %1$u version needs to be version %2$u.%3$u or newer."), descname,
-				              required_major_version, required_minor_version)));
+				          "The %u version needs to be version %u.%u or newer.",
+				          name, required_major_version, required_minor_version),
+				   format("%s\n%s",
+				          /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
+				             Font support is limited here, so do not use advanced typography **/
+				          _("Widelands won’t work because your graphics driver is too old."),
+				          /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
+				             Font support is limited here, so do not use advanced typography **/
+				          format(_("The %1$u version needs to be version %2$u.%3$u or newer."),
+				                 descname, required_major_version, required_minor_version)));
 			}
 		} else {
 			// We don't have a minor version. Ensure that the string to compare is a valid integer
@@ -228,8 +227,8 @@ SDL_GLContext initialize(
 				if (std::stol(version_string) < required_major_version + 1) {
 					show_opengl_error_and_exit(
 					   format("Widelands won’t work because your graphics driver is too old.\n"
-					           "The %s needs to be version %u.%u or newer.",
-					           name, required_major_version, required_minor_version),
+					          "The %s needs to be version %u.%u or newer.",
+					          name, required_major_version, required_minor_version),
 					   format(
 					      "%s\n%s",
 					      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
@@ -238,7 +237,7 @@ SDL_GLContext initialize(
 					      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
 					         Font support is limited here, so do not use advanced typography **/
 					      format(_("The %1$s needs to be version %2$u.%3$u or newer."), descname,
-					              required_major_version, required_minor_version)));
+					             required_major_version, required_minor_version)));
 				}
 			} else {
 				// We don't know how to interpret the version info

--- a/src/graphic/gl/initialize.cc
+++ b/src/graphic/gl/initialize.cc
@@ -166,7 +166,7 @@ SDL_GLContext initialize(
 		show_opengl_error_and_exit(
 		   "Widelands won't work because we were unable to detect the shading language version.\n"
 		   "There is an unknown problem with reading the information from the graphics driver.",
-		   bformat("%s\n%s",
+		   format("%s\n%s",
 		           /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
 		              support is limited here, so do not use advanced typography **/
 		           _("Widelands won't work because we were unable to detect the shading language "
@@ -180,7 +180,7 @@ SDL_GLContext initialize(
 		show_opengl_error_and_exit(
 		   "Widelands won't work because we were unable to detect the OpenGL version.\n"
 		   "There is an unknown problem with reading the information from the graphics driver.",
-		   bformat("%s\n%s",
+		   format("%s\n%s",
 		           /** TRANSLATORS: Basic error message when we can't handle the graphics driver. Font
 		              support is limited here, so do not use advanced typography **/
 		           _("Widelands won't work because we were unable to detect the OpenGL version."),
@@ -207,17 +207,17 @@ SDL_GLContext initialize(
 			if (major_version < required_major_version ||
 			    (major_version == required_major_version && minor_version < required_minor_version)) {
 				show_opengl_error_and_exit(
-				   bformat("Widelands won’t work because your graphics driver is too old.\n"
+				   format("Widelands won’t work because your graphics driver is too old.\n"
 				           "The %u version needs to be version %u.%u or newer.",
 				           name, required_major_version, required_minor_version),
-				   bformat(
+				   format(
 				      "%s\n%s",
 				      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
 				         Font support is limited here, so do not use advanced typography **/
 				      _("Widelands won’t work because your graphics driver is too old."),
 				      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
 				         Font support is limited here, so do not use advanced typography **/
-				      bformat(_("The %1$u version needs to be version %2$u.%3$u or newer."), descname,
+				      format(_("The %1$u version needs to be version %2$u.%3$u or newer."), descname,
 				              required_major_version, required_minor_version)));
 			}
 		} else {
@@ -227,17 +227,17 @@ SDL_GLContext initialize(
 			if (std::regex_match(version_string, re)) {
 				if (std::stol(version_string) < required_major_version + 1) {
 					show_opengl_error_and_exit(
-					   bformat("Widelands won’t work because your graphics driver is too old.\n"
+					   format("Widelands won’t work because your graphics driver is too old.\n"
 					           "The %s needs to be version %u.%u or newer.",
 					           name, required_major_version, required_minor_version),
-					   bformat(
+					   format(
 					      "%s\n%s",
 					      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
 					         Font support is limited here, so do not use advanced typography **/
 					      _("Widelands won’t work because your graphics driver is too old."),
 					      /** TRANSLATORS: Basic error message when we can't handle the graphics driver.
 					         Font support is limited here, so do not use advanced typography **/
-					      bformat(_("The %1$s needs to be version %2$u.%3$u or newer."), descname,
+					      format(_("The %1$s needs to be version %2$u.%3$u or newer."), descname,
 					              required_major_version, required_minor_version)));
 				}
 			} else {

--- a/src/graphic/style_manager.cc
+++ b/src/graphic/style_manager.cc
@@ -155,7 +155,7 @@ StyleManager::StyleManager() {
 	scrollbarstyles_.clear();
 
 	LuaInterface lua;
-	std::unique_ptr<LuaTable> table(lua.run_script(bformat("%1%init.lua", template_dir())));
+	std::unique_ptr<LuaTable> table(lua.run_script(format("%1%init.lua", template_dir())));
 
 	// Buttons
 	std::unique_ptr<LuaTable> element_table = table->get_table("buttons");
@@ -382,7 +382,7 @@ const RGBColor& StyleManager::minimap_icon_frame() const {
 }
 
 std::string StyleManager::color_tag(const std::string& text, const RGBColor& color) {
-	return bformat("<font color=%s>%s</font>", color.hex_value(), text);
+	return format("<font color=%s>%s</font>", color.hex_value(), text);
 }
 
 // Fill the maps

--- a/src/graphic/styles/font_style.cc
+++ b/src/graphic/styles/font_style.cc
@@ -92,7 +92,7 @@ std::string FontStyleInfo::as_font_tag(const std::string& text) const {
 		optionals += " underline=1";
 	}
 	return format("<font face=%s size=%d color=%s%s>%s</font>", face_to_string(), size_,
-	               color_.hex_value(), optionals, text);
+	              color_.hex_value(), optionals, text);
 }
 
 FontStyleInfo::Face FontStyleInfo::face() const {

--- a/src/graphic/styles/font_style.cc
+++ b/src/graphic/styles/font_style.cc
@@ -91,7 +91,7 @@ std::string FontStyleInfo::as_font_tag(const std::string& text) const {
 	if (underline_) {
 		optionals += " underline=1";
 	}
-	return bformat("<font face=%s size=%d color=%s%s>%s</font>", face_to_string(), size_,
+	return format("<font face=%s size=%d color=%s%s>%s</font>", face_to_string(), size_,
 	               color_.hex_value(), optionals, text);
 }
 

--- a/src/graphic/text/font_io.cc
+++ b/src/graphic/text/font_io.cc
@@ -50,7 +50,7 @@ IFont* load_font(const std::string& face, int ptsize) {
 
 	TTF_Font* font = TTF_OpenFontIndexRW(ops, true, ptsize, 0);
 	if (!font) {
-		throw BadFont(bformat("Font loading error for %s, %i pts: %s", face, ptsize, TTF_GetError()));
+		throw BadFont(format("Font loading error for %s, %i pts: %s", face, ptsize, TTF_GetError()));
 	}
 
 	return new SdlTtfFont(font, face, ptsize, memory.release());

--- a/src/graphic/text/font_set.cc
+++ b/src/graphic/text/font_set.cc
@@ -159,9 +159,9 @@ void FontSet::set_font_group(const LuaTable& table,
                              std::string* italic,
                              std::string* bold_italic) {
 	*basic = get_string_with_default(table, key, fallback);
-	*bold = get_string_with_default(table, bformat("%s_bold", key), *basic);
-	*italic = get_string_with_default(table, bformat("%s_italic", key), *basic);
-	*bold_italic = get_string_with_default(table, bformat("%s_bold_italic", key), *bold);
+	*bold = get_string_with_default(table, format("%s_bold", key), *basic);
+	*italic = get_string_with_default(table, format("%s_italic", key), *basic);
+	*bold_italic = get_string_with_default(table, format("%s_bold_italic", key), *bold);
 }
 
 FontSets::FontSets() {

--- a/src/graphic/text/rt_errors_impl.h
+++ b/src/graphic/text/rt_errors_impl.h
@@ -32,7 +32,7 @@ struct SyntaxErrorImpl : public SyntaxError {
 	                const std::string& got,
 	                const std::string& next_chars)
 	   : SyntaxError(
-	        bformat("Syntax error at %1%:%2%: expected %3%, got '%4%'. String continues with: '%5%'",
+	        format("Syntax error at %1%:%2%: expected %3%, got '%4%'. String continues with: '%5%'",
 	                line,
 	                col,
 	                expected,

--- a/src/graphic/text/rt_errors_impl.h
+++ b/src/graphic/text/rt_errors_impl.h
@@ -33,11 +33,11 @@ struct SyntaxErrorImpl : public SyntaxError {
 	                const std::string& next_chars)
 	   : SyntaxError(
 	        format("Syntax error at %1%:%2%: expected %3%, got '%4%'. String continues with: '%5%'",
-	                line,
-	                col,
-	                expected,
-	                got,
-	                next_chars)) {
+	               line,
+	               col,
+	               expected,
+	               got,
+	               next_chars)) {
 	}
 };
 }  // namespace RT

--- a/src/graphic/text/rt_parse.cc
+++ b/src/graphic/text/rt_parse.cc
@@ -53,7 +53,7 @@ bool Attr::get_bool() const {
 
 RGBColor Attr::get_color() const {
 	if (value_.size() != 6) {
-		throw InvalidColor(bformat("Could not parse '%s' as a color.", value_));
+		throw InvalidColor(format("Could not parse '%s' as a color.", value_));
 	}
 
 	uint32_t clrn = strtol(value_.c_str(), nullptr, 16);
@@ -117,7 +117,7 @@ void Tag::parse_closing_tag(TextStream& ts) {
 void Tag::parse_attribute(TextStream& ts, std::unordered_set<std::string>& allowed_attrs) {
 	std::string aname = ts.till_any("=");
 	if (!allowed_attrs.count(aname)) {
-		const std::string error_info = bformat("an allowed attribute for '%s' tag", name_);
+		const std::string error_info = format("an allowed attribute for '%s' tag", name_);
 		throw SyntaxErrorImpl(ts.line(), ts.col(), error_info, aname, ts.peek(100));
 	}
 

--- a/src/graphic/text/rt_render.cc
+++ b/src/graphic/text/rt_render.cc
@@ -284,7 +284,7 @@ protected:
 	void check_size(int check_w, int check_h) {
 		const int maximum_size = g_gr->max_texture_size_for_font_rendering();
 		if (check_w > maximum_size || check_h > maximum_size) {
-			const std::string error_message = bformat(
+			const std::string error_message = format(
 			   "Texture (%d, %d) too big! Maximum size is %d.", check_w, check_h, maximum_size);
 			log_err("%s\n", error_message.c_str());
 			throw TextureTooBig(error_message);
@@ -725,7 +725,7 @@ private:
 std::shared_ptr<UI::RenderedText> FillingTextNode::render(TextureCache* texture_cache) {
 	std::shared_ptr<UI::RenderedText> rendered_text(new UI::RenderedText());
 	const std::string hash =
-	   bformat("rt:fill:%s:%s:%i:%i:%i:%s", txt_, nodestyle_.font_color.hex_value(),
+	   format("rt:fill:%s:%s:%i:%i:%i:%s", txt_, nodestyle_.font_color.hex_value(),
 	           nodestyle_.font_style, width(), height(), (is_expanding_ ? "e" : "f"));
 
 	std::shared_ptr<const Image> rendered_image = texture_cache->get(hash);
@@ -765,7 +765,7 @@ public:
 	std::shared_ptr<UI::RenderedText> render(TextureCache* texture_cache) override {
 		if (show_spaces_) {
 			std::shared_ptr<UI::RenderedText> rendered_text(new UI::RenderedText());
-			const std::string hash = bformat("rt:wsp:%i:%i", width(), height());
+			const std::string hash = format("rt:wsp:%i:%i", width(), height());
 			std::shared_ptr<const Image> rendered_image = texture_cache->get(hash);
 			if (rendered_image == nullptr) {
 				auto texture = std::make_shared<Texture>(width(), height());
@@ -844,7 +844,7 @@ public:
 	std::shared_ptr<UI::RenderedText> render(TextureCache* texture_cache) override {
 		std::shared_ptr<UI::RenderedText> rendered_text(new UI::RenderedText());
 		const std::string hash =
-		   bformat("rt:sp:%s:%i:%i:%s", filename_, width(), height(), (is_expanding_ ? "e" : "f"));
+		   format("rt:sp:%s:%i:%i:%s", filename_, width(), height(), (is_expanding_ ? "e" : "f"));
 
 		std::shared_ptr<const Image> rendered_image = texture_cache->get(hash);
 		if (rendered_image == nullptr) {
@@ -1065,7 +1065,7 @@ std::shared_ptr<UI::RenderedText> ImgRenderNode::render(TextureCache* texture_ca
 		   std::unique_ptr<UI::RenderedRect>(new UI::RenderedRect(image_)));
 	} else {
 		const std::string hash =
-		   bformat("rt:img:%s:%s:%i:%i", filename_, (use_playercolor_ ? color_.hex_value() : ""),
+		   format("rt:img:%s:%s:%i:%i", filename_, (use_playercolor_ ? color_.hex_value() : ""),
 		           width(), height());
 		std::shared_ptr<const Image> rendered_image = texture_cache->get(hash);
 		if (rendered_image == nullptr) {
@@ -1760,7 +1760,7 @@ TagHandler* create_taghandler(Tag& tag,
 	TagHandlerMap::iterator i = map.find(tag.name());
 	if (i == map.end()) {
 		throw RenderError(
-		   bformat("No Tag handler for %s. This is a bug, please submit a report.", tag.name()));
+		   format("No Tag handler for %s. This is a bug, please submit a report.", tag.name()));
 	}
 	return i->second(tag, fc, ns, image_cache, renderer_style, fontsets);
 }

--- a/src/graphic/text/rt_render.cc
+++ b/src/graphic/text/rt_render.cc
@@ -284,8 +284,8 @@ protected:
 	void check_size(int check_w, int check_h) {
 		const int maximum_size = g_gr->max_texture_size_for_font_rendering();
 		if (check_w > maximum_size || check_h > maximum_size) {
-			const std::string error_message = format(
-			   "Texture (%d, %d) too big! Maximum size is %d.", check_w, check_h, maximum_size);
+			const std::string error_message =
+			   format("Texture (%d, %d) too big! Maximum size is %d.", check_w, check_h, maximum_size);
 			log_err("%s\n", error_message.c_str());
 			throw TextureTooBig(error_message);
 		}
@@ -726,7 +726,7 @@ std::shared_ptr<UI::RenderedText> FillingTextNode::render(TextureCache* texture_
 	std::shared_ptr<UI::RenderedText> rendered_text(new UI::RenderedText());
 	const std::string hash =
 	   format("rt:fill:%s:%s:%i:%i:%i:%s", txt_, nodestyle_.font_color.hex_value(),
-	           nodestyle_.font_style, width(), height(), (is_expanding_ ? "e" : "f"));
+	          nodestyle_.font_style, width(), height(), (is_expanding_ ? "e" : "f"));
 
 	std::shared_ptr<const Image> rendered_image = texture_cache->get(hash);
 	if (rendered_image == nullptr) {
@@ -1066,7 +1066,7 @@ std::shared_ptr<UI::RenderedText> ImgRenderNode::render(TextureCache* texture_ca
 	} else {
 		const std::string hash =
 		   format("rt:img:%s:%s:%i:%i", filename_, (use_playercolor_ ? color_.hex_value() : ""),
-		           width(), height());
+		          width(), height());
 		std::shared_ptr<const Image> rendered_image = texture_cache->get(hash);
 		if (rendered_image == nullptr) {
 			auto texture = std::make_shared<Texture>(width(), height());

--- a/src/graphic/text/sdl_ttf_font.cc
+++ b/src/graphic/text/sdl_ttf_font.cc
@@ -66,7 +66,7 @@ std::shared_ptr<const Image> SdlTtfFont::render(const std::string& txt,
                                                 TextureCache* texture_cache) {
 	const std::string hash =
 	   format("ttf:%s:%i:%s:%02x%02x%02x:%i", font_name_, ptsize_, txt, static_cast<int>(clr.r),
-	           static_cast<int>(clr.g), static_cast<int>(clr.b), style);
+	          static_cast<int>(clr.g), static_cast<int>(clr.b), style);
 	std::shared_ptr<const Image> rv = texture_cache->get(hash);
 	if (rv != nullptr) {
 		return rv;

--- a/src/graphic/text/sdl_ttf_font.cc
+++ b/src/graphic/text/sdl_ttf_font.cc
@@ -65,7 +65,7 @@ std::shared_ptr<const Image> SdlTtfFont::render(const std::string& txt,
                                                 int style,
                                                 TextureCache* texture_cache) {
 	const std::string hash =
-	   bformat("ttf:%s:%i:%s:%02x%02x%02x:%i", font_name_, ptsize_, txt, static_cast<int>(clr.r),
+	   format("ttf:%s:%i:%s:%02x%02x%02x:%i", font_name_, ptsize_, txt, static_cast<int>(clr.r),
 	           static_cast<int>(clr.g), static_cast<int>(clr.b), style);
 	std::shared_ptr<const Image> rv = texture_cache->get(hash);
 	if (rv != nullptr) {
@@ -130,7 +130,7 @@ std::shared_ptr<const Image> SdlTtfFont::render(const std::string& txt,
 	}
 
 	if (!text_surface) {
-		throw RenderError(bformat("Rendering '%s' gave the error: %s", txt, TTF_GetError()));
+		throw RenderError(format("Rendering '%s' gave the error: %s", txt, TTF_GetError()));
 	}
 
 	return texture_cache->insert(hash, std::make_shared<Texture>(text_surface));

--- a/src/graphic/text/textstream.cc
+++ b/src/graphic/text/textstream.cc
@@ -26,7 +26,7 @@ namespace RT {
 
 struct EndOfTextImpl : public EndOfText {
 	EndOfTextImpl(size_t pos, const std::string& text)
-	   : EndOfText(bformat("Unexpected End of Text, starting at %1%. Text is: '%2%'", pos, text)) {
+	   : EndOfText(format("Unexpected End of Text, starting at %1%. Text is: '%2%'", pos, text)) {
 	}
 };
 
@@ -77,7 +77,7 @@ void TextStream::expect(std::string n, bool skip_whitespace) {
 	}
 
 	if (peek(n.size()) != n) {
-		throw SyntaxErrorImpl(line_, col_, bformat("'%s'", n), peek(n.size()), peek(100));
+		throw SyntaxErrorImpl(line_, col_, format("'%s'", n), peek(n.size()), peek(100));
 	}
 	consume(n.size());
 }

--- a/src/graphic/text_layout.cc
+++ b/src/graphic/text_layout.cc
@@ -50,7 +50,7 @@ std::string as_richtext_paragraph(const std::string& text, UI::Align align) {
 		break;
 	}
 
-	return bformat("<rt><p align=%s>%s</p></rt>", alignment, text);
+	return format("<rt><p align=%s>%s</p></rt>", alignment, text);
 }
 }  // namespace
 
@@ -95,7 +95,7 @@ void newlines_to_richtext(std::string& text) {
 /// Bullet list item
 std::string as_listitem(const std::string& txt, UI::FontStyle style) {
 	const UI::FontStyleInfo& font_style = g_style_manager->font_style(style);
-	return bformat("<div width=100%%><div><p><font size=%d "
+	return format("<div width=100%%><div><p><font size=%d "
 	               "color=%s>•</font></p></div><div><p><space gap=6></p></div><div "
 	               "width=*><p><font size=%d color=%s>%s<vspace "
 	               "gap=6></font></p></div></div>",
@@ -104,7 +104,7 @@ std::string as_listitem(const std::string& txt, UI::FontStyle style) {
 }
 
 std::string as_richtext(const std::string& txt) {
-	return bformat("<rt>%s</rt>", txt);
+	return format("<rt>%s</rt>", txt);
 }
 
 std::string as_richtext_paragraph(const std::string& text, UI::FontStyle style, UI::Align align) {
@@ -117,11 +117,11 @@ as_richtext_paragraph(const std::string& text, const UI::FontStyleInfo& style, U
 }
 
 std::string as_editor_richtext_paragraph(const std::string& text, const UI::FontStyleInfo& style) {
-	return bformat("<rt keep_spaces=1><p>%s</p></rt>", style.as_font_tag(text));
+	return format("<rt keep_spaces=1><p>%s</p></rt>", style.as_font_tag(text));
 }
 
 std::string as_game_tip(const std::string& txt) {
-	return bformat("<rt><p align=center>%s</p></rt>",
+	return format("<rt><p align=center>%s</p></rt>",
 	               g_style_manager->font_style(UI::FontStyle::kFsMenuGameTip).as_font_tag(txt));
 }
 
@@ -133,13 +133,13 @@ std::string as_mapobject_message(const std::string& image,
 	assert(!txt.empty());
 	const std::string image_type = g_image_cache->has(image) ? "src" : "object";
 	if (player_color != nullptr) {
-		return bformat(
+		return format(
 		   "<div padding_r=10><p><img width=%d %s=%s color=%s></p></div>"
 		   "<div width=*><p>%s</p></div>",
 		   width, image_type, image, player_color->hex_value(),
 		   g_style_manager->font_style(UI::FontStyle::kWuiMessageParagraph).as_font_tag(txt));
 	} else {
-		return bformat(
+		return format(
 		   "<div padding_r=10><p><img width=%d %s=%s></p></div>"
 		   "<div width=*><p>%s</p></div>",
 		   width, image_type, image,
@@ -148,12 +148,12 @@ std::string as_mapobject_message(const std::string& image,
 }
 
 std::string as_message(const std::string& heading, const std::string& body) {
-	return (bformat(
+	return (format(
 	   "<rt><p>%s<br></p><vspace gap=6>%s</rt>",
 	   g_style_manager->font_style(UI::FontStyle::kWuiMessageHeading).as_font_tag(heading),
 	   (is_paragraph(body) || is_div(body) ?
           body :
-          bformat(
+          format(
 	          "<p>%s</p>",
 	          g_style_manager->font_style(UI::FontStyle::kWuiMessageParagraph).as_font_tag(body)))));
 }
@@ -184,13 +184,13 @@ std::string as_heading_with_content(const std::string& header,
                                     bool noescape) {
 	switch (style) {
 	case UI::PanelStyle::kFsMenu:
-		return bformat("<p>%s%s %s</p>", (is_first ? "" : "<vspace gap=9>"),
+		return format("<p>%s%s %s</p>", (is_first ? "" : "<vspace gap=9>"),
 		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
 		                  .as_font_tag(noescape ? header : richtext_escape(header)),
 		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 		                  .as_font_tag(noescape ? content : richtext_escape(content)));
 	case UI::PanelStyle::kWui:
-		return bformat("<p>%s%s %s</p>", (is_first ? "" : "<vspace gap=6>"),
+		return format("<p>%s%s %s</p>", (is_first ? "" : "<vspace gap=6>"),
 		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelHeading)
 		                  .as_font_tag(noescape ? header : richtext_escape(header)),
 		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelParagraph)
@@ -202,11 +202,11 @@ std::string as_heading_with_content(const std::string& header,
 std::string as_heading(const std::string& txt, UI::PanelStyle style, bool is_first) {
 	switch (style) {
 	case UI::PanelStyle::kFsMenu:
-		return bformat("<p>%s%s</p>", (is_first ? "" : "<vspace gap=9>"),
+		return format("<p>%s%s</p>", (is_first ? "" : "<vspace gap=9>"),
 		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
 		                  .as_font_tag(richtext_escape(txt)));
 	case UI::PanelStyle::kWui:
-		return bformat("<p>%s%s</p>", (is_first ? "" : "<vspace gap=6>"),
+		return format("<p>%s%s</p>", (is_first ? "" : "<vspace gap=6>"),
 		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelHeading)
 		                  .as_font_tag(richtext_escape(txt)));
 	}
@@ -216,11 +216,11 @@ std::string as_heading(const std::string& txt, UI::PanelStyle style, bool is_fir
 std::string as_content(const std::string& txt, UI::PanelStyle style) {
 	switch (style) {
 	case UI::PanelStyle::kFsMenu:
-		return bformat("<p><vspace gap=2>%s</p>",
+		return format("<p><vspace gap=2>%s</p>",
 		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 		                  .as_font_tag(richtext_escape(txt)));
 	case UI::PanelStyle::kWui:
-		return bformat("<p><vspace gap=2>%s</p>",
+		return format("<p><vspace gap=2>%s</p>",
 		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelParagraph)
 		                  .as_font_tag(richtext_escape(txt)));
 	}
@@ -230,7 +230,7 @@ std::string as_content(const std::string& txt, UI::PanelStyle style) {
 std::string as_tooltip_text_with_hotkey(const std::string& text,
                                         const std::string& hotkey,
                                         const UI::PanelStyle style) {
-	return bformat("<rt><p>%s %s</p></rt>",
+	return format("<rt><p>%s %s</p></rt>",
 	               g_style_manager
 	                  ->font_style(style == UI::PanelStyle::kWui ? UI::FontStyle::kWuiTooltip :
                                                                   UI::FontStyle::kFsTooltip)

--- a/src/graphic/text_layout.cc
+++ b/src/graphic/text_layout.cc
@@ -96,11 +96,11 @@ void newlines_to_richtext(std::string& text) {
 std::string as_listitem(const std::string& txt, UI::FontStyle style) {
 	const UI::FontStyleInfo& font_style = g_style_manager->font_style(style);
 	return format("<div width=100%%><div><p><font size=%d "
-	               "color=%s>•</font></p></div><div><p><space gap=6></p></div><div "
-	               "width=*><p><font size=%d color=%s>%s<vspace "
-	               "gap=6></font></p></div></div>",
-	               font_style.size(), font_style.color().hex_value(), font_style.size(),
-	               font_style.color().hex_value(), txt);
+	              "color=%s>•</font></p></div><div><p><space gap=6></p></div><div "
+	              "width=*><p><font size=%d color=%s>%s<vspace "
+	              "gap=6></font></p></div></div>",
+	              font_style.size(), font_style.color().hex_value(), font_style.size(),
+	              font_style.color().hex_value(), txt);
 }
 
 std::string as_richtext(const std::string& txt) {
@@ -122,7 +122,7 @@ std::string as_editor_richtext_paragraph(const std::string& text, const UI::Font
 
 std::string as_game_tip(const std::string& txt) {
 	return format("<rt><p align=center>%s</p></rt>",
-	               g_style_manager->font_style(UI::FontStyle::kFsMenuGameTip).as_font_tag(txt));
+	              g_style_manager->font_style(UI::FontStyle::kFsMenuGameTip).as_font_tag(txt));
 }
 
 std::string as_mapobject_message(const std::string& image,
@@ -185,16 +185,16 @@ std::string as_heading_with_content(const std::string& header,
 	switch (style) {
 	case UI::PanelStyle::kFsMenu:
 		return format("<p>%s%s %s</p>", (is_first ? "" : "<vspace gap=9>"),
-		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
-		                  .as_font_tag(noescape ? header : richtext_escape(header)),
-		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-		                  .as_font_tag(noescape ? content : richtext_escape(content)));
+		              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
+		                 .as_font_tag(noescape ? header : richtext_escape(header)),
+		              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+		                 .as_font_tag(noescape ? content : richtext_escape(content)));
 	case UI::PanelStyle::kWui:
 		return format("<p>%s%s %s</p>", (is_first ? "" : "<vspace gap=6>"),
-		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelHeading)
-		                  .as_font_tag(noescape ? header : richtext_escape(header)),
-		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelParagraph)
-		                  .as_font_tag(noescape ? content : richtext_escape(content)));
+		              g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelHeading)
+		                 .as_font_tag(noescape ? header : richtext_escape(header)),
+		              g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelParagraph)
+		                 .as_font_tag(noescape ? content : richtext_escape(content)));
 	}
 	NEVER_HERE();
 }
@@ -203,12 +203,12 @@ std::string as_heading(const std::string& txt, UI::PanelStyle style, bool is_fir
 	switch (style) {
 	case UI::PanelStyle::kFsMenu:
 		return format("<p>%s%s</p>", (is_first ? "" : "<vspace gap=9>"),
-		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
-		                  .as_font_tag(richtext_escape(txt)));
+		              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
+		                 .as_font_tag(richtext_escape(txt)));
 	case UI::PanelStyle::kWui:
 		return format("<p>%s%s</p>", (is_first ? "" : "<vspace gap=6>"),
-		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelHeading)
-		                  .as_font_tag(richtext_escape(txt)));
+		              g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelHeading)
+		                 .as_font_tag(richtext_escape(txt)));
 	}
 	NEVER_HERE();
 }
@@ -217,12 +217,12 @@ std::string as_content(const std::string& txt, UI::PanelStyle style) {
 	switch (style) {
 	case UI::PanelStyle::kFsMenu:
 		return format("<p><vspace gap=2>%s</p>",
-		               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-		                  .as_font_tag(richtext_escape(txt)));
+		              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+		                 .as_font_tag(richtext_escape(txt)));
 	case UI::PanelStyle::kWui:
 		return format("<p><vspace gap=2>%s</p>",
-		               g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelParagraph)
-		                  .as_font_tag(richtext_escape(txt)));
+		              g_style_manager->font_style(UI::FontStyle::kWuiInfoPanelParagraph)
+		                 .as_font_tag(richtext_escape(txt)));
 	}
 	NEVER_HERE();
 }
@@ -231,12 +231,12 @@ std::string as_tooltip_text_with_hotkey(const std::string& text,
                                         const std::string& hotkey,
                                         const UI::PanelStyle style) {
 	return format("<rt><p>%s %s</p></rt>",
-	               g_style_manager
-	                  ->font_style(style == UI::PanelStyle::kWui ? UI::FontStyle::kWuiTooltip :
-                                                                  UI::FontStyle::kFsTooltip)
-	                  .as_font_tag(text),
-	               g_style_manager
-	                  ->font_style(style == UI::PanelStyle::kWui ? UI::FontStyle::kWuiTooltipHotkey :
-                                                                  UI::FontStyle::kFsTooltipHotkey)
-	                  .as_font_tag("(" + hotkey + ")"));
+	              g_style_manager
+	                 ->font_style(style == UI::PanelStyle::kWui ? UI::FontStyle::kWuiTooltip :
+                                                                 UI::FontStyle::kFsTooltip)
+	                 .as_font_tag(text),
+	              g_style_manager
+	                 ->font_style(style == UI::PanelStyle::kWui ? UI::FontStyle::kWuiTooltipHotkey :
+                                                                 UI::FontStyle::kFsTooltipHotkey)
+	                 .as_font_tag("(" + hotkey + ")"));
 }

--- a/src/graphic/wordwrap.cc
+++ b/src/graphic/wordwrap.cc
@@ -39,7 +39,7 @@
 namespace {
 inline std::string as_editorfont(const std::string& text, int ptsize, const RGBColor& clr) {
 	// UI Text is always bold due to historic reasons
-	return bformat(
+	return format(
 	   "<rt keep_spaces=1><p><font face=sans size=%i bold=1 shadow=1 color=%s>%s</font></p></rt>",
 	   ptsize, clr.hex_value(), richtext_escape(text));
 }

--- a/src/io/filesystem/filesystem.cc
+++ b/src/io/filesystem/filesystem.cc
@@ -248,15 +248,15 @@ std::string FileSystem::illegal_filename_tooltip() {
 	   /** TRANSLATORS: Tooltip entry for characters in illegal filenames.
 	    *  %s is a list of illegal characters */
 	   format(pgettext("illegal_filename_characters", "%s at the start of the filename"),
-	           richtext_escape(i18n::localize_list(starting_characters, i18n::ConcatenateWith::OR))),
+	          richtext_escape(i18n::localize_list(starting_characters, i18n::ConcatenateWith::OR))),
 	   UI::FontStyle::kWuiMessageParagraph));
 
 	const std::string illegal(as_listitem(
 	   /** TRANSLATORS: Tooltip entry for characters in illegal filenames.
 	    * %s is a list of illegal characters */
 	   format(pgettext("illegal_filename_characters", "%s anywhere in the filename"),
-	           richtext_escape(
-	              i18n::localize_list(illegal_filename_characters, i18n::ConcatenateWith::OR))),
+	          richtext_escape(
+	             i18n::localize_list(illegal_filename_characters, i18n::ConcatenateWith::OR))),
 	   UI::FontStyle::kWuiMessageParagraph));
 
 	return format(

--- a/src/io/filesystem/filesystem.cc
+++ b/src/io/filesystem/filesystem.cc
@@ -119,7 +119,7 @@ bool NumberGlob::next(std::string* s) {
 
 	*s = template_;
 	if (max_) {
-		replace_last(*s, to_replace_, bformat(format_, current_));
+		replace_last(*s, to_replace_, format(format_, current_));
 	}
 	++current_;
 	return true;
@@ -247,19 +247,19 @@ std::string FileSystem::illegal_filename_tooltip() {
 	const std::string illegal_start(as_listitem(
 	   /** TRANSLATORS: Tooltip entry for characters in illegal filenames.
 	    *  %s is a list of illegal characters */
-	   bformat(pgettext("illegal_filename_characters", "%s at the start of the filename"),
+	   format(pgettext("illegal_filename_characters", "%s at the start of the filename"),
 	           richtext_escape(i18n::localize_list(starting_characters, i18n::ConcatenateWith::OR))),
 	   UI::FontStyle::kWuiMessageParagraph));
 
 	const std::string illegal(as_listitem(
 	   /** TRANSLATORS: Tooltip entry for characters in illegal filenames.
 	    * %s is a list of illegal characters */
-	   bformat(pgettext("illegal_filename_characters", "%s anywhere in the filename"),
+	   format(pgettext("illegal_filename_characters", "%s anywhere in the filename"),
 	           richtext_escape(
 	              i18n::localize_list(illegal_filename_characters, i18n::ConcatenateWith::OR))),
 	   UI::FontStyle::kWuiMessageParagraph));
 
-	return bformat(
+	return format(
 	   "%s%s%s",
 	   /** TRANSLATORS: Tooltip header for characters in illegal filenames.
 	    * This is followed by a list of bullet points */

--- a/src/io/filesystem/zip_filesystem.cc
+++ b/src/io/filesystem/zip_filesystem.cc
@@ -415,7 +415,7 @@ void* ZipFilesystem::load(const std::string& fname, size_t& length) {
 		}
 		if (len < 0) {
 			unzCloseCurrentFile(zip_file_->read_handle());
-			const std::string errormessage = bformat("read error %i", len);
+			const std::string errormessage = format("read error %i", len);
 			throw ZipOperationError("ZipFilesystem::load", fname, zip_file_->path(), errormessage);
 		}
 
@@ -469,10 +469,10 @@ void ZipFilesystem::write(const std::string& fname, void const* const data, size
 		break;
 	case ZIP_ERRNO:
 		throw FileError("ZipFilesystem::write", complete_filename,
-		                bformat("in path '%s'', Error", zip_file_->path(), strerror(errno)));
+		                format("in path '%s'', Error", zip_file_->path(), strerror(errno)));
 	default:
 		throw FileError(
-		   "ZipFilesystem::write", complete_filename, bformat("in path '%s'", zip_file_->path()));
+		   "ZipFilesystem::write", complete_filename, format("in path '%s'", zip_file_->path()));
 	}
 
 	zipCloseFileInZip(zip_file_->write_handle());

--- a/src/logic/addons.cc
+++ b/src/logic/addons.cc
@@ -102,7 +102,7 @@ std::string version_to_string(const AddOnVersion& version, const bool localize) 
 		if (s.empty()) {
 			s = std::to_string(v);
 		} else if (localize) {
-			s = bformat(_("%1$s.%2$u"), s, v);
+			s = format(_("%1$s.%2$u"), s, v);
 		} else {
 			s += '.';
 			s += std::to_string(v);
@@ -175,17 +175,17 @@ static AddOnConflict check_requirements_conflicts(const AddOnRequirements& requi
 			for (const auto& a : addons_wrong_version) {
 				if (list.empty()) {
 					list =
-					   bformat(_("%1$s (expected version %2$s, found %3$s)"), a.first,
+					   format(_("%1$s (expected version %2$s, found %3$s)"), a.first,
 					           version_to_string(a.second.second), version_to_string(a.second.first));
 				} else {
 					list =
-					   bformat(_("%1$s, %2$s (expected version %3$s, found %4$s)"), list, a.first,
+					   format(_("%1$s, %2$s (expected version %3$s, found %4$s)"), list, a.first,
 					           version_to_string(a.second.second), version_to_string(a.second.first));
 				}
 			}
 			// Wrong versions might work, so do not forbid loading
 			return std::make_pair(
-			   bformat(ngettext("%1$u add-on with wrong version: %2$s",
+			   format(ngettext("%1$u add-on with wrong version: %2$s",
 			                    "%1$u add-ons with wrong version: %2$s", addons_wrong_version.size()),
 			           addons_wrong_version.size(), list),
 			   false);
@@ -197,11 +197,11 @@ static AddOnConflict check_requirements_conflicts(const AddOnRequirements& requi
 				if (list.empty()) {
 					list = a;
 				} else {
-					list = bformat(_("%1$s, %2$s"), list, a);
+					list = format(_("%1$s, %2$s"), list, a);
 				}
 			}
 			return std::make_pair(
-			   bformat(ngettext("%1$u missing add-on: %2$s", "%1$u missing add-ons: %2$s",
+			   format(ngettext("%1$u missing add-on: %2$s", "%1$u missing add-ons: %2$s",
 			                    addons_missing.size()),
 			           addons_missing.size(), list),
 			   true);
@@ -209,21 +209,21 @@ static AddOnConflict check_requirements_conflicts(const AddOnRequirements& requi
 			std::string list;
 			for (const std::string& a : addons_missing) {
 				if (list.empty()) {
-					list = bformat(_("%s (missing)"), a);
+					list = format(_("%s (missing)"), a);
 				} else {
-					list = bformat(_("%1$s, %2$s (missing)"), list, a);
+					list = format(_("%1$s, %2$s (missing)"), list, a);
 				}
 			}
 			for (const auto& a : addons_wrong_version) {
-				list = bformat(_("%1$s, %2$s (expected version %3$s, found %4$s)"), list, a.first,
+				list = format(_("%1$s, %2$s (expected version %3$s, found %4$s)"), list, a.first,
 				               version_to_string(a.second.second), version_to_string(a.second.first));
 			}
 			return std::make_pair(
-			   bformat(
+			   format(
 			      _("%1$s and %2$s: %3$s"),
-			      bformat(ngettext("%u missing add-on", "%u missing add-ons", addons_missing.size()),
+			      format(ngettext("%u missing add-on", "%u missing add-ons", addons_missing.size()),
 			              addons_missing.size()),
-			      bformat(ngettext("%u add-on with wrong version", "%u add-ons with wrong version",
+			      format(ngettext("%u add-on with wrong version", "%u add-ons with wrong version",
 			                       addons_missing.size()),
 			              addons_missing.size()),
 			      list),
@@ -240,7 +240,7 @@ AddOnConflict check_requirements(const AddOnRequirements& required_addons) {
 	}
 	AddOnConflict result = check_requirements_conflicts(required_addons);
 	for (const auto& pair : required_addons) {
-		result.first = bformat(_("%1$s<br>· %2$s (version %3$s)"), result.first, pair.first,
+		result.first = format(_("%1$s<br>· %2$s (version %3$s)"), result.first, pair.first,
 		                       version_to_string(pair.second));
 	}
 	return result;

--- a/src/logic/addons.cc
+++ b/src/logic/addons.cc
@@ -174,20 +174,18 @@ static AddOnConflict check_requirements_conflicts(const AddOnRequirements& requi
 			std::string list;
 			for (const auto& a : addons_wrong_version) {
 				if (list.empty()) {
-					list =
-					   format(_("%1$s (expected version %2$s, found %3$s)"), a.first,
-					           version_to_string(a.second.second), version_to_string(a.second.first));
+					list = format(_("%1$s (expected version %2$s, found %3$s)"), a.first,
+					              version_to_string(a.second.second), version_to_string(a.second.first));
 				} else {
-					list =
-					   format(_("%1$s, %2$s (expected version %3$s, found %4$s)"), list, a.first,
-					           version_to_string(a.second.second), version_to_string(a.second.first));
+					list = format(_("%1$s, %2$s (expected version %3$s, found %4$s)"), list, a.first,
+					              version_to_string(a.second.second), version_to_string(a.second.first));
 				}
 			}
 			// Wrong versions might work, so do not forbid loading
 			return std::make_pair(
 			   format(ngettext("%1$u add-on with wrong version: %2$s",
-			                    "%1$u add-ons with wrong version: %2$s", addons_wrong_version.size()),
-			           addons_wrong_version.size(), list),
+			                   "%1$u add-ons with wrong version: %2$s", addons_wrong_version.size()),
+			          addons_wrong_version.size(), list),
 			   false);
 		}
 	} else {
@@ -200,11 +198,10 @@ static AddOnConflict check_requirements_conflicts(const AddOnRequirements& requi
 					list = format(_("%1$s, %2$s"), list, a);
 				}
 			}
-			return std::make_pair(
-			   format(ngettext("%1$u missing add-on: %2$s", "%1$u missing add-ons: %2$s",
-			                    addons_missing.size()),
-			           addons_missing.size(), list),
-			   true);
+			return std::make_pair(format(ngettext("%1$u missing add-on: %2$s",
+			                                      "%1$u missing add-ons: %2$s", addons_missing.size()),
+			                             addons_missing.size(), list),
+			                      true);
 		} else {
 			std::string list;
 			for (const std::string& a : addons_missing) {
@@ -216,16 +213,16 @@ static AddOnConflict check_requirements_conflicts(const AddOnRequirements& requi
 			}
 			for (const auto& a : addons_wrong_version) {
 				list = format(_("%1$s, %2$s (expected version %3$s, found %4$s)"), list, a.first,
-				               version_to_string(a.second.second), version_to_string(a.second.first));
+				              version_to_string(a.second.second), version_to_string(a.second.first));
 			}
 			return std::make_pair(
 			   format(
 			      _("%1$s and %2$s: %3$s"),
 			      format(ngettext("%u missing add-on", "%u missing add-ons", addons_missing.size()),
-			              addons_missing.size()),
+			             addons_missing.size()),
 			      format(ngettext("%u add-on with wrong version", "%u add-ons with wrong version",
-			                       addons_missing.size()),
-			              addons_missing.size()),
+			                      addons_missing.size()),
+			             addons_missing.size()),
 			      list),
 			   true);
 		}
@@ -241,7 +238,7 @@ AddOnConflict check_requirements(const AddOnRequirements& required_addons) {
 	AddOnConflict result = check_requirements_conflicts(required_addons);
 	for (const auto& pair : required_addons) {
 		result.first = format(_("%1$s<br>· %2$s (version %3$s)"), result.first, pair.first,
-		                       version_to_string(pair.second));
+		                      version_to_string(pair.second));
 	}
 	return result;
 }

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -249,7 +249,7 @@ Player* EditorGameBase::add_player(PlayerNumber const player_number,
                                    const std::string& name,
                                    TeamNumber team) {
 	Notifications::publish(UI::NoteLoadingMessage(
-	   bformat(_("Creating player %d…"), static_cast<unsigned int>(player_number))));
+	   format(_("Creating player %d…"), static_cast<unsigned int>(player_number))));
 	return player_manager_->add_player(player_number, initialization_index, pc, tribe, name, team);
 }
 

--- a/src/logic/game_data_error.cc
+++ b/src/logic/game_data_error.cc
@@ -40,7 +40,7 @@ GameDataError::GameDataError(char const* const fmt, ...) {
 UnhandledVersionError::UnhandledVersionError(const char* packet_name,
                                              int32_t packet_version,
                                              int32_t current_packet_version) {
-	what_ = bformat(
+	what_ = format(
 	   "\n\nUnhandledVersionError: %s\n\nPacket Name: %s\nSaved Version: %i\nCurrent "
 	   "Version: %i",
 	   _("This game was saved using an older version of Widelands and cannot be loaded anymore, "

--- a/src/logic/generic_save_handler.cc
+++ b/src/logic/generic_save_handler.cc
@@ -70,7 +70,7 @@ void GenericSaveHandler::make_backup() {
 			error_ |= Error::kBackupFailed;
 			uint32_t index = get_index(Error::kBackupFailed);
 			error_msg_[index] =
-			   bformat("GenericSaveHandler::make_backup: %s: for all "
+			   format("GenericSaveHandler::make_backup: %s: for all "
 			           "considered filenames a file already existed (last filename tried "
 			           "was %s)\n",
 			           complete_filename_.c_str(), backup_filename_);
@@ -85,7 +85,7 @@ void GenericSaveHandler::make_backup() {
 	} catch (const FileError& e) {
 		error_ |= Error::kBackupFailed;
 		uint32_t index = get_index(Error::kBackupFailed);
-		error_msg_[index] = bformat("GenericSaveHandler::make_backup: file %s "
+		error_msg_[index] = format("GenericSaveHandler::make_backup: file %s "
 		                            "could not be renamed to %s: %s\n",
 		                            complete_filename_.c_str(), backup_filename_, e.what());
 		log_err("%s", error_msg_[index].c_str());
@@ -101,7 +101,7 @@ void GenericSaveHandler::save_file() {
 	} catch (const std::exception& e) {
 		error_ |= Error::kSavingDataFailed;
 		uint32_t index = get_index(Error::kSavingDataFailed);
-		error_msg_[index] = bformat("GenericSaveHandler::save_file: data could not be "
+		error_msg_[index] = format("GenericSaveHandler::save_file: data could not be "
 		                            "written to file %s: %s\n",
 		                            complete_filename_.c_str(), e.what());
 		log_err("%s", error_msg_[index].c_str());
@@ -115,7 +115,7 @@ void GenericSaveHandler::save_file() {
 			} catch (const FileError& e) {
 				error_ |= Error::kCorruptFileLeft;
 				uint32_t index = get_index(Error::kCorruptFileLeft);
-				error_msg_[index] = bformat("GenericSaveHandler::save_file: possibly corrupt "
+				error_msg_[index] = format("GenericSaveHandler::save_file: possibly corrupt "
 				                            "file %s could not be deleted: %s\n",
 				                            complete_filename_.c_str(), e.what());
 				log_err("%s", error_msg_[index].c_str());
@@ -135,7 +135,7 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 		} catch (const FileError& e) {
 			error_ |= Error::kCreatingDirFailed;
 			uint32_t index = get_index(Error::kCreatingDirFailed);
-			error_msg_[index] = bformat("GenericSaveHandler::save: directory %s could not be "
+			error_msg_[index] = format("GenericSaveHandler::save: directory %s could not be "
 			                            "created: %s\n",
 			                            dir_.c_str(), e.what());
 			log_err("%s", error_msg_[index].c_str());
@@ -162,7 +162,7 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 				} catch (const FileError& e) {
 					error_ |= Error::kDeletingBackupFailed;
 					uint32_t index = get_index(Error::kDeletingBackupFailed);
-					error_msg_[index] = bformat("GenericSaveHandler::save: backup file %s could "
+					error_msg_[index] = format("GenericSaveHandler::save: backup file %s could "
 					                            "not be deleted: %s\n",
 					                            backup_filename_.c_str(), e.what());
 					log_err("%s", error_msg_[index].c_str());
@@ -172,7 +172,7 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 				if ((error_ & Error::kCorruptFileLeft) != Error::kNone) {
 					error_ |= Error::kRestoringBackupFailed;
 					uint32_t index = get_index(Error::kRestoringBackupFailed);
-					error_msg_[index] = bformat("GenericSaveHandler::save: file %s could not be "
+					error_msg_[index] = format("GenericSaveHandler::save: file %s could not be "
 					                            "restored from backup %s: file still exists\n",
 					                            complete_filename_.c_str(), backup_filename_.c_str());
 					log_err("%s", error_msg_[index].c_str());
@@ -184,7 +184,7 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 						error_ |= Error::kRestoringBackupFailed;
 						uint32_t index = get_index(Error::kRestoringBackupFailed);
 						error_msg_[index] =
-						   bformat("GenericSaveHandler::save: file %s could not "
+						   format("GenericSaveHandler::save: file %s could not "
 						           "be restored from backup %s: %s\n",
 						           backup_filename_.c_str(), backup_filename_.c_str(), e.what());
 						log_err("%s", error_msg_[index].c_str());
@@ -196,7 +196,7 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 	} catch (const std::exception& e) {
 		error_ |= Error::kUnexpectedError;
 		uint32_t index = get_index(Error::kUnexpectedError);
-		error_msg_[index] = bformat("GenericSaveHandler::save: unknown error: %s\n", e.what());
+		error_msg_[index] = format("GenericSaveHandler::save: unknown error: %s\n", e.what());
 		log_err("%s", error_msg_[index].c_str());
 	}
 
@@ -223,21 +223,21 @@ std::string GenericSaveHandler::localized_formatted_result_message() {
 
 	if (error_ == Error::kDeletingBackupFailed) {
 		return std::string(_("File successfully saved!")) + "\n" +
-		       bformat(_("Backup file ‘%s’ could not be deleted."), backup_filename_);
+		       format(_("Backup file ‘%s’ could not be deleted."), backup_filename_);
 	}
 
 	if (error_ == Error::kCreatingDirFailed) {
-		return bformat(_("Directory ‘%s’ could not be created!"), dir_);
+		return format(_("Directory ‘%s’ could not be created!"), dir_);
 	}
 
 	if (error_ == Error::kBackupFailed) {
-		return bformat(_("File ‘%s’ could not be removed!"), complete_filename_) + "\n" +
+		return format(_("File ‘%s’ could not be removed!"), complete_filename_) + "\n" +
 		       _("Try saving under a different name!");
 	}
 
 	// from here on multiple errors might have occurred
 	if ((error_ & Error::kSavingDataFailed) != Error::kNone) {
-		msg = bformat(_("Error writing data to file ‘%s’!"), complete_filename_);
+		msg = format(_("Error writing data to file ‘%s’!"), complete_filename_);
 	}
 
 	if ((error_ & Error::kCorruptFileLeft) != Error::kNone) {
@@ -251,8 +251,8 @@ std::string GenericSaveHandler::localized_formatted_result_message() {
 		if (!msg.empty()) {
 			msg += '\n';
 		}
-		msg += bformat(_("File ‘%s’ could not be restored!"), complete_filename_) + "\n" +
-		       bformat(_("Backup file ‘%s’ will be available for some time."), backup_filename_);
+		msg += format(_("File ‘%s’ could not be restored!"), complete_filename_) + "\n" +
+		       format(_("Backup file ‘%s’ will be available for some time."), backup_filename_);
 	}
 
 	if (!backup_filename_.empty() && ((error_ & Error::kSavingDataFailed) != Error::kNone) &&
@@ -261,7 +261,7 @@ std::string GenericSaveHandler::localized_formatted_result_message() {
 		if (!msg.empty()) {
 			msg += '\n';
 		}
-		msg += bformat(_("File ‘%s’ was restored from backup."), complete_filename_);
+		msg += format(_("File ‘%s’ was restored from backup."), complete_filename_);
 	}
 
 	if ((error_ & Error::kUnexpectedError) != Error::kNone) {

--- a/src/logic/generic_save_handler.cc
+++ b/src/logic/generic_save_handler.cc
@@ -71,9 +71,9 @@ void GenericSaveHandler::make_backup() {
 			uint32_t index = get_index(Error::kBackupFailed);
 			error_msg_[index] =
 			   format("GenericSaveHandler::make_backup: %s: for all "
-			           "considered filenames a file already existed (last filename tried "
-			           "was %s)\n",
-			           complete_filename_.c_str(), backup_filename_);
+			          "considered filenames a file already existed (last filename tried "
+			          "was %s)\n",
+			          complete_filename_.c_str(), backup_filename_);
 			log_err("%s", error_msg_[index].c_str());
 			return;
 		}
@@ -86,8 +86,8 @@ void GenericSaveHandler::make_backup() {
 		error_ |= Error::kBackupFailed;
 		uint32_t index = get_index(Error::kBackupFailed);
 		error_msg_[index] = format("GenericSaveHandler::make_backup: file %s "
-		                            "could not be renamed to %s: %s\n",
-		                            complete_filename_.c_str(), backup_filename_, e.what());
+		                           "could not be renamed to %s: %s\n",
+		                           complete_filename_.c_str(), backup_filename_, e.what());
 		log_err("%s", error_msg_[index].c_str());
 		return;
 	}
@@ -102,8 +102,8 @@ void GenericSaveHandler::save_file() {
 		error_ |= Error::kSavingDataFailed;
 		uint32_t index = get_index(Error::kSavingDataFailed);
 		error_msg_[index] = format("GenericSaveHandler::save_file: data could not be "
-		                            "written to file %s: %s\n",
-		                            complete_filename_.c_str(), e.what());
+		                           "written to file %s: %s\n",
+		                           complete_filename_.c_str(), e.what());
 		log_err("%s", error_msg_[index].c_str());
 	}
 
@@ -116,8 +116,8 @@ void GenericSaveHandler::save_file() {
 				error_ |= Error::kCorruptFileLeft;
 				uint32_t index = get_index(Error::kCorruptFileLeft);
 				error_msg_[index] = format("GenericSaveHandler::save_file: possibly corrupt "
-				                            "file %s could not be deleted: %s\n",
-				                            complete_filename_.c_str(), e.what());
+				                           "file %s could not be deleted: %s\n",
+				                           complete_filename_.c_str(), e.what());
 				log_err("%s", error_msg_[index].c_str());
 			}
 		}
@@ -136,8 +136,8 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 			error_ |= Error::kCreatingDirFailed;
 			uint32_t index = get_index(Error::kCreatingDirFailed);
 			error_msg_[index] = format("GenericSaveHandler::save: directory %s could not be "
-			                            "created: %s\n",
-			                            dir_.c_str(), e.what());
+			                           "created: %s\n",
+			                           dir_.c_str(), e.what());
 			log_err("%s", error_msg_[index].c_str());
 			return error_;
 		}
@@ -163,8 +163,8 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 					error_ |= Error::kDeletingBackupFailed;
 					uint32_t index = get_index(Error::kDeletingBackupFailed);
 					error_msg_[index] = format("GenericSaveHandler::save: backup file %s could "
-					                            "not be deleted: %s\n",
-					                            backup_filename_.c_str(), e.what());
+					                           "not be deleted: %s\n",
+					                           backup_filename_.c_str(), e.what());
 					log_err("%s", error_msg_[index].c_str());
 				}
 
@@ -173,8 +173,8 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 					error_ |= Error::kRestoringBackupFailed;
 					uint32_t index = get_index(Error::kRestoringBackupFailed);
 					error_msg_[index] = format("GenericSaveHandler::save: file %s could not be "
-					                            "restored from backup %s: file still exists\n",
-					                            complete_filename_.c_str(), backup_filename_.c_str());
+					                           "restored from backup %s: file still exists\n",
+					                           complete_filename_.c_str(), backup_filename_.c_str());
 					log_err("%s", error_msg_[index].c_str());
 				} else {
 					// Restore backup.
@@ -185,8 +185,8 @@ GenericSaveHandler::Error GenericSaveHandler::save() {
 						uint32_t index = get_index(Error::kRestoringBackupFailed);
 						error_msg_[index] =
 						   format("GenericSaveHandler::save: file %s could not "
-						           "be restored from backup %s: %s\n",
-						           backup_filename_.c_str(), backup_filename_.c_str(), e.what());
+						          "be restored from backup %s: %s\n",
+						          backup_filename_.c_str(), backup_filename_.c_str(), e.what());
 						log_err("%s", error_msg_[index].c_str());
 					}
 				}

--- a/src/logic/map_objects/immovable.cc
+++ b/src/logic/map_objects/immovable.cc
@@ -500,7 +500,7 @@ void Immovable::draw_construction(const Time& gametime,
 	// Additionally, if statistics are enabled, draw a progression string
 	do_draw_info(
 	   info_to_draw, descr().descname(),
-	   StyleManager::color_tag(bformat(_("%i%% built"), (done.get() * 100 / total.get())),
+	   StyleManager::color_tag(format(_("%i%% built"), (done.get() * 100 / total.get())),
 	                           g_style_manager->building_statistics_style().construction_color()),
 	   point_on_dst, scale, dst);
 }

--- a/src/logic/map_objects/tribes/constructionsite.cc
+++ b/src/logic/map_objects/tribes/constructionsite.cc
@@ -172,7 +172,7 @@ ConstructionSite::ConstructionSite(const ConstructionSiteDescr& cs_descr)
 
 void ConstructionSite::update_statistics_string(std::string* s) {
 	unsigned int percent = (get_built_per64k() * 100) >> 16;
-	*s = StyleManager::color_tag(bformat(_("%i%% built"), percent),
+	*s = StyleManager::color_tag(format(_("%i%% built"), percent),
 	                             g_style_manager->building_statistics_style().construction_color());
 }
 

--- a/src/logic/map_objects/tribes/dismantlesite.cc
+++ b/src/logic/map_objects/tribes/dismantlesite.cc
@@ -115,7 +115,7 @@ Print completion percentage.
 */
 void DismantleSite::update_statistics_string(std::string* s) {
 	unsigned int percent = (get_built_per64k() * 100) >> 16;
-	*s = StyleManager::color_tag(bformat(_("%u%% dismantled"), percent),
+	*s = StyleManager::color_tag(format(_("%u%% dismantled"), percent),
 	                             g_style_manager->building_statistics_style().construction_color());
 }
 

--- a/src/logic/map_objects/tribes/militarysite.cc
+++ b/src/logic/map_objects/tribes/militarysite.cc
@@ -416,21 +416,21 @@ void MilitarySite::update_statistics_string(std::string* s) {
 			if (s->empty()) {
 				/** TRANSLATORS: %1% is the number of soldiers the plural refers to. %2% is the maximum
 				 * number of soldier slots in the building */
-				*s = bformat(ngettext("%1% soldier (+%2%)", "%1% soldiers (+%2%)", stationed),
+				*s = format(ngettext("%1% soldier (+%2%)", "%1% soldiers (+%2%)", stationed),
 				             stationed, (capacity_ - stationed));
 			}
 		} else {
 			*s = read_capacity_string(present, stationed, 1);
 			if (s->empty()) {
 				/** TRANSLATORS: Number of soldiers stationed at a militarysite. */
-				*s = bformat(ngettext("%1% soldier", "%1% soldiers", stationed), stationed);
+				*s = format(ngettext("%1% soldier", "%1% soldiers", stationed), stationed);
 			}
 		}
 	} else {
 		if (capacity_ > stationed) {
 			*s = read_capacity_string(present, stationed, 2);
 			if (s->empty()) {
-				*s = bformat(
+				*s = format(
 				   /** TRANSLATORS: %1% is the number of soldiers the plural refers to. %2% are
 				      currently open soldier slots in the building. %3% is the maximum number of
 				      soldier slots in the building */
@@ -442,7 +442,7 @@ void MilitarySite::update_statistics_string(std::string* s) {
 			if (s->empty()) {
 				/** TRANSLATORS: %1% is the number of soldiers the plural refers to. %2% are currently
 				 * open soldier slots in the building */
-				*s = bformat(ngettext("%1%(+%2%) soldier", "%1%(+%2%) soldiers", stationed), present,
+				*s = format(ngettext("%1%(+%2%) soldier", "%1%(+%2%) soldiers", stationed), present,
 				             (stationed - present));
 			}
 		}

--- a/src/logic/map_objects/tribes/militarysite.cc
+++ b/src/logic/map_objects/tribes/militarysite.cc
@@ -416,8 +416,8 @@ void MilitarySite::update_statistics_string(std::string* s) {
 			if (s->empty()) {
 				/** TRANSLATORS: %1% is the number of soldiers the plural refers to. %2% is the maximum
 				 * number of soldier slots in the building */
-				*s = format(ngettext("%1% soldier (+%2%)", "%1% soldiers (+%2%)", stationed),
-				             stationed, (capacity_ - stationed));
+				*s = format(ngettext("%1% soldier (+%2%)", "%1% soldiers (+%2%)", stationed), stationed,
+				            (capacity_ - stationed));
 			}
 		} else {
 			*s = read_capacity_string(present, stationed, 1);
@@ -443,7 +443,7 @@ void MilitarySite::update_statistics_string(std::string* s) {
 				/** TRANSLATORS: %1% is the number of soldiers the plural refers to. %2% are currently
 				 * open soldier slots in the building */
 				*s = format(ngettext("%1%(+%2%) soldier", "%1%(+%2%) soldiers", stationed), present,
-				             (stationed - present));
+				            (stationed - present));
 			}
 		}
 	}

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -452,7 +452,7 @@ bool ProductionProgram::ActReturn::EconomyNeedsWare::evaluate(const ProductionSi
 }
 std::string ProductionProgram::ActReturn::EconomyNeedsWare::description(
    const Descriptions& descriptions) const {
-	std::string result = bformat(
+	std::string result = format(
 	   /** TRANSLATORS: e.g. Completed/Skipped/Did not start ... because the economy needs the ware
 	    * '%s' */
 	   _("the economy needs the ware ‘%s’"), descriptions.get_ware_descr(ware_type)->descname());
@@ -462,7 +462,7 @@ std::string ProductionProgram::ActReturn::EconomyNeedsWare::description_negation
    const Descriptions& descriptions) const {
 	/** TRANSLATORS: e.g. Completed/Skipped/Did not start ... because the economy doesn't need the
 	 * ware '%s' */
-	std::string result = bformat(_("the economy doesn’t need the ware ‘%s’"),
+	std::string result = format(_("the economy doesn’t need the ware ‘%s’"),
 	                             descriptions.get_ware_descr(ware_type)->descname());
 	return result;
 }
@@ -474,7 +474,7 @@ std::string ProductionProgram::ActReturn::EconomyNeedsWorker::description(
    const Descriptions& descriptions) const {
 	/** TRANSLATORS: e.g. Completed/Skipped/Did not start ... because the economy needs the worker
 	 * '%s' */
-	std::string result = bformat(_("the economy needs the worker ‘%s’"),
+	std::string result = format(_("the economy needs the worker ‘%s’"),
 	                             descriptions.get_worker_descr(worker_type)->descname());
 	return result;
 }
@@ -483,7 +483,7 @@ std::string ProductionProgram::ActReturn::EconomyNeedsWorker::description_negati
    const Descriptions& descriptions) const {
 	/** TRANSLATORS: e.g. Completed/Skipped/Did not start ... */
 	/** TRANSLATORS:      ... because the economy doesn’t need the worker '%s' */
-	std::string result = bformat(_("the economy doesn’t need the worker ‘%s’"),
+	std::string result = format(_("the economy doesn’t need the worker ‘%s’"),
 	                             descriptions.get_worker_descr(worker_type)->descname());
 	return result;
 }
@@ -532,12 +532,12 @@ ProductionProgram::ActReturn::SiteHas::description(const Descriptions& descripti
 		   /** TRANSLATORS: This is an item in a list of wares, e.g. "3x water": */
 		   /** TRANSLATORS:    %1$i = "3" */
 		   /** TRANSLATORS:    %2$s = "water" */
-		   bformat(_("%1$ix %2$s"), static_cast<unsigned int>(group.second), condition);
+		   format(_("%1$ix %2$s"), static_cast<unsigned int>(group.second), condition);
 	}
 
 	std::string result =
 	   /** TRANSLATORS: %s is a list of wares*/
-	   bformat(_("the building has the following wares: %s"), condition);
+	   format(_("the building has the following wares: %s"), condition);
 	return result;
 }
 
@@ -555,12 +555,12 @@ std::string ProductionProgram::ActReturn::SiteHas::description_negation(
 		   /** TRANSLATORS: This is an item in a list of wares, e.g. "3x water": */
 		   /** TRANSLATORS:    %1$i = "3" */
 		   /** TRANSLATORS:    %2$s = "water" */
-		   bformat(_("%1$ix %2$s"), static_cast<unsigned int>(group.second), condition);
+		   format(_("%1$ix %2$s"), static_cast<unsigned int>(group.second), condition);
 	}
 
 	std::string result =
 	   /** TRANSLATORS: %s is a list of wares*/
-	   bformat(_("the building doesn’t have the following wares: %s"), condition);
+	   format(_("the building doesn’t have the following wares: %s"), condition);
 	return result;
 }
 
@@ -712,22 +712,22 @@ void ProductionProgram::ActReturn::execute(Game& game, ProductionSite& ps) const
 		switch (result_) {
 		case ProgramResult::kFailed: {
 			/** TRANSLATORS: "Did not start working because the economy needs the ware '%s'" */
-			result_string = bformat(_("Did not start %1$s because %2$s"),
+			result_string = format(_("Did not start %1$s because %2$s"),
 			                        ps.top_state().program->descname(), condition_string);
 		} break;
 		case ProgramResult::kCompleted: {
-			result_string = bformat(
+			result_string = format(
 			   /** TRANSLATORS: "Completed working because the economy needs the ware '%s'" */
 			   _("Completed %1$s because %2$s"), ps.top_state().program->descname(), condition_string);
 		} break;
 		case ProgramResult::kSkipped: {
-			result_string = bformat(
+			result_string = format(
 			   /** TRANSLATORS: "Skipped working because the economy needs the ware '%s'" */
 			   _("Skipped %1$s because %2$s"), ps.top_state().program->descname(), condition_string);
 		} break;
 		case ProgramResult::kNone: {
 			// TODO(GunChleoc): Same as skipped - is this on purpose?
-			result_string = bformat(
+			result_string = format(
 			   _("Skipped %1$s because %2$s"), ps.top_state().program->descname(), condition_string);
 		}
 		}
@@ -1221,7 +1221,7 @@ void ProductionProgram::ActConsume::execute(Game& game, ProductionSite& ps) cons
 				   /** TRANSLATORS: For this example, this is what's in the place holders: */
 				   /** TRANSLATORS:    %1$i = "3" */
 				   /** TRANSLATORS:    %2$s = "water" */
-				   bformat(_("%1$ix %2$s"), static_cast<unsigned int>(count), ware_string);
+				   format(_("%1$ix %2$s"), static_cast<unsigned int>(count), ware_string);
 			}
 			group_list.push_back(ware_string);
 		}
@@ -1230,7 +1230,7 @@ void ProductionProgram::ActConsume::execute(Game& game, ProductionSite& ps) cons
 		   /** TRANSLATORS: e.g. 'Did not start working because 3x water and 3x wheat are missing' */
 		   /** TRANSLATORS: e.g. 'Did not start working because fish, meat or pitta bread is missing'
 		    */
-		   bformat(ngettext("%s is missing", "%s are missing", nr_missing_groups),
+		   format(ngettext("%s is missing", "%s are missing", nr_missing_groups),
 		           i18n::localize_list(group_list, i18n::ConcatenateWith::AND));
 
 		std::string result_string =
@@ -1243,7 +1243,7 @@ void ProductionProgram::ActConsume::execute(Game& game, ProductionSite& ps) cons
 		   /** TRANSLATORS: on a development build if you can, and let us know if there are any issues
 		    */
 		   /** TRANSLATORS: we need to address for your language. */
-		   bformat(_("Did not start %1$s because %2$s"), ps.top_state().program->descname(),
+		   format(_("Did not start %1$s because %2$s"), ps.top_state().program->descname(),
 		           is_missing_string);
 
 		if (ps.production_result() != ps.descr().out_of_resource_heading() ||
@@ -1322,7 +1322,7 @@ void ProductionProgram::ActProduce::execute(Game& game, ProductionSite& ps) cons
 		count += item_pair.second;
 		std::string ware_descname = tribe.get_ware_descr(item_pair.first)->descname();
 		if (1 < item_pair.second || 1 < produced_wares_.size()) {
-			ware_descname = bformat(
+			ware_descname = format(
 			   /** TRANSLATORS: This is an item in a list of wares, e.g. "Produced 2x Coal": */
 			   /** TRANSLATORS:    %1$i = "2" */
 			   /** TRANSLATORS:    %2$s = "Coal" */
@@ -1335,7 +1335,7 @@ void ProductionProgram::ActProduce::execute(Game& game, ProductionSite& ps) cons
 	const std::string result_string =
 	   /** TRANSLATORS: %s is a list of wares. String is fetched according to total amount of
 	      wares. */
-	   bformat(ngettext("Produced %s", "Produced %s", count), ware_list);
+	   format(ngettext("Produced %s", "Produced %s", count), ware_list);
 	if (ps.production_result() != ps.descr().out_of_resource_heading() ||
 	    ps.descr().out_of_resource_heading().empty()) {
 		ps.set_production_result(result_string);
@@ -1404,7 +1404,7 @@ void ProductionProgram::ActRecruit::execute(Game& game, ProductionSite& ps) cons
 		count += item_pair.second;
 		std::string worker_descname = tribe.get_worker_descr(item_pair.first)->descname();
 		if (1 < item_pair.second || 1 < recruited_workers_.size()) {
-			worker_descname = bformat(
+			worker_descname = format(
 			   /** TRANSLATORS: This is an item in a list of workers, e.g. "Recruited 2x Ox": */
 			   /** TRANSLATORS:    %1$i = "2" */
 			   /** TRANSLATORS:    %2$s = "Ox" */
@@ -1417,7 +1417,7 @@ void ProductionProgram::ActRecruit::execute(Game& game, ProductionSite& ps) cons
 	const std::string result_string =
 	   /** TRANSLATORS: %s is a list of workers. String is fetched according to total amount of
 	      workers. */
-	   bformat(ngettext("Recruited %s", "Recruited %s", count), unit_string);
+	   format(ngettext("Recruited %s", "Recruited %s", count), unit_string);
 	ps.set_production_result(result_string);
 }
 
@@ -1884,7 +1884,7 @@ void ProductionProgram::ActTrain::execute(Game& game, ProductionSite& ps) const 
 	ps.set_production_result(
 	   /** TRANSLATORS: Success message of a trainingsite '%s' stands for the description of the
 	    * training program, e.g. Completed upgrading soldier evade from level 0 to level 1 */
-	   bformat(_("Completed %s"), ps.top_state().program->descname()));
+	   format(_("Completed %s"), ps.top_state().program->descname()));
 
 	ts.training_successful(training_.attribute, current_level);
 

--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -463,7 +463,7 @@ std::string ProductionProgram::ActReturn::EconomyNeedsWare::description_negation
 	/** TRANSLATORS: e.g. Completed/Skipped/Did not start ... because the economy doesn't need the
 	 * ware '%s' */
 	std::string result = format(_("the economy doesn’t need the ware ‘%s’"),
-	                             descriptions.get_ware_descr(ware_type)->descname());
+	                            descriptions.get_ware_descr(ware_type)->descname());
 	return result;
 }
 
@@ -475,7 +475,7 @@ std::string ProductionProgram::ActReturn::EconomyNeedsWorker::description(
 	/** TRANSLATORS: e.g. Completed/Skipped/Did not start ... because the economy needs the worker
 	 * '%s' */
 	std::string result = format(_("the economy needs the worker ‘%s’"),
-	                             descriptions.get_worker_descr(worker_type)->descname());
+	                            descriptions.get_worker_descr(worker_type)->descname());
 	return result;
 }
 
@@ -484,7 +484,7 @@ std::string ProductionProgram::ActReturn::EconomyNeedsWorker::description_negati
 	/** TRANSLATORS: e.g. Completed/Skipped/Did not start ... */
 	/** TRANSLATORS:      ... because the economy doesn’t need the worker '%s' */
 	std::string result = format(_("the economy doesn’t need the worker ‘%s’"),
-	                             descriptions.get_worker_descr(worker_type)->descname());
+	                            descriptions.get_worker_descr(worker_type)->descname());
 	return result;
 }
 
@@ -713,7 +713,7 @@ void ProductionProgram::ActReturn::execute(Game& game, ProductionSite& ps) const
 		case ProgramResult::kFailed: {
 			/** TRANSLATORS: "Did not start working because the economy needs the ware '%s'" */
 			result_string = format(_("Did not start %1$s because %2$s"),
-			                        ps.top_state().program->descname(), condition_string);
+			                       ps.top_state().program->descname(), condition_string);
 		} break;
 		case ProgramResult::kCompleted: {
 			result_string = format(
@@ -1231,7 +1231,7 @@ void ProductionProgram::ActConsume::execute(Game& game, ProductionSite& ps) cons
 		   /** TRANSLATORS: e.g. 'Did not start working because fish, meat or pitta bread is missing'
 		    */
 		   format(ngettext("%s is missing", "%s are missing", nr_missing_groups),
-		           i18n::localize_list(group_list, i18n::ConcatenateWith::AND));
+		          i18n::localize_list(group_list, i18n::ConcatenateWith::AND));
 
 		std::string result_string =
 		   /** TRANSLATORS: e.g. 'Did not start working because 3x water and 3x wheat are missing' */
@@ -1244,7 +1244,7 @@ void ProductionProgram::ActConsume::execute(Game& game, ProductionSite& ps) cons
 		    */
 		   /** TRANSLATORS: we need to address for your language. */
 		   format(_("Did not start %1$s because %2$s"), ps.top_state().program->descname(),
-		           is_missing_string);
+		          is_missing_string);
 
 		if (ps.production_result() != ps.descr().out_of_resource_heading() ||
 		    ps.descr().out_of_resource_heading().empty()) {

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -424,10 +424,10 @@ void ProductionSite::format_statistics_string() {
 	// as a string and persists them into a string for reuse when the class is
 	// asked for the statistics string. However this string should only then be constructed.
 
-	// bformat would treat uint8_t as char
+	// format would treat uint8_t as char
 	const unsigned int percent = std::min(get_actual_statistics() * 100 / 98, 100);
 	const std::string perc_str = StyleManager::color_tag(
-	   bformat(_("%i%%"), percent),
+	   format(_("%i%%"), percent),
 	   (percent < 33) ? g_style_manager->building_statistics_style().low_color() :
 	   (percent < 66) ? g_style_manager->building_statistics_style().medium_color() :
                        g_style_manager->building_statistics_style().high_color());
@@ -451,7 +451,7 @@ void ProductionSite::format_statistics_string() {
 
 		// TODO(GunChleoc): We might need to reverse the order here for RTL languages
 		statistics_string_on_changed_statistics_ =
-		   bformat("%s\u2009%s", perc_str, StyleManager::color_tag(trend, color));
+		   format("%s\u2009%s", perc_str, StyleManager::color_tag(trend, color));
 	} else {
 		statistics_string_on_changed_statistics_ = perc_str;
 	}

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1055,7 +1055,7 @@ void Ship::log_general_info(const EditorGameBase& egbase) const {
 
 	molog(egbase.get_gametime(), "Ship belongs to fleet %u\nlastdock: %s\n",
 	      fleet_ ? fleet_->serial() : 0,
-	      (lastdock_.is_set()) ? bformat("%u (%d x %d)", lastdock_.serial(),
+	      (lastdock_.is_set()) ? format("%u (%d x %d)", lastdock_.serial(),
 	                                     lastdock_.get(egbase)->get_positions(egbase)[0].x,
 	                                     lastdock_.get(egbase)->get_positions(egbase)[0].y)
 
@@ -1082,7 +1082,7 @@ void Ship::log_general_info(const EditorGameBase& egbase) const {
 		molog(egbase.get_gametime(), "  * %u (%s), destination: %s\n", shipping_item.object_.serial(),
 		      shipping_item.object_.get(egbase)->descr().name().c_str(),
 		      (shipping_item.destination_dock_.is_set()) ?
-               bformat("%u (%d x %d)", shipping_item.destination_dock_.serial(),
+               format("%u (%d x %d)", shipping_item.destination_dock_.serial(),
 		                 shipping_item.destination_dock_.get(egbase)->get_positions(egbase)[0].x,
 		                 shipping_item.destination_dock_.get(egbase)->get_positions(egbase)[0].y)
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1056,8 +1056,8 @@ void Ship::log_general_info(const EditorGameBase& egbase) const {
 	molog(egbase.get_gametime(), "Ship belongs to fleet %u\nlastdock: %s\n",
 	      fleet_ ? fleet_->serial() : 0,
 	      (lastdock_.is_set()) ? format("%u (%d x %d)", lastdock_.serial(),
-	                                     lastdock_.get(egbase)->get_positions(egbase)[0].x,
-	                                     lastdock_.get(egbase)->get_positions(egbase)[0].y)
+	                                    lastdock_.get(egbase)->get_positions(egbase)[0].x,
+	                                    lastdock_.get(egbase)->get_positions(egbase)[0].y)
 
 	                                .c_str() :
                                 "-");
@@ -1083,8 +1083,8 @@ void Ship::log_general_info(const EditorGameBase& egbase) const {
 		      shipping_item.object_.get(egbase)->descr().name().c_str(),
 		      (shipping_item.destination_dock_.is_set()) ?
                format("%u (%d x %d)", shipping_item.destination_dock_.serial(),
-		                 shipping_item.destination_dock_.get(egbase)->get_positions(egbase)[0].x,
-		                 shipping_item.destination_dock_.get(egbase)->get_positions(egbase)[0].y)
+		                shipping_item.destination_dock_.get(egbase)->get_positions(egbase)[0].x,
+		                shipping_item.destination_dock_.get(egbase)->get_positions(egbase)[0].y)
 
 		            .c_str() :
                "-");

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1491,7 +1491,7 @@ void Soldier::battle_update(Game& game, State&) {
 				BaseImmovable const* const immovable_position = get_position().field->get_immovable();
 				BaseImmovable const* const immovable_dest = map[dest].get_immovable();
 
-				const std::string messagetext = bformat(
+				const std::string messagetext = format(
 				   "The game engine has encountered a logic error. The %s "
 				   "#%u of player %u could not find a way from (%i, %i) "
 				   "(with %s immovable) to the opponent (%s #%u of player "

--- a/src/logic/map_objects/tribes/trainingsite.cc
+++ b/src/logic/map_objects/tribes/trainingsite.cc
@@ -1052,7 +1052,7 @@ void TrainingSite::start_upgrade(Game& game, Upgrade& upgrade) {
 	upgrade.lastattempt = level;
 	upgrade.lastsuccess = false;
 
-	return program_start(game, bformat("%s%i", upgrade.prefix, level));
+	return program_start(game, format("%s%i", upgrade.prefix, level));
 }
 
 TrainingSite::Upgrade* TrainingSite::get_upgrade(TrainingAttribute const atr) {

--- a/src/logic/map_objects/tribes/tribe_descr.cc
+++ b/src/logic/map_objects/tribes/tribe_descr.cc
@@ -167,7 +167,7 @@ TribeDescr::TribeDescr(const Widelands::TribeBasicInfo& info,
 	auto set_progress_message = [this](const std::string& str, int i) {
 		Notifications::publish(UI::NoteLoadingMessage(
 		   /** TRANSLATORS: Example: Loading Barbarians: Buildings (2/6) */
-		   bformat(_("Loading %1%: %2% (%3%/%4%)"), descname(), str, i, 6)));
+		   format(_("Loading %1%: %2% (%3%/%4%)"), descname(), str, i, 6)));
 	};
 
 	try {

--- a/src/logic/map_objects/tribes/worker.cc
+++ b/src/logic/map_objects/tribes/worker.cc
@@ -2061,7 +2061,7 @@ void Worker::return_update(Game& game, State& state) {
 	if (!start_task_movepath(game, target_flag.get_position(), 15,
 	                         descr().get_right_walk_anims(does_carry_ware(), this))) {
 		molog(game.get_gametime(), "[return]: Failed to return\n");
-		const std::string message = bformat(
+		const std::string message = format(
 		   _("Your %s can’t find a way home and will likely die."), descr().descname().c_str());
 
 		get_owner()->add_message(

--- a/src/logic/map_objects/world/terrain_description.cc
+++ b/src/logic/map_objects/world/terrain_description.cc
@@ -59,7 +59,7 @@ TerrainDescription::Is terrain_type_from_string(const std::string& type) {
 	if (type == "unwalkable") {
 		return TerrainDescription::Is::kUnwalkable;
 	}
-	throw LuaError(bformat("Invalid terrain \"is\" value '%s'", type));
+	throw LuaError(format("Invalid terrain \"is\" value '%s'", type));
 }
 
 }  // namespace

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -1934,7 +1934,7 @@ const std::string Player::pick_shipname() {
 	++ship_name_counter_;
 
 	if (remaining_shipnames_.empty()) {
-		return bformat(pgettext("shipname", "Ship %d"), ship_name_counter_);
+		return format(pgettext("shipname", "Ship %d"), ship_name_counter_);
 	}
 
 	Game& game = dynamic_cast<Game&>(egbase());

--- a/src/logic/replay.cc
+++ b/src/logic/replay.cc
@@ -86,14 +86,14 @@ public:
 			UI::WLMessageBox m(
 			   game.get_ibase(), UI::WindowStyle::kWui, _("Desync"),
 			   format(_("The replay has desynced and the game was paused.\n"
-			             "You are probably watching a replay created with another version of "
-			             "Widelands, which is not supported.\n\n"
-			             "If you are certain that the replay was created with the same version "
-			             "of Widelands, %1$s (%2$s), "
-			             "please report this problem as a bug.\n"
-			             "You will find related messages in the standard output (stdout.txt on "
-			             "Windows). Please add this information to your report."),
-			           build_id(), build_type()),
+			            "You are probably watching a replay created with another version of "
+			            "Widelands, which is not supported.\n\n"
+			            "If you are certain that the replay was created with the same version "
+			            "of Widelands, %1$s (%2$s), "
+			            "please report this problem as a bug.\n"
+			            "You will find related messages in the standard output (stdout.txt on "
+			            "Windows). Please add this information to your report."),
+			          build_id(), build_type()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 		}

--- a/src/logic/replay.cc
+++ b/src/logic/replay.cc
@@ -85,7 +85,7 @@ public:
 
 			UI::WLMessageBox m(
 			   game.get_ibase(), UI::WindowStyle::kWui, _("Desync"),
-			   bformat(_("The replay has desynced and the game was paused.\n"
+			   format(_("The replay has desynced and the game was paused.\n"
 			             "You are probably watching a replay created with another version of "
 			             "Widelands, which is not supported.\n\n"
 			             "If you are certain that the replay was created with the same version "

--- a/src/logic/save_handler.cc
+++ b/src/logic/save_handler.cc
@@ -55,7 +55,7 @@ bool SaveHandler::roll_save_files(const std::string& filename, std::string* cons
 
 	// Only roll the smallest necessary number of files.
 	while (rolls < number_of_rolls_) {
-		filename_previous = create_file_name(kSaveDir, bformat("%s_%02d", filename, rolls));
+		filename_previous = create_file_name(kSaveDir, format("%s_%02d", filename, rolls));
 		if (!g_fs->file_exists(filename_previous)) {
 			break;
 		}
@@ -68,7 +68,7 @@ bool SaveHandler::roll_save_files(const std::string& filename, std::string* cons
 	} else {
 		verb_log_info("Autosave: Rolling savefiles (count): %d\n", rolls);
 		rolls--;
-		filename_previous = create_file_name(kSaveDir, bformat("%s_%02d", filename, rolls));
+		filename_previous = create_file_name(kSaveDir, format("%s_%02d", filename, rolls));
 		if (rolls > 0) {
 			try {
 				g_fs->fs_unlink(filename_previous);  // Delete last of the rolling files
@@ -77,7 +77,7 @@ bool SaveHandler::roll_save_files(const std::string& filename, std::string* cons
 				log_warn(
 				   "Autosave: Unable to delete file %s: %s\n", filename_previous.c_str(), e.what());
 				if (error) {
-					*error = bformat(
+					*error = format(
 					   "Autosave: Unable to delete file %s: %s\n", filename_previous.c_str(), e.what());
 				}
 				return false;
@@ -88,7 +88,7 @@ bool SaveHandler::roll_save_files(const std::string& filename, std::string* cons
 	rolls--;
 	while (rolls >= 0) {
 		const std::string filename_next =
-		   create_file_name(kSaveDir, bformat("%s_%02d", filename, rolls));
+		   create_file_name(kSaveDir, format("%s_%02d", filename, rolls));
 		try {
 			g_fs->fs_rename(
 			   filename_next, filename_previous);  // e.g. wl_autosave_08 -> wl_autosave_09
@@ -160,7 +160,7 @@ void SaveHandler::think(Widelands::Game& game) {
 			// Autosave ...
 			save_success = roll_save_files(filename, &error);
 			if (save_success) {
-				filename = bformat("%s_00", autosave_filename_);
+				filename = format("%s_00", autosave_filename_);
 				verb_log_info_time(game.get_gametime(), "Autosave: saving as %s\n", filename.c_str());
 			}
 		}

--- a/src/logic/single_player_game_settings_provider.cc
+++ b/src/logic/single_player_game_settings_provider.cc
@@ -108,7 +108,7 @@ void SinglePlayerGameSettingsProvider::set_map(const std::string& mapname,
 		player.tribe = s.tribes.at(0).name;
 		player.random_tribe = false;
 		player.initialization_index = 0;
-		player.name = bformat(_("Player %u"), (player_nr + 1));
+		player.name = format(_("Player %u"), (player_nr + 1));
 		player.team = 0;
 		player.color = kPlayerColors[player_nr];
 		// Set default computerplayer ai type

--- a/src/map_io/map_allowed_building_types_packet.cc
+++ b/src/map_io/map_allowed_building_types_packet.cc
@@ -70,7 +70,7 @@ void MapAllowedBuildingTypesPacket::read(FileSystem& fs,
 				}
 				try {
 					Section& s =
-					   prof.get_safe_section(bformat("player_%u", static_cast<unsigned int>(p)));
+					   prof.get_safe_section(format("player_%u", static_cast<unsigned int>(p)));
 
 					bool allowed;
 					while (const char* const name = s.get_next_bool(nullptr, &allowed)) {
@@ -103,7 +103,7 @@ void MapAllowedBuildingTypesPacket::write(FileSystem& fs, EditorGameBase& egbase
 	PlayerNumber const nr_players = egbase.map().get_nrplayers();
 	iterate_players_existing_const(p, nr_players, egbase, player) {
 		const TribeDescr& tribe = player->tribe();
-		const std::string section_key = bformat("player_%u", static_cast<unsigned int>(p));
+		const std::string section_key = format("player_%u", static_cast<unsigned int>(p));
 		Section& section = prof.create_section(section_key.c_str());
 
 		//  Write for all buildings if it is enabled.

--- a/src/map_io/map_allowed_worker_types_packet.cc
+++ b/src/map_io/map_allowed_worker_types_packet.cc
@@ -54,7 +54,7 @@ void MapAllowedWorkerTypesPacket::read(FileSystem& fs,
 			iterate_players_existing(p, egbase.map().get_nrplayers(), egbase, player) {
 				const TribeDescr& tribe = player->tribe();
 				try {
-					Section* s = prof.get_section(bformat("player_%u", static_cast<unsigned int>(p)));
+					Section* s = prof.get_section(format("player_%u", static_cast<unsigned int>(p)));
 					if (s == nullptr) {
 						continue;
 					}
@@ -91,7 +91,7 @@ void MapAllowedWorkerTypesPacket::write(FileSystem& fs, EditorGameBase& egbase, 
 	bool forbidden_worker_seen = false;
 	iterate_players_existing_const(p, egbase.map().get_nrplayers(), egbase, player) {
 		const TribeDescr& tribe = player->tribe();
-		const std::string section_key = bformat("player_%u", static_cast<unsigned int>(p));
+		const std::string section_key = format("player_%u", static_cast<unsigned int>(p));
 		Section& section = prof.create_section(section_key.c_str());
 
 		// Only write the workers which are disabled.

--- a/src/map_io/map_elemental_packet.cc
+++ b/src/map_io/map_elemental_packet.cc
@@ -90,14 +90,14 @@ void MapElementalPacket::pre_read(FileSystem& fs, Map* map) {
 			map->suggested_teams_.clear();
 
 			uint16_t team_section_id = 0;
-			std::string teamsection_key = bformat("teams%02i", team_section_id);
+			std::string teamsection_key = format("teams%02i", team_section_id);
 			while (Section* teamsection = prof.get_section(teamsection_key)) {
 
 				// A lineup is made up of teams
 				SuggestedTeamLineup lineup;
 
 				uint16_t team_number = 1;
-				std::string team_key = bformat("team%i", team_number);
+				std::string team_key = format("team%i", team_number);
 				std::string team_string = teamsection->get_string(team_key.c_str(), "");
 				while (!team_string.empty()) {
 					// A team is made up of players
@@ -116,7 +116,7 @@ void MapElementalPacket::pre_read(FileSystem& fs, Map* map) {
 
 					// Increase team number
 					++team_number;
-					team_key = bformat("team%i", team_number);
+					team_key = format("team%i", team_number);
 					team_string = teamsection->get_string(team_key.c_str(), "");
 				}
 
@@ -124,7 +124,7 @@ void MapElementalPacket::pre_read(FileSystem& fs, Map* map) {
 
 				// Increase teamsection
 				++team_section_id;
-				teamsection_key = bformat("teams%02i", team_section_id);
+				teamsection_key = format("teams%02i", team_section_id);
 			}
 		} else {
 			throw UnhandledVersionError(
@@ -184,19 +184,19 @@ void MapElementalPacket::write(FileSystem& fs, EditorGameBase& egbase, MapObject
 
 	int counter = 0;
 	for (const Widelands::SuggestedTeamLineup& lineup : map.get_suggested_teams()) {
-		Section& teams_section = prof.create_section(bformat("teams%02d", counter++).c_str());
+		Section& teams_section = prof.create_section(format("teams%02d", counter++).c_str());
 		int lineup_counter = 0;
 		for (const Widelands::SuggestedTeam& team : lineup) {
 			std::string section_contents;
 			for (std::vector<PlayerNumber>::const_iterator it = team.begin(); it != team.end(); ++it) {
 				if (it == team.begin()) {
-					section_contents = bformat("%d", static_cast<unsigned int>(*it));
+					section_contents = format("%d", static_cast<unsigned int>(*it));
 				} else {
 					section_contents =
-					   bformat("%s,%d", section_contents, static_cast<unsigned int>(*it));
+					   format("%s,%d", section_contents, static_cast<unsigned int>(*it));
 				}
 			}
-			teams_section.set_string(bformat("team%d", ++lineup_counter).c_str(), section_contents);
+			teams_section.set_string(format("team%d", ++lineup_counter).c_str(), section_contents);
 		}
 	}
 

--- a/src/map_io/map_elemental_packet.cc
+++ b/src/map_io/map_elemental_packet.cc
@@ -192,8 +192,7 @@ void MapElementalPacket::write(FileSystem& fs, EditorGameBase& egbase, MapObject
 				if (it == team.begin()) {
 					section_contents = format("%d", static_cast<unsigned int>(*it));
 				} else {
-					section_contents =
-					   format("%s,%d", section_contents, static_cast<unsigned int>(*it));
+					section_contents = format("%s,%d", section_contents, static_cast<unsigned int>(*it));
 				}
 			}
 			teams_section.set_string(format("team%d", ++lineup_counter).c_str(), section_contents);

--- a/src/map_io/map_player_names_and_tribes_packet.cc
+++ b/src/map_io/map_player_names_and_tribes_packet.cc
@@ -57,13 +57,13 @@ void MapPlayerNamesAndTribesPacket::pre_read(FileSystem& fs, Map* const map, boo
 			i18n::Textdomain td("widelands");
 			PlayerNumber const nr_players = map->get_nrplayers();
 			iterate_player_numbers(p, nr_players) {
-				Section& s = prof.get_safe_section(bformat("player_%u", static_cast<unsigned int>(p)));
+				Section& s = prof.get_safe_section(format("player_%u", static_cast<unsigned int>(p)));
 
 				// Replace empty or standard player names with localized standard player name
 				std::string player_name = s.get_string("name", "");
 				if (player_name.empty() ||
-				    player_name == bformat("Player %u", static_cast<unsigned int>(p))) {
-					player_name = bformat(_("Player %u"), static_cast<unsigned int>(p));
+				    player_name == format("Player %u", static_cast<unsigned int>(p))) {
+					player_name = format(_("Player %u"), static_cast<unsigned int>(p));
 				}
 				map->set_scenario_player_name(p, player_name);
 				map->set_scenario_player_tribe(p, s.get_string("tribe", ""));
@@ -88,14 +88,14 @@ void MapPlayerNamesAndTribesPacket::write(FileSystem& fs, EditorGameBase& egbase
 	const Map& map = egbase.map();
 	PlayerNumber const nr_players = map.get_nrplayers();
 	iterate_player_numbers(p, nr_players) {
-		const std::string section_key = bformat("player_%u", static_cast<unsigned int>(p));
+		const std::string section_key = format("player_%u", static_cast<unsigned int>(p));
 
 		// Make sure that no player name is empty, and trim leading/trailing whitespaces.
 		std::string player_name = map.get_scenario_player_name(p);
 		trim(player_name);
 
 		// Save default player names as empty
-		if (player_name == bformat(_("Player %u"), static_cast<unsigned int>(p))) {
+		if (player_name == format(_("Player %u"), static_cast<unsigned int>(p))) {
 			player_name = "";
 		}
 

--- a/src/map_io/map_player_position_packet.cc
+++ b/src/map_io/map_player_position_packet.cc
@@ -47,7 +47,7 @@ void MapPlayerPositionPacket::read(FileSystem& fs, EditorGameBase& egbase, bool,
 				try {
 					map->set_starting_pos(
 					   p,
-					   get_safe_coords(bformat("player_%u", static_cast<unsigned int>(p)), extent, &s));
+					   get_safe_coords(format("player_%u", static_cast<unsigned int>(p)), extent, &s));
 				} catch (const WException& e) {
 					throw GameDataError("player %u: %s", p, e.what());
 				}
@@ -71,7 +71,7 @@ void MapPlayerPositionPacket::write(FileSystem& fs, EditorGameBase& egbase, MapO
 	const Map& map = egbase.map();
 	const PlayerNumber nr_players = map.get_nrplayers();
 	iterate_player_numbers(p, nr_players) {
-		set_coords(bformat("player_%u", static_cast<unsigned int>(p)), map.get_starting_pos(p), &s);
+		set_coords(format("player_%u", static_cast<unsigned int>(p)), map.get_starting_pos(p), &s);
 	}
 
 	prof.write("player_position", false, fs);

--- a/src/map_io/map_players_messages_packet.cc
+++ b/src/map_io/map_players_messages_packet.cc
@@ -51,7 +51,7 @@ void MapPlayersMessagesPacket::read(FileSystem& fs,
 		Profile prof;
 		try {
 			const std::string profile_filename =
-			   bformat(kFilenameTemplate, static_cast<unsigned int>(p));
+			   format(kFilenameTemplate, static_cast<unsigned int>(p));
 			prof.read(profile_filename.c_str(), nullptr, fs);
 		} catch (...) {
 			continue;
@@ -189,9 +189,9 @@ void MapPlayersMessagesPacket::write(FileSystem& fs, EditorGameBase& egbase, Map
 			}
 			s.set_string("subtype", message.sub_type().c_str());
 		}
-		fs.ensure_directory_exists(bformat(kPlayerDirnameTemplate, static_cast<unsigned int>(p)));
+		fs.ensure_directory_exists(format(kPlayerDirnameTemplate, static_cast<unsigned int>(p)));
 
-		const std::string profile_filename = bformat(kFilenameTemplate, static_cast<unsigned int>(p));
+		const std::string profile_filename = format(kFilenameTemplate, static_cast<unsigned int>(p));
 		prof.write(profile_filename.c_str(), false, fs);
 	}
 }

--- a/src/map_io/map_saver.cc
+++ b/src/map_io/map_saver.cc
@@ -84,7 +84,7 @@ void MapSaver::save() {
 
 	auto set_progress_message = [](std::string text, int step) {
 		Notifications::publish(UI::NoteLoadingMessage(
-		   step < 0 ? text : bformat(_("Saving map: %1$s (%2$d/%3$d)"), text, step, 22)));
+		   step < 0 ? text : format(_("Saving map: %1$s (%2$d/%3$d)"), text, step, 22)));
 	};
 	set_progress_message(_("Autosaving map…"), -1);
 

--- a/src/map_io/widelands_map_loader.cc
+++ b/src/map_io/widelands_map_loader.cc
@@ -193,7 +193,7 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 	// PRELOAD DATA BEGIN
 	auto set_progress_message = [is_editor](const std::string& text, unsigned step) {
 		Notifications::publish(UI::NoteLoadingMessage(
-		   bformat(_("Loading map: %1$s (%2$u/%3$d)"), text, step, (is_editor ? 9 : 23))));
+		   format(_("Loading map: %1$s (%2$u/%3$d)"), text, step, (is_editor ? 9 : 23))));
 	};
 
 	set_progress_message(_("Elemental data"), 1);

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -145,7 +145,7 @@ InteractiveGameBase* GameClientImpl::init_game(GameClient* parent, UI::ProgressW
 	game->set_game_controller(parent->get_pointer());
 	uint8_t const pn = settings.playernum + 1;
 	game->save_handler().set_autosave_filename(
-	   bformat("%s_netclient%u", kAutosavePrefix, static_cast<unsigned int>(pn)));
+	   format("%s_netclient%u", kAutosavePrefix, static_cast<unsigned int>(pn)));
 	InteractiveGameBase* igb;
 	if (pn > 0) {
 		igb = new InteractivePlayer(*game, get_config_section(), pn, true, parent);
@@ -175,7 +175,7 @@ void GameClientImpl::run_game(InteractiveGameBase* igb) {
 	game->run(settings.savegame ? Widelands::Game::StartGameType::kSaveGame :
 	          settings.scenario ? Widelands::Game::StartGameType::kMultiPlayerScenario :
                                  Widelands::Game::StartGameType::kMap,
-	          "", false, bformat("netclient_%d", static_cast<int>(settings.usernum)));
+	          "", false, format("netclient_%d", static_cast<int>(settings.usernum)));
 
 	// if this is an internet game, tell the metaserver that the game is done.
 	if (internet_) {
@@ -747,13 +747,13 @@ void GameClient::handle_hello(RecvPacket& packet) {
 	}
 	if (!missing_addons.empty() || !wrong_version_addons.empty()) {
 		const size_t nr = missing_addons.size() + wrong_version_addons.size();
-		std::string message = bformat(
+		std::string message = format(
 		   ngettext("%u add-on mismatch detected:\n", "%u add-on mismatches detected:\n", nr), nr);
 		for (const std::string& name : missing_addons) {
-			message = bformat(_("%1$s\n· ‘%2$s’ required by host not found"), message, name);
+			message = format(_("%1$s\n· ‘%2$s’ required by host not found"), message, name);
 		}
 		for (const auto& pair : wrong_version_addons) {
-			message = bformat(_("%1$s\n· ‘%2$s’ installed at version %3$s but host uses version %4$s"),
+			message = format(_("%1$s\n· ‘%2$s’ installed at version %3$s but host uses version %4$s"),
 			                  message, pair.first, pair.second.first, pair.second.second);
 		}
 		throw AddOnsMismatchException(message);
@@ -1275,7 +1275,7 @@ void GameClient::disconnect(const std::string& reason,
 		} else {
 			capsule_.menu().show_messagebox(
 			   _("Disconnected"),
-			   bformat(_("The connection with the host was lost for the following reason:\n%s"),
+			   format(_("The connection with the host was lost for the following reason:\n%s"),
 			           (arg.empty() ? NetworkGamingMessages::get_message(reason) :
                                    NetworkGamingMessages::get_message(reason, arg))));
 		}

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -754,7 +754,7 @@ void GameClient::handle_hello(RecvPacket& packet) {
 		}
 		for (const auto& pair : wrong_version_addons) {
 			message = format(_("%1$s\n· ‘%2$s’ installed at version %3$s but host uses version %4$s"),
-			                  message, pair.first, pair.second.first, pair.second.second);
+			                 message, pair.first, pair.second.first, pair.second.second);
 		}
 		throw AddOnsMismatchException(message);
 	}
@@ -1276,8 +1276,8 @@ void GameClient::disconnect(const std::string& reason,
 			capsule_.menu().show_messagebox(
 			   _("Disconnected"),
 			   format(_("The connection with the host was lost for the following reason:\n%s"),
-			           (arg.empty() ? NetworkGamingMessages::get_message(reason) :
-                                   NetworkGamingMessages::get_message(reason, arg))));
+			          (arg.empty() ? NetworkGamingMessages::get_message(reason) :
+                                  NetworkGamingMessages::get_message(reason, arg))));
 		}
 	}
 

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -113,7 +113,7 @@ struct HostChatProvider : public ChatProvider {
 
 			// Help
 			if (cmd == "help") {
-				c.msg = bformat(
+				c.msg = format(
 				   "<br>%s<br>%s<br>%s<br>%s<br>%s<br>%s<br>%s", _("Available host commands are:"),
 				   /** TRANSLATORS: Available host command */
 				   _("/help  -  Shows this help"),
@@ -148,9 +148,9 @@ struct HostChatProvider : public ChatProvider {
 				} else {
 					int32_t num = h->check_client(arg1);
 					if (num == -1) {
-						c.msg = bformat(_("The client %s could not be found."), arg1);
+						c.msg = format(_("The client %s could not be found."), arg1);
 					} else {
-						c.msg = bformat("HOST WARNING FOR %s: ", arg1);
+						c.msg = format("HOST WARNING FOR %s: ", arg1);
 						c.msg += arg2;
 					}
 				}
@@ -172,12 +172,12 @@ struct HostChatProvider : public ChatProvider {
 					if (num == -2) {
 						c.msg = _("You can not kick yourself!");
 					} else if (num == -1) {
-						c.msg = bformat(_("The client %s could not be found."), arg1);
+						c.msg = format(_("The client %s could not be found."), arg1);
 					} else {
 						kickClient = num;
-						c.msg = bformat(_("Are you sure you want to kick %s?"), arg1) + "<br>";
-						c.msg += bformat(_("The stated reason was: %s"), kickReason) + "<br>";
-						c.msg += bformat(_("If yes, type: /ack_kick %s"), arg1);
+						c.msg = format(_("Are you sure you want to kick %s?"), arg1) + "<br>";
+						c.msg += format(_("The stated reason was: %s"), kickReason) + "<br>";
+						c.msg += format(_("If yes, type: /ack_kick %s"), arg1);
 					}
 				}
 			}
@@ -546,7 +546,7 @@ void GameHost::run_callback() {
 		game_->set_game_controller(pointer_);
 		InteractiveGameBase* igb;
 		player_number = d->settings.playernum + 1;
-		game_->save_handler().set_autosave_filename(bformat("%s_nethost", kAutosavePrefix));
+		game_->save_handler().set_autosave_filename(format("%s_nethost", kAutosavePrefix));
 
 		if (d->settings.savegame) {
 			// Read and broadcast original win condition
@@ -1630,7 +1630,7 @@ std::string GameHost::get_computer_player_name(uint8_t const playernum) {
 	std::string name;
 	uint32_t suffix = playernum;
 	do {
-		name = bformat(_("Computer %u"), static_cast<unsigned int>(++suffix));
+		name = format(_("Computer %u"), static_cast<unsigned int>(++suffix));
 	} while (has_user_name(name, playernum));
 	return name;
 }
@@ -1705,7 +1705,7 @@ void GameHost::welcome_client(uint32_t const number, std::string& playername) {
 	if (has_user_name(effective_name, client.usernum)) {
 		uint32_t i = 1;
 		do {
-			effective_name = bformat("%s%u", playername, i++);
+			effective_name = format("%s%u", playername, i++);
 		} while (has_user_name(effective_name, client.usernum));
 	}
 
@@ -1877,7 +1877,7 @@ void GameHost::check_hung_clients() {
 					// inform the other clients about the problem regulary
 					if (deltanow - d->clients.at(i).lastdelta > 30) {
 						std::string seconds =
-						   bformat(ngettext("%li second", "%li seconds", deltanow), deltanow);
+						   format(ngettext("%li second", "%li seconds", deltanow), deltanow);
 						send_system_message_code(
 						   "CLIENT_HUNG", d->settings.users.at(d->clients.at(i).usernum).name, seconds);
 						d->clients.at(i).lastdelta = deltanow;

--- a/src/network/internet_gaming.cc
+++ b/src/network/internet_gaming.cc
@@ -429,8 +429,8 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 			if (clientname_ != assigned_name) {
 				format_and_add_chat("", "", true,
 				                    format(_("You have been logged in as ‘%s’ since your "
-				                              "requested name is already in use or reserved."),
-				                            assigned_name));
+				                             "requested name is already in use or reserved."),
+				                           assigned_name));
 			}
 			clientname_ = assigned_name;
 			clientrights_ = packet.string();
@@ -501,8 +501,8 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 			time_offset_ = stoi(packet.string()) - time(nullptr);
 			verb_log_info("InternetGaming: Server time offset is %d second(s).", time_offset_);
 			std::string temp = format(ngettext("Server time offset is %d second.",
-			                                    "Server time offset is %d seconds.", time_offset_),
-			                           time_offset_);
+			                                   "Server time offset is %d seconds.", time_offset_),
+			                          time_offset_);
 			format_and_add_chat("", "", true, temp);
 		}
 
@@ -701,7 +701,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 			} else {
 				message =
 				   format(_("An unexpected error message has been received about command %1%: %2%"),
-				           subcmd, reason);
+				          subcmd, reason);
 			}
 
 			// Finally send the error message as system chat to the client.

--- a/src/network/internet_gaming.cc
+++ b/src/network/internet_gaming.cc
@@ -333,7 +333,7 @@ void InternetGaming::handle_metaserver_communication(bool relogin_on_error) {
 			}
 		}
 	} catch (const std::exception& e) {
-		logout(bformat(_("Something went wrong: %s"), e.what()));
+		logout(format(_("Something went wrong: %s"), e.what()));
 		set_error();
 	}
 
@@ -428,7 +428,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 			const std::string assigned_name = packet.string();
 			if (clientname_ != assigned_name) {
 				format_and_add_chat("", "", true,
-				                    bformat(_("You have been logged in as ‘%s’ since your "
+				                    format(_("You have been logged in as ‘%s’ since your "
 				                              "requested name is already in use or reserved."),
 				                            assigned_name));
 			}
@@ -491,7 +491,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 			// Login specific commands but not in CONNECTING state...
 			log_err("InternetGaming: Received %s cmd although client is not in CONNECTING state.\n",
 			        cmd.c_str());
-			std::string temp = bformat(
+			std::string temp = format(
 			   _("WARNING: Received a %s command although we are not in CONNECTING state."), cmd);
 			format_and_add_chat("", "", true, temp);
 		}
@@ -500,7 +500,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 			// Client received the server time
 			time_offset_ = stoi(packet.string()) - time(nullptr);
 			verb_log_info("InternetGaming: Server time offset is %d second(s).", time_offset_);
-			std::string temp = bformat(ngettext("Server time offset is %d second.",
+			std::string temp = format(ngettext("Server time offset is %d second.",
 			                                    "Server time offset is %d seconds.", time_offset_),
 			                           time_offset_);
 			format_and_add_chat("", "", true, temp);
@@ -554,7 +554,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 				    (ing->build_id == build_id() || (ing->build_id.compare(0, 6, "build-") != 0 &&
 				                                     build_id().compare(0, 6, "build-") != 0))) {
 					format_and_add_chat(
-					   "", "", true, bformat(_("The game %s is now available"), ing->name));
+					   "", "", true, format(_("The game %s is now available"), ing->name));
 				}
 
 				delete ing;
@@ -564,7 +564,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 			for (InternetGame& old_game : old) {
 				if (!old_game.name.empty()) {
 					format_and_add_chat(
-					   "", "", true, bformat(_("The game %s has been closed"), old_game.name));
+					   "", "", true, format(_("The game %s has been closed"), old_game.name));
 				}
 			}
 
@@ -603,7 +603,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 					}
 				}
 				if (!found) {
-					format_and_add_chat("", "", true, bformat(_("%s joined the lobby"), inc.name));
+					format_and_add_chat("", "", true, format(_("%s joined the lobby"), inc.name));
 				}
 			}
 
@@ -614,7 +614,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 
 			for (InternetClient& client : old) {
 				if (!client.name.empty()) {
-					format_and_add_chat("", "", true, bformat(_("%s left the lobby"), client.name));
+					format_and_add_chat("", "", true, format(_("%s left the lobby"), client.name));
 				}
 			}
 			clientupdate_ = true;
@@ -673,14 +673,14 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 				// Something went wrong with the chat message the user sent.
 				message += _("Chat message could not be sent.");
 				if (reason == "NO_SUCH_USER") {
-					message = bformat("%s %s", message, InternetGamingMessages::get_message(reason));
+					message = format("%s %s", message, InternetGamingMessages::get_message(reason));
 				}
 			}
 
 			else if (subcmd == IGPCMD_CMD) {
 				// Something went wrong with the command
 				message += _("Command could not be executed.");
-				message = bformat("%s %s", message, InternetGamingMessages::get_message(reason));
+				message = format("%s %s", message, InternetGamingMessages::get_message(reason));
 			}
 
 			else if (subcmd == IGPCMD_GAME_OPEN) {
@@ -697,10 +697,10 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 				waitcmd_ = "";
 			}
 			if (!message.empty()) {
-				message = bformat(_("ERROR: %s"), message);
+				message = format(_("ERROR: %s"), message);
 			} else {
 				message =
-				   bformat(_("An unexpected error message has been received about command %1%: %2%"),
+				   format(_("An unexpected error message has been received about command %1%: %2%"),
 				           subcmd, reason);
 			}
 
@@ -711,7 +711,7 @@ void InternetGaming::handle_packet(RecvPacket& packet, bool relogin_on_error) {
 		else {
 			// Inform the client about the unknown command
 			format_and_add_chat(
-			   "", "", true, bformat(_("Received an unknown command from the metaserver: %s"), cmd));
+			   "", "", true, format(_("Received an unknown command from the metaserver: %s"), cmd));
 		}
 
 	} catch (WLWarning& e) {
@@ -1021,7 +1021,7 @@ void InternetGaming::format_and_add_chat(const std::string& from,
                                          const std::string& msg) {
 	ChatMessage c(msg);
 	if (!system && from.empty()) {
-		std::string unkown_string = bformat("<%s>", pgettext("chat_sender", "Unknown"));
+		std::string unkown_string = format("<%s>", pgettext("chat_sender", "Unknown"));
 		c.sender = unkown_string;
 	} else {
 		c.sender = from;

--- a/src/network/network_gaming_messages.cc
+++ b/src/network/network_gaming_messages.cc
@@ -77,7 +77,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
 				// try to merge last three strings
 				std::string temp =
 				   format(strings.at(strings.size() - 3), strings.at(strings.size() - 2),
-				           strings.at(strings.size() - 1));
+				          strings.at(strings.size() - 1));
 				strings.resize(strings.size() - 3);
 				strings.push_back(temp);
 			} catch (...) {
@@ -88,7 +88,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
 					// try to merge all four strings
 					std::string temp =
 					   format(strings.at(strings.size() - 4), strings.at(strings.size() - 3),
-					           strings.at(strings.size() - 2), strings.at(strings.size() - 1));
+					          strings.at(strings.size() - 2), strings.at(strings.size() - 1));
 					strings.resize(strings.size() - 4);
 					strings.push_back(temp);
 				} catch (...) {
@@ -105,7 +105,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
 
 	// No, it did not
 	return (format("%s, %s, %s, %s", get_message(code), get_message(arg1), get_message(arg2),
-	                get_message(arg3)));
+	               get_message(arg3)));
 }
 
 /// Fills the map.

--- a/src/network/network_gaming_messages.cc
+++ b/src/network/network_gaming_messages.cc
@@ -42,7 +42,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
                                                      const std::string& arg3) {
 	if (ngmessages.find(code) == ngmessages.end()) {
 		return (
-		   bformat("%s, %s, %s, %s", code, get_message(arg1), get_message(arg2), get_message(arg3)));
+		   format("%s, %s, %s, %s", code, get_message(arg1), get_message(arg2), get_message(arg3)));
 	}
 
 	// push code and all arguments - if existing - in a vector for easier handling
@@ -66,7 +66,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
 		// try to merge the strings from back to front
 		try {
 			// try to merge last two strings
-			std::string temp = bformat(strings.at(strings.size() - 2), strings.at(strings.size() - 1));
+			std::string temp = format(strings.at(strings.size() - 2), strings.at(strings.size() - 1));
 			strings.resize(strings.size() - 2);
 			strings.push_back(temp);
 		} catch (...) {
@@ -76,7 +76,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
 			try {
 				// try to merge last three strings
 				std::string temp =
-				   bformat(strings.at(strings.size() - 3), strings.at(strings.size() - 2),
+				   format(strings.at(strings.size() - 3), strings.at(strings.size() - 2),
 				           strings.at(strings.size() - 1));
 				strings.resize(strings.size() - 3);
 				strings.push_back(temp);
@@ -87,7 +87,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
 				try {
 					// try to merge all four strings
 					std::string temp =
-					   bformat(strings.at(strings.size() - 4), strings.at(strings.size() - 3),
+					   format(strings.at(strings.size() - 4), strings.at(strings.size() - 3),
 					           strings.at(strings.size() - 2), strings.at(strings.size() - 1));
 					strings.resize(strings.size() - 4);
 					strings.push_back(temp);
@@ -104,7 +104,7 @@ const std::string NetworkGamingMessages::get_message(const std::string& code,
 	}
 
 	// No, it did not
-	return (bformat("%s, %s, %s, %s", get_message(code), get_message(arg1), get_message(arg2),
+	return (format("%s, %s, %s, %s", get_message(code), get_message(arg1), get_message(arg2),
 	                get_message(arg3)));
 }
 

--- a/src/scripting/lua_bases.cc
+++ b/src/scripting/lua_bases.cc
@@ -683,7 +683,7 @@ int LuaPlayerBase::__eq(lua_State* L) {
 
 int LuaPlayerBase::__tostring(lua_State* L) {
 	const std::string pushme =
-	   bformat("Player(%i)", static_cast<unsigned int>(get(L, get_egbase(L)).player_number()));
+	   format("Player(%i)", static_cast<unsigned int>(get(L, get_egbase(L)).player_number()));
 	lua_pushstring(L, pushme.c_str());
 	return 1;
 }

--- a/src/scripting/lua_game.cc
+++ b/src/scripting/lua_game.cc
@@ -1330,7 +1330,7 @@ int LuaObjective::set_done(lua_State* L) {
 		/** TRANSLATORS: %1% = map name. %2% = achievement name */
 		std::string filename = _("%1% (%2%)");
 		i18n::Textdomain td("maps");  // TODO(Nordfriese): What if the scenario is in an add-on?
-		filename = bformat(filename, _(get_egbase(L).map().get_name()), o.descname());
+		filename = format(filename, _(get_egbase(L).map().get_name()), o.descname());
 		get_game(L).save_handler().request_save(filename);
 	}
 	return 0;

--- a/src/scripting/lua_globals.cc
+++ b/src/scripting/lua_globals.cc
@@ -66,13 +66,15 @@ files name.
 /* RST
 .. function:: string.bformat
 
-   Not really a global function. But we add a method to string built in type in
-   Lua that has similar functionality to the built in string.format, but
-   instead uses our own ``bformat``. This allows for better control of the formatting
-   as well as reordering of arguments which is needed for proper localisation.
+   Not really a global function. But we add a method to ``string`` built-in type in
+   Lua that has similar functionality to the built-in ``string.format``, but
+   instead uses our own ``format`` function. This allows for better control of the
+   formatting as well as reordering of arguments which is needed for proper localisation.
 
-   :returns: :const:`nil`
+   :returns: The formatted string.
 */
+// The 'b' in bformat used to stand for "boost", which we no longer use, but
+// renaming the Lua function would break backwards compatibility.
 static int L_string_bformat(lua_State* L) {
 	try {
 		format_impl::ArgsVector fmt_args;
@@ -127,7 +129,7 @@ static int L_string_bformat(lua_State* L) {
 			}
 		}
 
-		lua_pushstring(L, bformat(luaL_checkstring(L, 1), fmt_args));
+		lua_pushstring(L, format(luaL_checkstring(L, 1), fmt_args));
 		return 1;
 	} catch (const std::exception& err) {
 		report_error(L, "Error in bformat: %s", err.what());
@@ -439,7 +441,7 @@ void luaopen_globals(lua_State* L) {
 	luaL_setfuncs(L, globals, 0);
 	lua_pop(L, 1);
 
-	// Also add in string.bformat to use bformat instead, so that we get
+	// Also add in string.bformat to use format instead, so that we get
 	// proper localisation.
 	lua_getglobal(L, "string");               // S: string_lib
 	lua_pushstring(L, "bformat");             // S: string_lib "bformat"

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -922,7 +922,7 @@ int upcasted_map_object_to_lua(lua_State* L, Widelands::MapObject* mo) {
 	case Widelands::MapObjectType::FERRY_FLEET:
 	case Widelands::MapObjectType::WARE:
 		throw LuaError(
-		   bformat("upcasted_map_object_to_lua: Unknown %i", static_cast<int>(mo->descr().type())));
+		   format("upcasted_map_object_to_lua: Unknown %i", static_cast<int>(mo->descr().type())));
 	}
 	NEVER_HERE();
 }
@@ -8181,7 +8181,7 @@ int LuaField::__eq(lua_State* L) {
 }
 
 int LuaField::__tostring(lua_State* L) {
-	const std::string pushme = bformat("Field(%i,%i)", coords_.x, coords_.y);
+	const std::string pushme = format("Field(%i,%i)", coords_.x, coords_.y);
 	lua_pushstring(L, pushme);
 	return 1;
 }

--- a/src/scripting/lua_path.cc
+++ b/src/scripting/lua_path.cc
@@ -67,7 +67,7 @@ bool NumberGlob::next(std::string* s) {
 
 	*s = template_;
 	if (max_) {
-		replace_last(*s, to_replace_, bformat(format_, current_));
+		replace_last(*s, to_replace_, format(format_, current_));
 	}
 	++current_;
 	return true;

--- a/src/scripting/lua_table.h
+++ b/src/scripting/lua_table.h
@@ -143,7 +143,7 @@ public:
 		std::unique_ptr<LuaTable> table(get_table(key));
 		std::vector<ValueType> pts = table->array_entries<ValueType>();
 		if (pts.size() != 2) {
-			throw LuaError(bformat("Expected 2 entries, but got %d.", pts.size()));
+			throw LuaError(format("Expected 2 entries, but got %d.", pts.size()));
 		}
 		result.x = pts[0];
 		result.y = pts[1];

--- a/src/scripting/run_script.cc
+++ b/src/scripting/run_script.cc
@@ -32,7 +32,7 @@ std::string get_file_content(FileSystem* fs, const std::string& filename) {
 		throw LuaScriptNotExistingError(filename);
 	}
 	if (fs->is_directory(filename)) {
-		throw LuaScriptNotExistingError(bformat("%s is a directory", filename));
+		throw LuaScriptNotExistingError(format("%s is a directory", filename));
 	}
 	size_t length;
 	void* input_data = fs->load(filename, length);

--- a/src/ui_basic/dropdown.cc
+++ b/src/ui_basic/dropdown.cc
@@ -307,7 +307,7 @@ void BaseDropdown::add(const std::string& name,
 
 	if (autoexpand_display_button_) {
 		/// Fit width of display button to make enough room for the entry's text
-		const std::string fitme = label_.empty() ? name : bformat(_("%1%: %2%"), label_, name);
+		const std::string fitme = label_.empty() ? name : format(_("%1%: %2%"), label_, name);
 		const int new_width =
 		   text_width(fitme, g_style_manager->button_style(button_style_).enabled().font()) + 8;
 		if (new_width > display_button_.get_w()) {
@@ -359,7 +359,7 @@ void BaseDropdown::set_tooltip(const std::string& text) {
 }
 
 void BaseDropdown::set_errored(const std::string& error_message) {
-	set_tooltip(bformat(_("%1%: %2%"), _("Error"), error_message));
+	set_tooltip(format(_("%1%: %2%"), _("Error"), error_message));
 	if (type_ != DropdownType::kPictorial && type_ != DropdownType::kPictorialMenu) {
 		set_label(_("Error"));
 	} else {
@@ -426,7 +426,7 @@ void BaseDropdown::update() {
 			display_button_.set_title(name);
 		} else {
 			/** TRANSLATORS: Label: Value. */
-			display_button_.set_title(bformat(_("%1%: %2%"), label_, name));
+			display_button_.set_title(format(_("%1%: %2%"), label_, name));
 		}
 		display_button_.set_tooltip(list_->has_selection() ? list_->get_selected_tooltip() :
                                                            tooltip_);
@@ -434,7 +434,7 @@ void BaseDropdown::update() {
 		display_button_.set_pic(list_->has_selection() ?
                                  list_->get_selected_image() :
                                  g_image_cache->get("images/ui_basic/different.png"));
-		display_button_.set_tooltip(bformat(_("%1%: %2%"), label_, name));
+		display_button_.set_tooltip(format(_("%1%: %2%"), label_, name));
 	}
 }
 

--- a/src/ui_basic/fileview_panel.cc
+++ b/src/ui_basic/fileview_panel.cc
@@ -61,7 +61,7 @@ void FileViewPanel::add_tab(const std::string& title, const std::string& lua_scr
 	   new UI::MultilineTextarea(boxes_.at(index).get(), 0, 0, Scrollbar::kSize, 0, panel_style_);
 
 	textviews_.push_back(std::unique_ptr<UI::MultilineTextarea>(textarea));
-	add(bformat("about_%" PRIuS, index), title, boxes_.at(index).get(), "");
+	add(format("about_%" PRIuS, index), title, boxes_.at(index).get(), "");
 
 	assert(boxes_.size() == textviews_.size());
 	assert(tabs().size() == textviews_.size());

--- a/src/ui_basic/progressbar.cc
+++ b/src/ui_basic/progressbar.cc
@@ -95,7 +95,7 @@ void ProgressBar::draw(RenderTarget& dst) {
 
 	// Print the state in percent without decimal points.
 	std::shared_ptr<const UI::RenderedText> rendered_text = UI::g_fh->render(as_richtext_paragraph(
-	   show_percent_ ? bformat("%u%%", floorf(fraction * 100.f)) : std::to_string(state_),
+	   show_percent_ ? format("%u%%", floorf(fraction * 100.f)) : std::to_string(state_),
 	   progress_style().font()));
 	Vector2i pos(get_w() / 2, get_h() / 2);
 	UI::center_vertically(rendered_text->height(), &pos);

--- a/src/ui_basic/spinbox.cc
+++ b/src/ui_basic/spinbox.cc
@@ -406,18 +406,18 @@ const std::string SpinBox::unit_text(int32_t value) const {
 	switch (sbi_->unit) {
 	case (Units::kMinutes):
 		/** TRANSLATORS: A spinbox unit */
-		return bformat(ngettext("%d minute", "%d minutes", value), value);
+		return format(ngettext("%d minute", "%d minutes", value), value);
 	case (Units::kPixels):
 		/** TRANSLATORS: A spinbox unit */
-		return bformat(ngettext("%d pixel", "%d pixels", value), value);
+		return format(ngettext("%d pixel", "%d pixels", value), value);
 	case (Units::kFields):
 		/** TRANSLATORS: A spinbox unit */
-		return bformat(ngettext("%d field", "%d fields", value), value);
+		return format(ngettext("%d field", "%d fields", value), value);
 	case (Units::kPercent):
 		/** TRANSLATORS: A spinbox unit */
-		return bformat(_("%i %%"), value);
+		return format(_("%i %%"), value);
 	case (Units::kNone):
-		return bformat("%d", value);
+		return format("%d", value);
 	}
 	NEVER_HERE();
 }

--- a/src/ui_fsmenu/about.cc
+++ b/src/ui_fsmenu/about.cc
@@ -69,8 +69,8 @@ About::About(MainMenu& fsmm, UI::UniqueWindow::Registry& r)
 			std::string label, localized_label, value, localized_value;
 		};
 		const std::vector<ContentT> content = {
-		   {"Version:", _("Version:"), bformat("%1$s (%2$s)", build_id(), build_type()),
-		    bformat(_("%1$s (%2$s)"), build_id(), build_type())},
+		   {"Version:", _("Version:"), format("%1$s (%2$s)", build_id(), build_type()),
+		    format(_("%1$s (%2$s)"), build_id(), build_type())},
 		   {"Operating System:", _("Operating System:"),
 #if defined(__APPLE__) || defined(__MACH__)
 		    "MacOS", _("MacOS")

--- a/src/ui_fsmenu/addons/contact.cc
+++ b/src/ui_fsmenu/addons/contact.cc
@@ -81,7 +81,7 @@ ContactForm::ContactForm(AddOnsCtrl& ctrl)
 			log_err("contact error: %s", e.what());
 			UI::WLMessageBox m(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(_("Unable to submit your enquiry.\nError message:\n%s"), e.what()),
+			   format(_("Unable to submit your enquiry.\nError message:\n%s"), e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 			return;

--- a/src/ui_fsmenu/addons/login_box.cc
+++ b/src/ui_fsmenu/addons/login_box.cc
@@ -72,7 +72,7 @@ AddOnsLoginBox::AddOnsLoginBox(AddOnsCtrl& ctrl)
 	   new UI::MultilineTextarea(&box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu, "",
 	                             UI::Align::kLeft, UI::MultilineTextarea::ScrollMode::kNoScrolling);
 	m->set_style(UI::FontStyle::kFsMenuInfoPanelParagraph);
-	m->set_text(bformat(
+	m->set_text(format(
 	   _("In order to use a registered account, you need an account on the Widelands website. "
 	     "Please log in at %s and set an online gaming password on your profile page."),
 	   "\n\nhttps://widelands.org/accounts/register/\n\n"));

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -68,13 +68,13 @@ std::string underline_tag(const std::string& text) {
 
 std::string filesize_string(const uint32_t bytes) {
 	if (bytes > 1000000000) {
-		return bformat_l(_("%.2f GB"), (bytes / 1000000000.f));
+		return format_l(_("%.2f GB"), (bytes / 1000000000.f));
 	} else if (bytes > 1000000) {
-		return bformat_l(_("%.2f MB"), (bytes / 1000000.f));
+		return format_l(_("%.2f MB"), (bytes / 1000000.f));
 	} else if (bytes > 1000) {
-		return bformat_l(_("%.2f kB"), (bytes / 1000.f));
+		return format_l(_("%.2f kB"), (bytes / 1000.f));
 	} else {
-		return bformat_l(_("%u bytes"), bytes);
+		return format_l(_("%u bytes"), bytes);
 	}
 }
 
@@ -346,9 +346,9 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 	dev_box_.add_space(kRowButtonSize);
 	dev_box_.add(new UI::MultilineTextarea(
 	                &dev_box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu,
-	                bformat("<rt><p>%1$s</p></rt>",
+	                format("<rt><p>%1$s</p></rt>",
 	                        g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-	                           .as_font_tag(bformat(
+	                           .as_font_tag(format(
 	                              _("For more information regarding how to develop and package your "
 	                                "own add-ons, please visit %s."),
 	                              underline_tag(kDocumentationURL)))),
@@ -379,7 +379,7 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 	dev_box_.add(
 	   new UI::MultilineTextarea(
 	      &dev_box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu,
-	      bformat(
+	      format(
 	         "<rt><p>%s</p><p>%s</p><p>%s</p><p>%s</p></rt>",
 	         g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 	            .as_font_tag(_(
@@ -429,10 +429,10 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 	dev_box_.add(
 	   new UI::MultilineTextarea(
 	      &dev_box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu,
-	      bformat("<rt><p>%1$s</p></rt>",
+	      format("<rt><p>%1$s</p></rt>",
 	              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 	                 .as_font_tag(
-	                    bformat(_("Technical problems? Unclear documentation? Advanced needs such "
+	                    format(_("Technical problems? Unclear documentation? Advanced needs such "
 	                              "as deletion of an add-on or collaborating with another add-on "
 	                              "designer? Please visit our forums at %s, explain your needs, and "
 	                              "the Widelands Development Team will be happy to help."),
@@ -446,7 +446,7 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 	dev_box_.add(
 	   new UI::MultilineTextarea(
 	      &dev_box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu,
-	      bformat("<rt><p>%1$s</p></rt>",
+	      format("<rt><p>%1$s</p></rt>",
 	              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 	                 .as_font_tag(
 	                    _("Alternatively you can also send a message to the Widelands Development "
@@ -521,7 +521,7 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 			UI::Checkbox* c =
 			   new UI::Checkbox(&browse_addons_buttons_box_category_box_, UI::PanelStyle::kFsMenu,
 			                    Vector2i(0, 0), g_image_cache->get(pair.second.icon),
-			                    bformat(_("Toggle category ‘%s’"), pair.second.descname()));
+			                    format(_("Toggle category ‘%s’"), pair.second.descname()));
 			filter_category_[pair.first] = c;
 			c->set_state(true);
 			c->changed.connect([this, &pair]() { category_filter_changed(pair.first); });
@@ -611,14 +611,14 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 		assert(!upgrades.empty());
 		if (nr_full_updates > 0 && (!all_verified || !(SDL_GetModState() & KMOD_CTRL))) {
 			// We ask for confirmation only for real upgrades. i18n-only upgrades are done silently.
-			std::string text = bformat(
+			std::string text = format(
 			   ngettext("Are you certain that you want to upgrade this %u add-on?",
 			            "Are you certain that you want to upgrade these %u add-ons?", nr_full_updates),
 			   nr_full_updates);
 			text += '\n';
 			for (const auto& pair : upgrades) {
 				if (pair.second) {
-					text += bformat(_("\n· %1$s (%2$s) by %3$s"), pair.first->descname(),
+					text += format(_("\n· %1$s (%2$s) by %3$s"), pair.first->descname(),
 					                (pair.first->verified ? _("verified") : _("NOT VERIFIED")),
 					                pair.first->author());
 				}
@@ -778,7 +778,7 @@ void AddOnsCtrl::update_login_button(UI::Button* b) {
 	} else {
 		upload_addon_accept_.set_enabled(true);
 		if (b) {
-			b->set_title(bformat(
+			b->set_title(format(
 			   net().is_admin() ? _("Logged in as %s (admin)") : _("Logged in as %s"), username_));
 			b->set_tooltip(_("Click to log out"));
 		}
@@ -816,7 +816,7 @@ void AddOnsCtrl::set_login(const std::string& username,
 			if (show_error) {
 				UI::WLMessageBox m(
 				   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Server Error"),
-				   bformat(_("Unable to connect to the server.\nError message:\n%s"), e.what()),
+				   format(_("Unable to connect to the server.\nError message:\n%s"), e.what()),
 				   UI::WLMessageBox::MBoxType::kOk);
 				m.run<UI::Panel::Returncodes>();
 			}
@@ -825,7 +825,7 @@ void AddOnsCtrl::set_login(const std::string& username,
 			if (show_error) {
 				UI::WLMessageBox m(
 				   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Wrong Password"),
-				   bformat(_("The entered username or password is invalid:\n%s"), e.what()),
+				   format(_("The entered username or password is invalid:\n%s"), e.what()),
 				   UI::WLMessageBox::MBoxType::kOk);
 				m.run<UI::Panel::Returncodes>();
 			}
@@ -931,7 +931,7 @@ void AddOnsCtrl::refresh_remotes(const bool showall) {
 		remotes_.resize(nr_addons);
 
 		for (int64_t i = 0, counter = 0; i < nr_addons; ++i, ++counter) {
-			progress.step(bformat_l(step_message, (100.0 * counter / nr_orig_entries)));
+			progress.step(format_l(step_message, (100.0 * counter / nr_orig_entries)));
 
 			try {
 				remotes_[i].reset(new AddOns::AddOnInfo(net().fetch_one_remote(names[i])));
@@ -948,7 +948,7 @@ void AddOnsCtrl::refresh_remotes(const bool showall) {
 		const std::string title = _("Server Connection Error");
 		/** TRANSLATORS: This will be inserted into the string "Server Connection Error <br> by %s" */
 		const std::string bug = _("a networking bug");
-		const std::string err = bformat(_("Unable to fetch the list of available add-ons from "
+		const std::string err = format(_("Unable to fetch the list of available add-ons from "
 		                                  "the server!<br>Error Message: %s"),
 		                                e.what());
 		std::shared_ptr<AddOns::AddOnInfo> i = std::make_shared<AddOns::AddOnInfo>();
@@ -965,7 +965,7 @@ void AddOnsCtrl::refresh_remotes(const bool showall) {
 		remotes_ = {i};
 	}
 
-	progress.step(bformat(step_message, 100));
+	progress.step(format(step_message, 100));
 	rebuild(false);
 }
 
@@ -1038,7 +1038,7 @@ void AddOnsCtrl::rebuild(const bool need_to_update_dependency_errors) {
 		upload_screenshot_.add(
 		   pair.first->internal_name, pair.first, pair.first->icon, false, pair.first->descname());
 	}
-	tabs_.tabs()[0]->set_title(bformat(_("Installed (%u)"), index));
+	tabs_.tabs()[0]->set_title(format(_("Installed (%u)"), index));
 
 	index = 0;
 	std::list<std::shared_ptr<AddOns::AddOnInfo>> remotes_to_show;
@@ -1116,7 +1116,7 @@ void AddOnsCtrl::rebuild(const bool need_to_update_dependency_errors) {
 		}
 		browse_.push_back(r);
 	}
-	tabs_.tabs()[1]->set_title(index == 0 ? _("Browse") : bformat(_("Browse (%u)"), index));
+	tabs_.tabs()[1]->set_title(index == 0 ? _("Browse") : format(_("Browse (%u)"), index));
 
 	if (installed_addons_inner_wrapper_.get_scrollbar() && scrollpos_i) {
 		installed_addons_inner_wrapper_.get_scrollbar()->set_scrollpos(scrollpos_i);
@@ -1126,17 +1126,17 @@ void AddOnsCtrl::rebuild(const bool need_to_update_dependency_errors) {
 	}
 
 	check_enable_move_buttons();
-	upgrade_all_.set_title(bformat(_("Upgrade all (%u)"), has_upgrades.size()));
+	upgrade_all_.set_title(format(_("Upgrade all (%u)"), has_upgrades.size()));
 	upgrade_all_.set_enabled(!has_upgrades.empty());
 	if (has_upgrades.empty()) {
 		upgrade_all_.set_tooltip(_("No upgrades are available for your installed add-ons"));
 	} else {
-		std::string text = bformat(ngettext("Upgrade the following %u add-on:",
+		std::string text = format(ngettext("Upgrade the following %u add-on:",
 		                                    "Upgrade the following %u add-ons:", has_upgrades.size()),
 		                           has_upgrades.size());
 		for (const std::string& name : has_upgrades) {
 			text += "<br>";
-			text += bformat(_("· %s"), name);
+			text += format(_("· %s"), name);
 		}
 		upgrade_all_.set_tooltip(text);
 	}
@@ -1172,18 +1172,18 @@ void AddOnsCtrl::update_dependency_errors() {
 			}
 			if (search_result == AddOns::g_addons.end()) {
 				warn_requirements.push_back(
-				   bformat(_("· ‘%1$s’ requires ‘%2$s’ which could not be found"),
+				   format(_("· ‘%1$s’ requires ‘%2$s’ which could not be found"),
 				           addon->first->descname(), requirement));
 			} else {
 				if (!search_result->second) {
-					warn_requirements.push_back(bformat(_("· ‘%1$s’ requires ‘%2$s’ which is disabled"),
+					warn_requirements.push_back(format(_("· ‘%1$s’ requires ‘%2$s’ which is disabled"),
 					                                    addon->first->descname(),
 					                                    search_result->first->descname()));
 				}
 				if (too_late &&
 				    AddOns::order_matters(addon->first->category, search_result->first->category)) {
 					warn_requirements.push_back(
-					   bformat(_("· ‘%1$s’ requires ‘%2$s’ which is listed below the requiring add-on"),
+					   format(_("· ‘%1$s’ requires ‘%2$s’ which is listed below the requiring add-on"),
 					           addon->first->descname(), search_result->first->descname()));
 				}
 			}
@@ -1209,7 +1209,7 @@ void AddOnsCtrl::update_dependency_errors() {
 				assert(prev != nullptr);
 				assert(!too_late || next != nullptr);
 				if (too_late && AddOns::order_matters(prev->category, next->category)) {
-					warn_requirements.push_back(bformat(
+					warn_requirements.push_back(format(
 					   _("· ‘%1$s’ requires first ‘%2$s’ and then ‘%3$s’, but they are "
 					     "listed in the wrong order"),
 					   addon->first->descname(), prev->descname(), search_result->first->descname()));
@@ -1225,7 +1225,7 @@ void AddOnsCtrl::update_dependency_errors() {
 			game.descriptions();
 		} catch (const std::exception& e) {
 			warn_requirements_.set_text(
-			   bformat(_("An enabled add-on is defective. No games can be started with the "
+			   format(_("An enabled add-on is defective. No games can be started with the "
 			             "current configuration.\nError message:\n%s"),
 			           e.what()));
 		}
@@ -1238,10 +1238,10 @@ void AddOnsCtrl::update_dependency_errors() {
 			}
 			list += msg;
 		}
-		warn_requirements_.set_text(bformat(
+		warn_requirements_.set_text(format(
 		   "<rt><p>%s</p><p>%s</p></rt>",
 		   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
-		      .as_font_tag(bformat(
+		      .as_font_tag(format(
 		         ngettext("%u Dependency Error", "%u Dependency Errors", nr_warnings), nr_warnings)),
 		   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph).as_font_tag(list)));
 		warn_requirements_.set_tooltip(_("Add-Ons with dependency errors may work incorrectly or "
@@ -1344,7 +1344,7 @@ void AddOnsCtrl::upload_addon(std::shared_ptr<AddOns::AddOnInfo> addon) {
 	upload_addon_.set_list_visibility(false);
 	{
 		UI::WLMessageBox w(&get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Upload"),
-		                   bformat(_("Do you really want to upload the add-on ‘%s’ to the server?"),
+		                   format(_("Do you really want to upload the add-on ‘%s’ to the server?"),
 		                           addon->internal_name),
 		                   UI::WLMessageBox::MBoxType::kOkCancel);
 		if (w.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
@@ -1352,14 +1352,14 @@ void AddOnsCtrl::upload_addon(std::shared_ptr<AddOns::AddOnInfo> addon) {
 		}
 	}
 	ProgressIndicatorWindow w(&get_topmost_forefather(), addon->descname());
-	w.set_message_1(bformat(_("Uploading ‘%s’…"), addon->descname()));
+	w.set_message_1(format(_("Uploading ‘%s’…"), addon->descname()));
 	try {
 		int64_t nr_files = 0;
 		net().upload_addon(
 		   addon->internal_name,
 		   [this, &w, &nr_files](const std::string& f, const int64_t l) {
 			   w.set_message_2(f);
-			   w.set_message_3(bformat(_("%1% / %2%"), l, nr_files));
+			   w.set_message_3(format(_("%1% / %2%"), l, nr_files));
 			   w.progressbar().set_state(l);
 			   do_redraw_now();
 			   if (w.is_dying()) {
@@ -1382,7 +1382,7 @@ void AddOnsCtrl::upload_addon(std::shared_ptr<AddOns::AddOnInfo> addon) {
 		w.set_visible(false);
 		UI::WLMessageBox m(
 		   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-		   bformat(
+		   format(
 		      _("The add-on ‘%1$s’ could not be uploaded to the server.\n\nError Message:\n%2$s"),
 		      addon->internal_name, e.what()),
 		   UI::WLMessageBox::MBoxType::kOk);
@@ -1395,7 +1395,7 @@ void AddOnsCtrl::upload_addon(std::shared_ptr<AddOns::AddOnInfo> addon) {
 void AddOnsCtrl::install_or_upgrade(std::shared_ptr<AddOns::AddOnInfo> remote,
                                     const bool only_translations) {
 	ProgressIndicatorWindow w(&get_topmost_forefather(), remote->descname());
-	w.set_message_1(bformat(_("Downloading ‘%s’…"), remote->descname()));
+	w.set_message_1(format(_("Downloading ‘%s’…"), remote->descname()));
 
 	std::string temp_dir =
 	   kTempFileDir + FileSystem::file_separator() + remote->internal_name + kTempFileExtension;
@@ -1414,7 +1414,7 @@ void AddOnsCtrl::install_or_upgrade(std::shared_ptr<AddOns::AddOnInfo> remote,
 			net().download_addon(remote->internal_name, temp_dir,
 			                     [this, &w, size](const std::string& f, const int64_t l) {
 				                     w.set_message_2(f);
-				                     w.set_message_3(bformat(_("%1% / %2%"), filesize_string(l), size));
+				                     w.set_message_3(format(_("%1% / %2%"), filesize_string(l), size));
 				                     w.progressbar().set_state(l);
 				                     do_redraw_now();
 				                     if (w.is_dying()) {
@@ -1429,7 +1429,7 @@ void AddOnsCtrl::install_or_upgrade(std::shared_ptr<AddOns::AddOnInfo> remote,
 			w.set_visible(false);
 			UI::WLMessageBox m(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(
+			   format(
 			      _("The add-on ‘%1$s’ could not be downloaded from the server. Installing/upgrading "
 			        "this add-on will be skipped.\n\nError Message:\n%2$s"),
 			      remote->internal_name, e.what()),
@@ -1477,7 +1477,7 @@ void AddOnsCtrl::install_or_upgrade(std::shared_ptr<AddOns::AddOnInfo> remote,
 		   remote->internal_name, temp_dir,
 		   [this, &w, &nr_translations](const std::string& f, const int64_t l) {
 			   w.set_message_2(f);
-			   w.set_message_3(bformat(_("%1% / %2%"), l, nr_translations));
+			   w.set_message_3(format(_("%1% / %2%"), l, nr_translations));
 			   w.progressbar().set_state(l);
 			   do_redraw_now();
 			   if (w.is_dying()) {
@@ -1508,7 +1508,7 @@ void AddOnsCtrl::install_or_upgrade(std::shared_ptr<AddOns::AddOnInfo> remote,
 		w.set_visible(false);
 		UI::WLMessageBox m(
 		   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-		   bformat(_("The translations for the add-on ‘%1$s’ could not be downloaded from the "
+		   format(_("The translations for the add-on ‘%1$s’ could not be downloaded from the "
 		             "server. Installing/upgrading "
 		             "the translations will be skipped.\n\nError Message:\n%2$s"),
 		           remote->internal_name, e.what()),
@@ -1577,7 +1577,7 @@ step1:
 		if (!found) {
 			UI::WLMessageBox w(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(_("The required add-on ‘%s’ could not be found on the server.") ,
+			   format(_("The required add-on ‘%s’ could not be found on the server.") ,
 			    addon_to_install)
 			      ,
 			   UI::WLMessageBox::MBoxType::kOk);

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -347,11 +347,11 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 	dev_box_.add(new UI::MultilineTextarea(
 	                &dev_box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu,
 	                format("<rt><p>%1$s</p></rt>",
-	                        g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-	                           .as_font_tag(format(
-	                              _("For more information regarding how to develop and package your "
-	                                "own add-ons, please visit %s."),
-	                              underline_tag(kDocumentationURL)))),
+	                       g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+	                          .as_font_tag(format(
+	                             _("For more information regarding how to develop and package your "
+	                               "own add-ons, please visit %s."),
+	                             underline_tag(kDocumentationURL)))),
 	                UI::Align::kLeft, UI::MultilineTextarea::ScrollMode::kNoScrolling),
 	             UI::Box::Resizing::kFullSize);
 	auto add_button = [this](const std::string& url) {
@@ -430,13 +430,13 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 	   new UI::MultilineTextarea(
 	      &dev_box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu,
 	      format("<rt><p>%1$s</p></rt>",
-	              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-	                 .as_font_tag(
-	                    format(_("Technical problems? Unclear documentation? Advanced needs such "
-	                              "as deletion of an add-on or collaborating with another add-on "
-	                              "designer? Please visit our forums at %s, explain your needs, and "
-	                              "the Widelands Development Team will be happy to help."),
-	                            underline_tag(kForumURL)))),
+	             g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+	                .as_font_tag(
+	                   format(_("Technical problems? Unclear documentation? Advanced needs such "
+	                            "as deletion of an add-on or collaborating with another add-on "
+	                            "designer? Please visit our forums at %s, explain your needs, and "
+	                            "the Widelands Development Team will be happy to help."),
+	                          underline_tag(kForumURL)))),
 	      UI::Align::kLeft, UI::MultilineTextarea::ScrollMode::kNoScrolling),
 	   UI::Box::Resizing::kFullSize);
 	dev_box_.add_space(kRowButtonSpacing);
@@ -447,15 +447,15 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 	   new UI::MultilineTextarea(
 	      &dev_box_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu,
 	      format("<rt><p>%1$s</p></rt>",
-	              g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-	                 .as_font_tag(
-	                    _("Alternatively you can also send a message to the Widelands Development "
-	                      "Team and we’ll try to help you with your enquiry as soon as we can. "
-	                      "Only the server administrators can read messages sent in this way. "
-	                      "Since other add-on designers can usually benefit from others’ questions "
-	                      "and answers, please use this way of communication only if there is a "
-	                      "reason why your concern is not for everyone’s ears. You’ll receive our "
-	                      "reply via a PM on your Widelands website user profile page."))),
+	             g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+	                .as_font_tag(
+	                   _("Alternatively you can also send a message to the Widelands Development "
+	                     "Team and we’ll try to help you with your enquiry as soon as we can. "
+	                     "Only the server administrators can read messages sent in this way. "
+	                     "Since other add-on designers can usually benefit from others’ questions "
+	                     "and answers, please use this way of communication only if there is a "
+	                     "reason why your concern is not for everyone’s ears. You’ll receive our "
+	                     "reply via a PM on your Widelands website user profile page."))),
 	      UI::Align::kLeft, UI::MultilineTextarea::ScrollMode::kNoScrolling),
 	   UI::Box::Resizing::kFullSize);
 	contact_.sigclicked.connect([this]() {
@@ -619,8 +619,8 @@ AddOnsCtrl::AddOnsCtrl(MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
 			for (const auto& pair : upgrades) {
 				if (pair.second) {
 					text += format(_("\n· %1$s (%2$s) by %3$s"), pair.first->descname(),
-					                (pair.first->verified ? _("verified") : _("NOT VERIFIED")),
-					                pair.first->author());
+					               (pair.first->verified ? _("verified") : _("NOT VERIFIED")),
+					               pair.first->author());
 				}
 			}
 			UI::WLMessageBox w(&get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Upgrade All"),
@@ -949,8 +949,8 @@ void AddOnsCtrl::refresh_remotes(const bool showall) {
 		/** TRANSLATORS: This will be inserted into the string "Server Connection Error <br> by %s" */
 		const std::string bug = _("a networking bug");
 		const std::string err = format(_("Unable to fetch the list of available add-ons from "
-		                                  "the server!<br>Error Message: %s"),
-		                                e.what());
+		                                 "the server!<br>Error Message: %s"),
+		                               e.what());
 		std::shared_ptr<AddOns::AddOnInfo> i = std::make_shared<AddOns::AddOnInfo>();
 		i->unlocalized_descname = title;
 		i->unlocalized_description = err;
@@ -1132,8 +1132,8 @@ void AddOnsCtrl::rebuild(const bool need_to_update_dependency_errors) {
 		upgrade_all_.set_tooltip(_("No upgrades are available for your installed add-ons"));
 	} else {
 		std::string text = format(ngettext("Upgrade the following %u add-on:",
-		                                    "Upgrade the following %u add-ons:", has_upgrades.size()),
-		                           has_upgrades.size());
+		                                   "Upgrade the following %u add-ons:", has_upgrades.size()),
+		                          has_upgrades.size());
 		for (const std::string& name : has_upgrades) {
 			text += "<br>";
 			text += format(_("· %s"), name);
@@ -1173,18 +1173,18 @@ void AddOnsCtrl::update_dependency_errors() {
 			if (search_result == AddOns::g_addons.end()) {
 				warn_requirements.push_back(
 				   format(_("· ‘%1$s’ requires ‘%2$s’ which could not be found"),
-				           addon->first->descname(), requirement));
+				          addon->first->descname(), requirement));
 			} else {
 				if (!search_result->second) {
 					warn_requirements.push_back(format(_("· ‘%1$s’ requires ‘%2$s’ which is disabled"),
-					                                    addon->first->descname(),
-					                                    search_result->first->descname()));
+					                                   addon->first->descname(),
+					                                   search_result->first->descname()));
 				}
 				if (too_late &&
 				    AddOns::order_matters(addon->first->category, search_result->first->category)) {
 					warn_requirements.push_back(
 					   format(_("· ‘%1$s’ requires ‘%2$s’ which is listed below the requiring add-on"),
-					           addon->first->descname(), search_result->first->descname()));
+					          addon->first->descname(), search_result->first->descname()));
 				}
 			}
 			// Also warn if the add-on's requirements are present in the wrong order
@@ -1226,8 +1226,8 @@ void AddOnsCtrl::update_dependency_errors() {
 		} catch (const std::exception& e) {
 			warn_requirements_.set_text(
 			   format(_("An enabled add-on is defective. No games can be started with the "
-			             "current configuration.\nError message:\n%s"),
-			           e.what()));
+			            "current configuration.\nError message:\n%s"),
+			          e.what()));
 		}
 	} else {
 		const unsigned nr_warnings = warn_requirements.size();
@@ -1345,7 +1345,7 @@ void AddOnsCtrl::upload_addon(std::shared_ptr<AddOns::AddOnInfo> addon) {
 	{
 		UI::WLMessageBox w(&get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Upload"),
 		                   format(_("Do you really want to upload the add-on ‘%s’ to the server?"),
-		                           addon->internal_name),
+		                          addon->internal_name),
 		                   UI::WLMessageBox::MBoxType::kOkCancel);
 		if (w.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
 			return;
@@ -1382,9 +1382,8 @@ void AddOnsCtrl::upload_addon(std::shared_ptr<AddOns::AddOnInfo> addon) {
 		w.set_visible(false);
 		UI::WLMessageBox m(
 		   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-		   format(
-		      _("The add-on ‘%1$s’ could not be uploaded to the server.\n\nError Message:\n%2$s"),
-		      addon->internal_name, e.what()),
+		   format(_("The add-on ‘%1$s’ could not be uploaded to the server.\n\nError Message:\n%2$s"),
+		          addon->internal_name, e.what()),
 		   UI::WLMessageBox::MBoxType::kOk);
 		m.run<UI::Panel::Returncodes>();
 	}
@@ -1509,9 +1508,9 @@ void AddOnsCtrl::install_or_upgrade(std::shared_ptr<AddOns::AddOnInfo> remote,
 		UI::WLMessageBox m(
 		   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
 		   format(_("The translations for the add-on ‘%1$s’ could not be downloaded from the "
-		             "server. Installing/upgrading "
-		             "the translations will be skipped.\n\nError Message:\n%2$s"),
-		           remote->internal_name, e.what()),
+		            "server. Installing/upgrading "
+		            "the translations will be skipped.\n\nError Message:\n%2$s"),
+		          remote->internal_name, e.what()),
 		   UI::WLMessageBox::MBoxType::kOk);
 		m.run<UI::Panel::Returncodes>();
 	}

--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -336,7 +336,7 @@ void AddOnsPackager::clicked_new_addon() {
 		if (!err.empty()) {
 			main_menu_.show_messagebox(
 			   _("Invalid Name"),
-			   bformat(_("This name is invalid. Reason: %s\n\nPlease choose a different name."), err));
+			   format(_("This name is invalid. Reason: %s\n\nPlease choose a different name."), err));
 			continue;
 		}
 
@@ -383,7 +383,7 @@ void AddOnsPackager::clicked_delete_addon() {
 	const std::string& name = addons_.get_selected();
 	UI::WLMessageBox m(
 	   get_parent(), UI::WindowStyle::kFsMenu, _("Delete Add-on"),
-	   bformat(ctrl_.is_remote(name) ?
+	   format(ctrl_.is_remote(name) ?
                  _("Do you really want to delete the add-on ‘%s’?") :
                  _("Do you really want to delete the local add-on ‘%s’?\n\nNote that this "
 	                "add-on can not be downloaded again from the server."),
@@ -404,7 +404,7 @@ void AddOnsPackager::clicked_delete_addon() {
 void AddOnsPackager::die() {
 	if (!addons_with_changes_.empty()) {
 		std::string msg =
-		   bformat(ngettext(
+		   format(ngettext(
 		              // Comments to fix codecheck false-positive
 		              "If you quit the packager now, all changes to the following %u add-on "
 		              "will be discarded.",
@@ -415,7 +415,7 @@ void AddOnsPackager::die() {
 		              addons_with_changes_.size()),
 		           addons_with_changes_.size());
 		for (const auto& str : addons_with_changes_) {
-			msg = bformat(_("%1$s\n· %2$s"), msg, str.first);
+			msg = format(_("%1$s\n· %2$s"), msg, str.first);
 		}
 
 		UI::WLMessageBox m(get_parent(), UI::WindowStyle::kFsMenu, _("Quit Packager"), msg,
@@ -433,16 +433,16 @@ void AddOnsPackager::clicked_discard_changes() {
 
 	std::string msg;
 	if (addons_with_changes_.size() == 1) {
-		msg = bformat(_("Do you really want to discard all changes to the add-on ‘%s’?"),
+		msg = format(_("Do you really want to discard all changes to the add-on ‘%s’?"),
 		              addons_with_changes_.begin()->first);
 	} else {
 		msg =
-		   bformat(ngettext("Do you really want to discard all changes to the following %u add-on?",
+		   format(ngettext("Do you really want to discard all changes to the following %u add-on?",
 		                    "Do you really want to discard all changes to the following %u add-ons?",
 		                    addons_with_changes_.size()),
 		           addons_with_changes_.size());
 		for (const auto& str : addons_with_changes_) {
-			msg = bformat(_("%1$s\n· %2$s"), msg, str.first);
+			msg = format(_("%1$s\n· %2$s"), msg, str.first);
 		}
 	}
 
@@ -458,16 +458,16 @@ void AddOnsPackager::clicked_write_changes() {
 
 	std::string msg;
 	if (addons_with_changes_.size() == 1) {
-		msg = bformat(_("Do you really want to commit all changes to the add-on ‘%s’ to disk?"),
+		msg = format(_("Do you really want to commit all changes to the add-on ‘%s’ to disk?"),
 		              addons_with_changes_.begin()->first);
 	} else {
-		msg = bformat(
+		msg = format(
 		   ngettext("Do you really want to commit all changes to the following %u add-on to disk?",
 		            "Do you really want to commit all changes to the following %u add-ons to disk?",
 		            addons_with_changes_.size()),
 		   addons_with_changes_.size());
 		for (const auto& str : addons_with_changes_) {
-			msg = bformat(_("%1$s\n· %2$s"), msg, str.first);
+			msg = format(_("%1$s\n· %2$s"), msg, str.first);
 		}
 	}
 	msg += "\n\n";
@@ -529,7 +529,7 @@ bool AddOnsPackager::do_write_addon_to_disk(const std::string& addon) {
 	} catch (...) {
 		main_menu_.show_messagebox(
 		   _("Invalid Version"),
-		   bformat(_("‘%1$s’ is not a valid version string. The add-on ‘%2$s’ will not be saved."),
+		   format(_("‘%1$s’ is not a valid version string. The add-on ‘%2$s’ will not be saved."),
 		           m->get_version(), addon));
 		return false;
 	}
@@ -539,7 +539,7 @@ bool AddOnsPackager::do_write_addon_to_disk(const std::string& addon) {
 	} catch (const WLWarning& e) {
 		main_menu_.show_messagebox(
 		   _("Error Writing Addon"),
-		   bformat(_("The add-on ‘%1$s’ can not be saved to disk:\n%2$s"), addon, e.what()));
+		   format(_("The add-on ‘%1$s’ can not be saved to disk:\n%2$s"), addon, e.what()));
 		return false;
 	}
 }

--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -384,10 +384,10 @@ void AddOnsPackager::clicked_delete_addon() {
 	UI::WLMessageBox m(
 	   get_parent(), UI::WindowStyle::kFsMenu, _("Delete Add-on"),
 	   format(ctrl_.is_remote(name) ?
-                 _("Do you really want to delete the add-on ‘%s’?") :
-                 _("Do you really want to delete the local add-on ‘%s’?\n\nNote that this "
-	                "add-on can not be downloaded again from the server."),
-	           name),
+                _("Do you really want to delete the add-on ‘%s’?") :
+                _("Do you really want to delete the local add-on ‘%s’?\n\nNote that this "
+	               "add-on can not be downloaded again from the server."),
+	          name),
 	   UI::WLMessageBox::MBoxType::kOkCancel);
 	if (m.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
 		return;
@@ -405,15 +405,15 @@ void AddOnsPackager::die() {
 	if (!addons_with_changes_.empty()) {
 		std::string msg =
 		   format(ngettext(
-		              // Comments to fix codecheck false-positive
-		              "If you quit the packager now, all changes to the following %u add-on "
-		              "will be discarded.",
-		              // Comments to fix codecheck false-positive
-		              "If you quit the packager now, all changes to the following %u add-ons "
-		              "will be discarded.",
-		              // Comments to fix codecheck false-positive
-		              addons_with_changes_.size()),
-		           addons_with_changes_.size());
+		             // Comments to fix codecheck false-positive
+		             "If you quit the packager now, all changes to the following %u add-on "
+		             "will be discarded.",
+		             // Comments to fix codecheck false-positive
+		             "If you quit the packager now, all changes to the following %u add-ons "
+		             "will be discarded.",
+		             // Comments to fix codecheck false-positive
+		             addons_with_changes_.size()),
+		          addons_with_changes_.size());
 		for (const auto& str : addons_with_changes_) {
 			msg = format(_("%1$s\n· %2$s"), msg, str.first);
 		}
@@ -434,13 +434,13 @@ void AddOnsPackager::clicked_discard_changes() {
 	std::string msg;
 	if (addons_with_changes_.size() == 1) {
 		msg = format(_("Do you really want to discard all changes to the add-on ‘%s’?"),
-		              addons_with_changes_.begin()->first);
+		             addons_with_changes_.begin()->first);
 	} else {
 		msg =
 		   format(ngettext("Do you really want to discard all changes to the following %u add-on?",
-		                    "Do you really want to discard all changes to the following %u add-ons?",
-		                    addons_with_changes_.size()),
-		           addons_with_changes_.size());
+		                   "Do you really want to discard all changes to the following %u add-ons?",
+		                   addons_with_changes_.size()),
+		          addons_with_changes_.size());
 		for (const auto& str : addons_with_changes_) {
 			msg = format(_("%1$s\n· %2$s"), msg, str.first);
 		}
@@ -459,7 +459,7 @@ void AddOnsPackager::clicked_write_changes() {
 	std::string msg;
 	if (addons_with_changes_.size() == 1) {
 		msg = format(_("Do you really want to commit all changes to the add-on ‘%s’ to disk?"),
-		              addons_with_changes_.begin()->first);
+		             addons_with_changes_.begin()->first);
 	} else {
 		msg = format(
 		   ngettext("Do you really want to commit all changes to the following %u add-on to disk?",
@@ -530,7 +530,7 @@ bool AddOnsPackager::do_write_addon_to_disk(const std::string& addon) {
 		main_menu_.show_messagebox(
 		   _("Invalid Version"),
 		   format(_("‘%1$s’ is not a valid version string. The add-on ‘%2$s’ will not be saved."),
-		           m->get_version(), addon));
+		          m->get_version(), addon));
 		return false;
 	}
 

--- a/src/ui_fsmenu/addons/packager_box.cc
+++ b/src/ui_fsmenu/addons/packager_box.cc
@@ -61,12 +61,12 @@ std::string check_addon_filename_validity(const std::string& name) {
 
 	size_t pos = name.find_first_not_of(kValidAddOnFilenameChars);
 	if (pos != std::string::npos) {
-		return bformat(_("Invalid character ‘%c’"), name.at(pos));
+		return format(_("Invalid character ‘%c’"), name.at(pos));
 	}
 
 	for (const std::string& q : kInvalidAddOnFilenameSequences) {
 		if (name.find(q) != std::string::npos) {
-			return bformat(_("Filename may not contain ‘%s’"), q);
+			return format(_("Filename may not contain ‘%s’"), q);
 		}
 	}
 
@@ -267,20 +267,20 @@ void MapsAddOnsPackagerBox::load_addon(AddOns::MutableAddOn* a) {
 			}
 			my_maps_.add(
 			   entry.first.localized_name, entry.first.filename, nullptr, false,
-			   bformat("%s<br>%s<br>%s<br>%s<br>%s",
+			   format("%s<br>%s<br>%s<br>%s<br>%s",
 			           g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
 			              .as_font_tag(entry.first.filename),
-			           bformat(_("Name: %s"),
+			           format(_("Name: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                      .as_font_tag(entry.first.localized_name)),
-			           bformat(_("Size: %s"),
+			           format(_("Size: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                      .as_font_tag(
-			                         bformat(_("%1$u×%2$u"), entry.first.width, entry.first.height))),
-			           bformat(_("Players: %s"),
+			                         format(_("%1$u×%2$u"), entry.first.width, entry.first.height))),
+			           format(_("Players: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                      .as_font_tag(std::to_string(entry.first.nrplayers))),
-			           bformat(_("Description: %s"),
+			           format(_("Description: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                      .as_font_tag(entry.first.description))));
 		}
@@ -370,7 +370,7 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 		if (!g_fs->is_directory(map)) {
 			UI::WLMessageBox mbox(
 			   &main_menu_, UI::WindowStyle::kFsMenu, _("Zipped Map"),
-			   bformat(_("The map ‘%s’ is not a directory. "
+			   format(_("The map ‘%s’ is not a directory. "
 			             "Please consider disabling the ‘Compress widelands data files’ option "
 			             "in the options menu and resaving the map in the editor."
 			             "\n\nDo you want to add this map anyway?"),
@@ -399,7 +399,7 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 			if (!err.empty()) {
 				main_menu_.show_messagebox(
 				   _("Invalid Name"),
-				   bformat(
+				   format(
 				      _("This name is invalid. Reason: %s\n\nPlease choose a different name."), err));
 				continue;
 			}
@@ -407,7 +407,7 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 			     {kWidelandsMapExtension, kS2MapExtension1, kS2MapExtension2}) {
 				if (name.size() >= ext.size() &&
 				    name.compare(name.size() - ext.size(), ext.size(), ext) == 0) {
-					err = bformat(_("Directories may not use the extension ‘%s’.\n\nPlease "
+					err = format(_("Directories may not use the extension ‘%s’.\n\nPlease "
 					                "choose a different name."),
 					              ext);
 					break;
@@ -436,9 +436,9 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 		UI::WLMessageBox mbox(
 		   &main_menu_, UI::WindowStyle::kFsMenu, _("Delete"),
 		   selected_map.empty() ?
-            bformat(_("Do you really want to delete the directory ‘%s’ and all its contents?"),
+            format(_("Do you really want to delete the directory ‘%s’ and all its contents?"),
 		              select.back()) :
-            bformat(_("Do you really want to delete the map ‘%s’?"), selected_map),
+            format(_("Do you really want to delete the map ‘%s’?"), selected_map),
 		   UI::WLMessageBox::MBoxType::kOkCancel, UI::Align::kLeft);
 		if (mbox.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
 			return;

--- a/src/ui_fsmenu/addons/packager_box.cc
+++ b/src/ui_fsmenu/addons/packager_box.cc
@@ -268,21 +268,21 @@ void MapsAddOnsPackagerBox::load_addon(AddOns::MutableAddOn* a) {
 			my_maps_.add(
 			   entry.first.localized_name, entry.first.filename, nullptr, false,
 			   format("%s<br>%s<br>%s<br>%s<br>%s",
-			           g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
-			              .as_font_tag(entry.first.filename),
-			           format(_("Name: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(entry.first.localized_name)),
-			           format(_("Size: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(
-			                         format(_("%1$u×%2$u"), entry.first.width, entry.first.height))),
-			           format(_("Players: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(std::to_string(entry.first.nrplayers))),
-			           format(_("Description: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(entry.first.description))));
+			          g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
+			             .as_font_tag(entry.first.filename),
+			          format(_("Name: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(entry.first.localized_name)),
+			          format(_("Size: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(
+			                       format(_("%1$u×%2$u"), entry.first.width, entry.first.height))),
+			          format(_("Players: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(std::to_string(entry.first.nrplayers))),
+			          format(_("Description: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(entry.first.description))));
 		}
 	}
 
@@ -371,10 +371,10 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 			UI::WLMessageBox mbox(
 			   &main_menu_, UI::WindowStyle::kFsMenu, _("Zipped Map"),
 			   format(_("The map ‘%s’ is not a directory. "
-			             "Please consider disabling the ‘Compress widelands data files’ option "
-			             "in the options menu and resaving the map in the editor."
-			             "\n\nDo you want to add this map anyway?"),
-			           filename),
+			            "Please consider disabling the ‘Compress widelands data files’ option "
+			            "in the options menu and resaving the map in the editor."
+			            "\n\nDo you want to add this map anyway?"),
+			          filename),
 			   UI::WLMessageBox::MBoxType::kOkCancel, UI::Align::kLeft);
 			if (mbox.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
 				return;
@@ -408,8 +408,8 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 				if (name.size() >= ext.size() &&
 				    name.compare(name.size() - ext.size(), ext.size(), ext) == 0) {
 					err = format(_("Directories may not use the extension ‘%s’.\n\nPlease "
-					                "choose a different name."),
-					              ext);
+					               "choose a different name."),
+					             ext);
 					break;
 				}
 			}
@@ -437,7 +437,7 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 		   &main_menu_, UI::WindowStyle::kFsMenu, _("Delete"),
 		   selected_map.empty() ?
             format(_("Do you really want to delete the directory ‘%s’ and all its contents?"),
-		              select.back()) :
+		             select.back()) :
             format(_("Do you really want to delete the map ‘%s’?"), selected_map),
 		   UI::WLMessageBox::MBoxType::kOkCancel, UI::Align::kLeft);
 		if (mbox.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -681,10 +681,9 @@ RemoteInteractionWindow::RemoteInteractionWindow(AddOnsCtrl& parent,
 			parent_.net().vote(info_->internal_name, current_vote_);
 			*info_ = parent_.net().fetch_one_remote(info_->internal_name);
 		} catch (const std::exception& e) {
-			UI::WLMessageBox w(
-			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   format(_("The vote could not be submitted.\nError code: %s"), e.what()),
-			   UI::WLMessageBox::MBoxType::kOk);
+			UI::WLMessageBox w(&get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
+			                   format(_("The vote could not be submitted.\nError code: %s"), e.what()),
+			                   UI::WLMessageBox::MBoxType::kOk);
 			w.run<UI::Panel::Returncodes>();
 			return;
 		}
@@ -827,8 +826,8 @@ void RemoteInteractionWindow::update_data() {
 	voting_stats_summary_.set_text(
 	   info_->number_of_votes() ?
          format_l(ngettext("Average rating: %1$.3f (%2$u vote)",
-	                         "Average rating: %1$.3f (%2$u votes)", info_->number_of_votes()),
-	                info_->average_rating(), info_->number_of_votes()) :
+	                        "Average rating: %1$.3f (%2$u votes)", info_->number_of_votes()),
+	               info_->average_rating(), info_->number_of_votes()) :
          _("No votes yet"));
 
 	uint32_t most_votes = 1;
@@ -849,7 +848,7 @@ void RemoteInteractionWindow::update_data() {
 	              info_->user_comments.empty() ?
                     _("No comments yet.") :
                     format(ngettext("%u comment:", "%u comments:", info_->user_comments.size()),
-	                         info_->user_comments.size()));
+	                        info_->user_comments.size()));
 	text += "</p></rt>";
 	comments_header_.set_text(text);
 	for (const auto& comment : info_->user_comments) {
@@ -860,8 +859,8 @@ void RemoteInteractionWindow::update_data() {
 		} else if (comment.second.editor == comment.second.username) {
 			text += g_style_manager->font_style(UI::FontStyle::kItalic)
 			           .as_font_tag(format(_("%1$s (edited on %2$s)"),
-			                                time_string(comment.second.timestamp),
-			                                time_string(comment.second.edit_timestamp)));
+			                               time_string(comment.second.timestamp),
+			                               time_string(comment.second.edit_timestamp)));
 		} else {
 			text += g_style_manager->font_style(UI::FontStyle::kItalic)
 			           .as_font_tag(format(
@@ -872,7 +871,7 @@ void RemoteInteractionWindow::update_data() {
 		text +=
 		   g_style_manager->font_style(UI::FontStyle::kItalic)
 		      .as_font_tag(format(_("‘%1$s’ commented on version %2$s:"), comment.second.username,
-		                           AddOns::version_to_string(comment.second.version)));
+		                          AddOns::version_to_string(comment.second.version)));
 		text += "<br>";
 		text += g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 		           .as_font_tag(comment.second.message);
@@ -897,8 +896,7 @@ void RemoteInteractionWindow::next_screenshot(int8_t delta) {
 	auto it = info_->screenshots.begin();
 	std::advance(it, current_screenshot_);
 
-	screenshot_stats_.set_text(
-	   format(_("%1$u / %2$u"), (current_screenshot_ + 1), nr_screenshots_));
+	screenshot_stats_.set_text(format(_("%1$u / %2$u"), (current_screenshot_ + 1), nr_screenshots_));
 	screenshot_descr_.set_text(it->second);
 	screenshot_.set_tooltip("");
 

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -102,7 +102,7 @@ CommentRow::CommentRow(AddOnsCtrl& ctrl,
 			        e.what());
 			UI::WLMessageBox m(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(_("The comment could not be deleted.\n\nError Message:\n%s"), e.what()),
+			   format(_("The comment could not be deleted.\n\nError Message:\n%s"), e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 		}
@@ -292,7 +292,7 @@ CommentEditor::CommentEditor(AddOnsCtrl& ctrl,
 			}
 			UI::WLMessageBox m(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(_("The comment could not be submitted.\n\nError Message:\n%s"), e.what()),
+			   format(_("The comment could not be submitted.\n\nError Message:\n%s"), e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 		}
@@ -683,7 +683,7 @@ RemoteInteractionWindow::RemoteInteractionWindow(AddOnsCtrl& parent,
 		} catch (const std::exception& e) {
 			UI::WLMessageBox w(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(_("The vote could not be submitted.\nError code: %s"), e.what()),
+			   format(_("The vote could not be submitted.\nError code: %s"), e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			w.run<UI::Panel::Returncodes>();
 			return;
@@ -743,7 +743,7 @@ RemoteInteractionWindow::RemoteInteractionWindow(AddOnsCtrl& parent,
 	tabs_.add("comments", "", &box_comments_);
 	if (nr_screenshots_) {
 		tabs_.add(
-		   "screenshots", bformat(_("Screenshots (%u)"), info_->screenshots.size()), &box_screenies_);
+		   "screenshots", format(_("Screenshots (%u)"), info_->screenshots.size()), &box_screenies_);
 		tabs_.sigclicked.connect([this]() {
 			if (tabs_.active() == 1) {
 				next_screenshot(0);
@@ -821,12 +821,12 @@ void RemoteInteractionWindow::layout() {
 }
 
 void RemoteInteractionWindow::update_data() {
-	(*tabs_.tabs().begin())->set_title(bformat(_("Comments (%u)"), info_->user_comments.size()));
-	(*tabs_.tabs().rbegin())->set_title(bformat(_("Votes (%u)"), info_->number_of_votes()));
+	(*tabs_.tabs().begin())->set_title(format(_("Comments (%u)"), info_->user_comments.size()));
+	(*tabs_.tabs().rbegin())->set_title(format(_("Votes (%u)"), info_->number_of_votes()));
 
 	voting_stats_summary_.set_text(
 	   info_->number_of_votes() ?
-         bformat_l(ngettext("Average rating: %1$.3f (%2$u vote)",
+         format_l(ngettext("Average rating: %1$.3f (%2$u vote)",
 	                         "Average rating: %1$.3f (%2$u votes)", info_->number_of_votes()),
 	                info_->average_rating(), info_->number_of_votes()) :
          _("No votes yet"));
@@ -848,7 +848,7 @@ void RemoteInteractionWindow::update_data() {
 	           .as_font_tag(
 	              info_->user_comments.empty() ?
                     _("No comments yet.") :
-                    bformat(ngettext("%u comment:", "%u comments:", info_->user_comments.size()),
+                    format(ngettext("%u comment:", "%u comments:", info_->user_comments.size()),
 	                         info_->user_comments.size()));
 	text += "</p></rt>";
 	comments_header_.set_text(text);
@@ -859,19 +859,19 @@ void RemoteInteractionWindow::update_data() {
 			           .as_font_tag(time_string(comment.second.timestamp));
 		} else if (comment.second.editor == comment.second.username) {
 			text += g_style_manager->font_style(UI::FontStyle::kItalic)
-			           .as_font_tag(bformat(_("%1$s (edited on %2$s)"),
+			           .as_font_tag(format(_("%1$s (edited on %2$s)"),
 			                                time_string(comment.second.timestamp),
 			                                time_string(comment.second.edit_timestamp)));
 		} else {
 			text += g_style_manager->font_style(UI::FontStyle::kItalic)
-			           .as_font_tag(bformat(
+			           .as_font_tag(format(
 			              _("%1$s (edited by ‘%2$s’ on %3$s)"), time_string(comment.second.timestamp),
 			              comment.second.editor, time_string(comment.second.edit_timestamp)));
 		}
 		text += "<br>";
 		text +=
 		   g_style_manager->font_style(UI::FontStyle::kItalic)
-		      .as_font_tag(bformat(_("‘%1$s’ commented on version %2$s:"), comment.second.username,
+		      .as_font_tag(format(_("‘%1$s’ commented on version %2$s:"), comment.second.username,
 		                           AddOns::version_to_string(comment.second.version)));
 		text += "<br>";
 		text += g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
@@ -898,7 +898,7 @@ void RemoteInteractionWindow::next_screenshot(int8_t delta) {
 	std::advance(it, current_screenshot_);
 
 	screenshot_stats_.set_text(
-	   bformat(_("%1$u / %2$u"), (current_screenshot_ + 1), nr_screenshots_));
+	   format(_("%1$u / %2$u"), (current_screenshot_ + 1), nr_screenshots_));
 	screenshot_descr_.set_text(it->second);
 	screenshot_.set_tooltip("");
 

--- a/src/ui_fsmenu/addons/rows_ui.cc
+++ b/src/ui_fsmenu/addons/rows_ui.cc
@@ -43,7 +43,7 @@ void uninstall(AddOnsCtrl* ctrl, std::shared_ptr<AddOns::AddOnInfo> info, const 
 	if (!(SDL_GetModState() & KMOD_CTRL)) {
 		UI::WLMessageBox w(
 		   &ctrl->get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Uninstall"),
-		   safe_richtext_message(bformat(
+		   safe_richtext_message(format(
 		      local ? _("Are you certain that you want to uninstall this add-on?\n\n"
 		                "%1$s\n"
 		                "by %2$s\n"
@@ -100,11 +100,11 @@ std::string required_wl_version_and_sync_safety_string(std::shared_ptr<AddOns::A
 		result += "<br>";
 		std::string str;
 		if (info->max_wl_version.empty()) {
-			str += bformat(_("Requires a Widelands version of at least %s."), info->min_wl_version);
+			str += format(_("Requires a Widelands version of at least %s."), info->min_wl_version);
 		} else if (info->min_wl_version.empty()) {
-			str += bformat(_("Requires a Widelands version of at most %s."), info->max_wl_version);
+			str += format(_("Requires a Widelands version of at most %s."), info->max_wl_version);
 		} else {
-			str += bformat(_("Requires a Widelands version of at least %1$s and at most %2$s."),
+			str += format(_("Requires a Widelands version of at least %1$s and at most %2$s."),
 			               info->min_wl_version, info->max_wl_version);
 		}
 		result += g_style_manager
@@ -161,7 +161,7 @@ InstalledAddOnRow::InstalledAddOnRow(Panel* parent,
               0,
               0,
               /** TRANSLATORS: (MajorVersion)+(MinorVersion) */
-              bformat(_("%1$s+%2$u"), AddOns::version_to_string(info->version), info->i18n_version),
+              format(_("%1$s+%2$u"), AddOns::version_to_string(info->version), info->i18n_version),
               UI::Align::kCenter),
      txt_(
         this,
@@ -170,17 +170,17 @@ InstalledAddOnRow::InstalledAddOnRow(Panel* parent,
         24,
         24,
         UI::PanelStyle::kFsMenu,
-        bformat(
+        format(
            "<rt><p>%s</p><p>%s%s</p><p>%s</p></rt>",
-           bformat(
+           format(
               /** TRANSLATORS: Add-On localized name as header (Add-On internal name in italics) */
               _("%1$s %2$s"),
               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
                  .as_font_tag(info->descname()),
               g_style_manager->font_style(UI::FontStyle::kItalic)
-                 .as_font_tag(bformat(_("(%s)"), info->internal_name))),
+                 .as_font_tag(format(_("(%s)"), info->internal_name))),
            g_style_manager->font_style(UI::FontStyle::kItalic)
-              .as_font_tag(bformat(_("by %s"), info->author())),
+              .as_font_tag(format(_("by %s"), info->author())),
            required_wl_version_and_sync_safety_string(info),
            g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
               .as_font_tag(info->description()))) {
@@ -209,9 +209,9 @@ InstalledAddOnRow::InstalledAddOnRow(Panel* parent,
 	});
 	category_.set_handle_mouse(true);
 	category_.set_tooltip(
-	   bformat(_("Category: %s"), AddOns::kAddOnCategories.at(info->category).descname()));
+	   format(_("Category: %s"), AddOns::kAddOnCategories.at(info->category).descname()));
 	version_.set_handle_mouse(true);
-	version_.set_tooltip(bformat(
+	version_.set_tooltip(format(
 	   /** TRANSLATORS: (MajorVersion)+(MinorVersion) */
 	   _("Version: %1$s+%2$u"), AddOns::version_to_string(info->version), info->i18n_version));
 	set_can_focus(true);
@@ -315,7 +315,7 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
               0,
               0,
               /** TRANSLATORS: (MajorVersion)+(MinorVersion) */
-              bformat(_("%1$s+%2$u"), AddOns::version_to_string(info->version), info->i18n_version),
+              format(_("%1$s+%2$u"), AddOns::version_to_string(info->version), info->i18n_version),
               UI::Align::kCenter),
      bottom_row_left_(this,
                       UI::PanelStyle::kFsMenu,
@@ -336,13 +336,13 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
         0,
         info->internal_name.empty() ?
            "" :
-           bformat(
+           format(
               /** TRANSLATORS: Filesize · Download count · Average rating · Number of comments ·
                  Number of screenshots */
               _("%1$s   ⬇ %2$u   ★ %3$s   “” %4$u   ▣ %5$u"),
               filesize_string(info->total_file_size),
               info->download_count,
-              (info->number_of_votes() ? bformat_l("%.2f", info->average_rating()) : "–"),
+              (info->number_of_votes() ? format_l("%.2f", info->average_rating()) : "–"),
               info->user_comments.size(),
               info->screenshots.size()),
         UI::Align::kRight),
@@ -353,19 +353,19 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
         24,
         24,
         UI::PanelStyle::kFsMenu,
-        bformat(
+        format(
            "<rt><p>%s</p><p>%s%s</p><p>%s</p></rt>",
-           bformat(
+           format(
               /** TRANSLATORS: Add-On localized name as header (Add-On internal name in italics) */
               _("%1$s %2$s"),
               g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
                  .as_font_tag(info->descname()),
               g_style_manager->font_style(UI::FontStyle::kItalic)
-                 .as_font_tag(bformat(_("(%s)"), info->internal_name))),
+                 .as_font_tag(format(_("(%s)"), info->internal_name))),
            g_style_manager->font_style(UI::FontStyle::kItalic)
               .as_font_tag(info->author() == info->upload_username ?
-                              bformat(_("by %s"), info->author()) :
-                              bformat(_("by %1$s (uploaded by %2$s)"),
+                              format(_("by %s"), info->author()) :
+                              format(_("by %1$s (uploaded by %2$s)"),
                                       info->author(),
                                       info->upload_username)),
            required_wl_version_and_sync_safety_string(info),
@@ -383,7 +383,7 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
 		if (!info_->verified || !(SDL_GetModState() & KMOD_CTRL)) {
 			UI::WLMessageBox w(
 			   &ctrl->get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Install"),
-			   safe_richtext_message(bformat(
+			   safe_richtext_message(format(
 			      _("Are you certain that you want to install this add-on?\n\n"
 			        "%1$s\n"
 			        "by %2$s\n"
@@ -407,7 +407,7 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
 		if (!info->verified || !(SDL_GetModState() & KMOD_CTRL)) {
 			UI::WLMessageBox w(
 			   &ctrl->get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Upgrade"),
-			   safe_richtext_message(bformat(
+			   safe_richtext_message(format(
 			      _("Are you certain that you want to upgrade this add-on?\n\n"
 			        "%1$s\n"
 			        "by %2$s\n"
@@ -447,8 +447,8 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
 		p->set_handle_mouse(true);
 	}
 	category_.set_tooltip(
-	   bformat(_("Category: %s"), AddOns::kAddOnCategories.at(info->category).descname()));
-	version_.set_tooltip(bformat(
+	   format(_("Category: %s"), AddOns::kAddOnCategories.at(info->category).descname()));
+	version_.set_tooltip(format(
 	   /** TRANSLATORS: (MajorVersion)+(MinorVersion) */
 	   _("Version: %1$s+%2$u"), AddOns::version_to_string(info->version), info->i18n_version));
 	verified_.set_tooltip(
@@ -464,20 +464,20 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
 	bottom_row_right_.set_tooltip(
 	   info->internal_name.empty() ?
          "" :
-         bformat(
+         format(
 	         "%s<br>%s<br>%s<br>%s<br>%s",
-	         bformat(ngettext("Total size: %u byte", "Total size: %u bytes", info->total_file_size),
+	         format(ngettext("Total size: %u byte", "Total size: %u bytes", info->total_file_size),
 	                 info->total_file_size),
-	         bformat(
+	         format(
 	            ngettext("%u download", "%u downloads", info->download_count), info->download_count),
 	         (info->number_of_votes() ?
-                bformat_l(ngettext("Average rating: %1$.3f (%2$u vote)",
+                format_l(ngettext("Average rating: %1$.3f (%2$u vote)",
 	                                "Average rating: %1$.3f (%2$u votes)", info->number_of_votes()),
 	                       info->average_rating(), info->number_of_votes()) :
                 _("No votes yet")),
-	         bformat(ngettext("%u comment", "%u comments", info->user_comments.size()),
+	         format(ngettext("%u comment", "%u comments", info->user_comments.size()),
 	                 info->user_comments.size()),
-	         bformat(ngettext("%u screenshot", "%u screenshots", info->screenshots.size()),
+	         format(ngettext("%u screenshot", "%u screenshots", info->screenshots.size()),
 	                 info->screenshots.size())));
 
 	layout();

--- a/src/ui_fsmenu/addons/rows_ui.cc
+++ b/src/ui_fsmenu/addons/rows_ui.cc
@@ -43,22 +43,22 @@ void uninstall(AddOnsCtrl* ctrl, std::shared_ptr<AddOns::AddOnInfo> info, const 
 	if (!(SDL_GetModState() & KMOD_CTRL)) {
 		UI::WLMessageBox w(
 		   &ctrl->get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Uninstall"),
-		   safe_richtext_message(format(
-		      local ? _("Are you certain that you want to uninstall this add-on?\n\n"
-		                "%1$s\n"
-		                "by %2$s\n"
-		                "Version %3$s\n"
-		                "Category: %4$s\n"
-		                "%5$s\n\n"
-		                "Note that this add-on can not be downloaded again from the server.") :
-                    _("Are you certain that you want to uninstall this add-on?\n\n"
-		                "%1$s\n"
-		                "by %2$s\n"
-		                "Version %3$s\n"
-		                "Category: %4$s\n"
-		                "%5$s"),
-		      info->descname(), info->author(), AddOns::version_to_string(info->version),
-		      AddOns::kAddOnCategories.at(info->category).descname(), info->description())),
+		   safe_richtext_message(
+		      format(local ? _("Are you certain that you want to uninstall this add-on?\n\n"
+		                       "%1$s\n"
+		                       "by %2$s\n"
+		                       "Version %3$s\n"
+		                       "Category: %4$s\n"
+		                       "%5$s\n\n"
+		                       "Note that this add-on can not be downloaded again from the server.") :
+                           _("Are you certain that you want to uninstall this add-on?\n\n"
+		                       "%1$s\n"
+		                       "by %2$s\n"
+		                       "Version %3$s\n"
+		                       "Category: %4$s\n"
+		                       "%5$s"),
+		             info->descname(), info->author(), AddOns::version_to_string(info->version),
+		             AddOns::kAddOnCategories.at(info->category).descname(), info->description())),
 		   UI::WLMessageBox::MBoxType::kOkCancel);
 		if (w.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
 			return;
@@ -105,7 +105,7 @@ std::string required_wl_version_and_sync_safety_string(std::shared_ptr<AddOns::A
 			str += format(_("Requires a Widelands version of at most %s."), info->max_wl_version);
 		} else {
 			str += format(_("Requires a Widelands version of at least %1$s and at most %2$s."),
-			               info->min_wl_version, info->max_wl_version);
+			              info->min_wl_version, info->max_wl_version);
 		}
 		result += g_style_manager
 		             ->font_style(info->matches_widelands_version() ? UI::FontStyle::kItalic :
@@ -363,11 +363,10 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
               g_style_manager->font_style(UI::FontStyle::kItalic)
                  .as_font_tag(format(_("(%s)"), info->internal_name))),
            g_style_manager->font_style(UI::FontStyle::kItalic)
-              .as_font_tag(info->author() == info->upload_username ?
-                              format(_("by %s"), info->author()) :
-                              format(_("by %1$s (uploaded by %2$s)"),
-                                      info->author(),
-                                      info->upload_username)),
+              .as_font_tag(
+                 info->author() == info->upload_username ?
+                    format(_("by %s"), info->author()) :
+                    format(_("by %1$s (uploaded by %2$s)"), info->author(), info->upload_username)),
            required_wl_version_and_sync_safety_string(info),
            g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
               .as_font_tag(info->description()))),
@@ -407,20 +406,20 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
 		if (!info->verified || !(SDL_GetModState() & KMOD_CTRL)) {
 			UI::WLMessageBox w(
 			   &ctrl->get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Upgrade"),
-			   safe_richtext_message(format(
-			      _("Are you certain that you want to upgrade this add-on?\n\n"
-			        "%1$s\n"
-			        "by %2$s\n"
-			        "%3$s\n"
-			        "Installed version: %4$s\n"
-			        "Available version: %5$s\n"
-			        "Category: %6$s\n"
-			        "%7$s"),
-			      info->descname(), info->author(),
-			      (info->verified ? _("Verified") : _("NOT VERIFIED")),
-			      AddOns::version_to_string(installed_version),
-			      AddOns::version_to_string(info->version),
-			      AddOns::kAddOnCategories.at(info->category).descname(), info->description())),
+			   safe_richtext_message(
+			      format(_("Are you certain that you want to upgrade this add-on?\n\n"
+			               "%1$s\n"
+			               "by %2$s\n"
+			               "%3$s\n"
+			               "Installed version: %4$s\n"
+			               "Available version: %5$s\n"
+			               "Category: %6$s\n"
+			               "%7$s"),
+			             info->descname(), info->author(),
+			             (info->verified ? _("Verified") : _("NOT VERIFIED")),
+			             AddOns::version_to_string(installed_version),
+			             AddOns::version_to_string(info->version),
+			             AddOns::kAddOnCategories.at(info->category).descname(), info->description())),
 			   UI::WLMessageBox::MBoxType::kOkCancel);
 			if (w.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
 				return;
@@ -467,18 +466,18 @@ RemoteAddOnRow::RemoteAddOnRow(Panel* parent,
          format(
 	         "%s<br>%s<br>%s<br>%s<br>%s",
 	         format(ngettext("Total size: %u byte", "Total size: %u bytes", info->total_file_size),
-	                 info->total_file_size),
+	                info->total_file_size),
 	         format(
 	            ngettext("%u download", "%u downloads", info->download_count), info->download_count),
 	         (info->number_of_votes() ?
                 format_l(ngettext("Average rating: %1$.3f (%2$u vote)",
-	                                "Average rating: %1$.3f (%2$u votes)", info->number_of_votes()),
-	                       info->average_rating(), info->number_of_votes()) :
+	                               "Average rating: %1$.3f (%2$u votes)", info->number_of_votes()),
+	                      info->average_rating(), info->number_of_votes()) :
                 _("No votes yet")),
 	         format(ngettext("%u comment", "%u comments", info->user_comments.size()),
-	                 info->user_comments.size()),
+	                info->user_comments.size()),
 	         format(ngettext("%u screenshot", "%u screenshots", info->screenshots.size()),
-	                 info->screenshots.size())));
+	                info->screenshots.size())));
 
 	layout();
 }

--- a/src/ui_fsmenu/addons/screenshot_upload.cc
+++ b/src/ui_fsmenu/addons/screenshot_upload.cc
@@ -40,7 +40,7 @@ ScreenshotUploadWindow::ScreenshotUploadWindow(AddOnsCtrl& ctrl,
                 0,
                 100,
                 100,
-                bformat(_("Upload Screenshot for ‘%s’"), info->internal_name)),
+                format(_("Upload Screenshot for ‘%s’"), info->internal_name)),
      box_(this, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Vertical),
      hbox_(&box_, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Horizontal),
      vbox_(&hbox_, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Vertical),
@@ -123,7 +123,7 @@ ScreenshotUploadWindow::ScreenshotUploadWindow(AddOnsCtrl& ctrl,
 			progress_.set_text("");
 			UI::WLMessageBox m(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(_("The screenshot ‘%1$s’ for the add-on ‘%2$s’ could not be uploaded "
+			   format(_("The screenshot ‘%1$s’ for the add-on ‘%2$s’ could not be uploaded "
 			             "to the server.\n\nError Message:\n%3$s"),
 			           sel, info->internal_name, e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);

--- a/src/ui_fsmenu/addons/screenshot_upload.cc
+++ b/src/ui_fsmenu/addons/screenshot_upload.cc
@@ -124,8 +124,8 @@ ScreenshotUploadWindow::ScreenshotUploadWindow(AddOnsCtrl& ctrl,
 			UI::WLMessageBox m(
 			   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Error"),
 			   format(_("The screenshot ‘%1$s’ for the add-on ‘%2$s’ could not be uploaded "
-			             "to the server.\n\nError Message:\n%3$s"),
-			           sel, info->internal_name, e.what()),
+			            "to the server.\n\nError Message:\n%3$s"),
+			          sel, info->internal_name, e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 			ok_.set_enabled(true);

--- a/src/ui_fsmenu/campaigndetails.cc
+++ b/src/ui_fsmenu/campaigndetails.cc
@@ -44,29 +44,29 @@ CampaignDetails::CampaignDetails(Panel* parent)
 
 void CampaignDetails::update(const CampaignData& campaigndata) {
 	name_label_.set_text(format("<rt>%s%s</rt>",
-	                             /** TRANSLATORS: Header for campaign name */
-	                             as_heading(_("Campaign"), UI::PanelStyle::kFsMenu, true),
-	                             as_content(campaigndata.descname, UI::PanelStyle::kFsMenu)));
+	                            /** TRANSLATORS: Header for campaign name */
+	                            as_heading(_("Campaign"), UI::PanelStyle::kFsMenu, true),
+	                            as_content(campaigndata.descname, UI::PanelStyle::kFsMenu)));
 
 	std::string description;
 
 	if (campaigndata.visible) {
 		description = format("%s%s",
-		                      /** TRANSLATORS: Header for campaign tribe */
-		                      as_heading(_("Tribe"), UI::PanelStyle::kFsMenu),
-		                      as_content(campaigndata.tribename, UI::PanelStyle::kFsMenu));
+		                     /** TRANSLATORS: Header for campaign tribe */
+		                     as_heading(_("Tribe"), UI::PanelStyle::kFsMenu),
+		                     as_content(campaigndata.tribename, UI::PanelStyle::kFsMenu));
 		description = format("%s%s", description,
-		                      /** TRANSLATORS: Header for campaign difficulty */
-		                      as_heading(_("Difficulty"), UI::PanelStyle::kFsMenu));
+		                     /** TRANSLATORS: Header for campaign difficulty */
+		                     as_heading(_("Difficulty"), UI::PanelStyle::kFsMenu));
 		description =
 		   format("%s%s", description,
-		           as_content(campaigndata.difficulty_description, UI::PanelStyle::kFsMenu));
+		          as_content(campaigndata.difficulty_description, UI::PanelStyle::kFsMenu));
 
 		description = format("%s%s", description,
-		                      /** TRANSLATORS: Header for campaign description */
-		                      as_heading(_("Description"), UI::PanelStyle::kFsMenu));
-		description = format(
-		   "%s%s", description, as_content(campaigndata.description, UI::PanelStyle::kFsMenu));
+		                     /** TRANSLATORS: Header for campaign description */
+		                     as_heading(_("Description"), UI::PanelStyle::kFsMenu));
+		description =
+		   format("%s%s", description, as_content(campaigndata.description, UI::PanelStyle::kFsMenu));
 	}
 
 	description = format("<rt>%s</rt>", description);

--- a/src/ui_fsmenu/campaigndetails.cc
+++ b/src/ui_fsmenu/campaigndetails.cc
@@ -43,7 +43,7 @@ CampaignDetails::CampaignDetails(Panel* parent)
 }
 
 void CampaignDetails::update(const CampaignData& campaigndata) {
-	name_label_.set_text(bformat("<rt>%s%s</rt>",
+	name_label_.set_text(format("<rt>%s%s</rt>",
 	                             /** TRANSLATORS: Header for campaign name */
 	                             as_heading(_("Campaign"), UI::PanelStyle::kFsMenu, true),
 	                             as_content(campaigndata.descname, UI::PanelStyle::kFsMenu)));
@@ -51,25 +51,25 @@ void CampaignDetails::update(const CampaignData& campaigndata) {
 	std::string description;
 
 	if (campaigndata.visible) {
-		description = bformat("%s%s",
+		description = format("%s%s",
 		                      /** TRANSLATORS: Header for campaign tribe */
 		                      as_heading(_("Tribe"), UI::PanelStyle::kFsMenu),
 		                      as_content(campaigndata.tribename, UI::PanelStyle::kFsMenu));
-		description = bformat("%s%s", description,
+		description = format("%s%s", description,
 		                      /** TRANSLATORS: Header for campaign difficulty */
 		                      as_heading(_("Difficulty"), UI::PanelStyle::kFsMenu));
 		description =
-		   bformat("%s%s", description,
+		   format("%s%s", description,
 		           as_content(campaigndata.difficulty_description, UI::PanelStyle::kFsMenu));
 
-		description = bformat("%s%s", description,
+		description = format("%s%s", description,
 		                      /** TRANSLATORS: Header for campaign description */
 		                      as_heading(_("Description"), UI::PanelStyle::kFsMenu));
-		description = bformat(
+		description = format(
 		   "%s%s", description, as_content(campaigndata.description, UI::PanelStyle::kFsMenu));
 	}
 
-	description = bformat("<rt>%s</rt>", description);
+	description = format("<rt>%s</rt>", description);
 	descr_.set_text(description);
 	descr_.scroll_to_top();
 }

--- a/src/ui_fsmenu/helpwindow.cc
+++ b/src/ui_fsmenu/helpwindow.cc
@@ -44,7 +44,7 @@ HelpWindow::HelpWindow(UI::Panel* const parent,
                 0,
                 width,
                 height,
-                bformat(_("Help: %s"), caption)),
+                format(_("Help: %s"), caption)),
      textarea_(
         new UI::MultilineTextarea(this, 5, 5, width - 10, height - 30, UI::PanelStyle::kFsMenu)) {
 	int margin = 5;

--- a/src/ui_fsmenu/internet_lobby.cc
+++ b/src/ui_fsmenu/internet_lobby.cc
@@ -414,9 +414,9 @@ void InternetLobby::change_servername() {
 			if (game.name == servername_.text()) {
 				hostgame_.set_enabled(false);
 				servername_.set_warning(true);
-				servername_.set_tooltip(format(
-				   _("The game %s is already running. Please choose a different name."),
-				   g_style_manager->font_style(UI::FontStyle::kWarning).as_font_tag(game.name)));
+				servername_.set_tooltip(
+				   format(_("The game %s is already running. Please choose a different name."),
+				          g_style_manager->font_style(UI::FontStyle::kWarning).as_font_tag(game.name)));
 			}
 		}
 	}

--- a/src/ui_fsmenu/internet_lobby.cc
+++ b/src/ui_fsmenu/internet_lobby.cc
@@ -154,7 +154,7 @@ InternetLobby::InternetLobby(MenuCapsule& fsmm,
 	});
 
 	// Prepare the lists
-	const std::string t_tip = bformat(
+	const std::string t_tip = format(
 	   "<rt padding=2><p align=center spacing=3>%s</p>"
 	   "<p valign=bottom><img src=images/wui/overlays/road_building_green.png> %s"
 	   "<br><img src=images/wui/overlays/road_building_yellow.png> %s"
@@ -414,7 +414,7 @@ void InternetLobby::change_servername() {
 			if (game.name == servername_.text()) {
 				hostgame_.set_enabled(false);
 				servername_.set_warning(true);
-				servername_.set_tooltip(bformat(
+				servername_.set_tooltip(format(
 				   _("The game %s is already running. Please choose a different name."),
 				   g_style_manager->font_style(UI::FontStyle::kWarning).as_font_tag(game.name)));
 			}
@@ -480,7 +480,7 @@ void InternetLobby::clicked_hostgame() {
 				do {
 					/** TRANSLATORS: This is shown for multiplayer games when no host */
 					/** TRANSLATORS: server to connect to has been specified yet. */
-					servername_ui = bformat(_("unnamed %u"), i++);
+					servername_ui = format(_("unnamed %u"), i++);
 				} while (servername_ui == game.name);
 			} else if (game.name == servername_ui) {
 				change_servername();

--- a/src/ui_fsmenu/keyboard_options.cc
+++ b/src/ui_fsmenu/keyboard_options.cc
@@ -264,9 +264,9 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 					   get_parent(), UI::WindowStyle::kFsMenu, _("Keyboard Shortcut Conflict"),
 					   as_richtext_paragraph(
 					      format(_("The shortcut you selected (‘%1$s’) is already in use for the "
-					                "following action: ‘%2$s’. Please select a different shortcut "
-					                "or change the conflicting shortcut first."),
-					              shortcut_string_for(c.key, true), to_string(conflict)),
+					               "following action: ‘%2$s’. Please select a different shortcut "
+					               "or change the conflicting shortcut first."),
+					             shortcut_string_for(c.key, true), to_string(conflict)),
 					      UI::FontStyle::kFsMenuLabel, UI::Align::kCenter),
 					   UI::WLMessageBox::MBoxType::kOk);
 					warning.run<UI::Panel::Returncodes>();

--- a/src/ui_fsmenu/keyboard_options.cc
+++ b/src/ui_fsmenu/keyboard_options.cc
@@ -233,7 +233,7 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 
 	auto generate_title = [](const KeyboardShortcut key) {
 		const std::string shortcut = shortcut_string_for(key, false);
-		return bformat(
+		return format(
 		   /** TRANSLATORS: This is a button label for a keyboard shortcut in the form
 		      "Action: Key" */
 		   _("%1$s: %2$s"), to_string(key), shortcut);
@@ -263,7 +263,7 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 					UI::WLMessageBox warning(
 					   get_parent(), UI::WindowStyle::kFsMenu, _("Keyboard Shortcut Conflict"),
 					   as_richtext_paragraph(
-					      bformat(_("The shortcut you selected (‘%1$s’) is already in use for the "
+					      format(_("The shortcut you selected (‘%1$s’) is already in use for the "
 					                "following action: ‘%2$s’. Please select a different shortcut "
 					                "or change the conflicting shortcut first."),
 					              shortcut_string_for(c.key, true), to_string(conflict)),

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -60,9 +60,9 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
         10,
         UI::PanelStyle::kFsMenu,
         format("<rt><p>%s</p></rt>",
-                g_style_manager->font_style(UI::FontStyle::kWarning)
-                   .as_font_tag(_(
-                      "An enabled add-on is known to cause desyncs. No replay will be written."))),
+               g_style_manager->font_style(UI::FontStyle::kWarning)
+                  .as_font_tag(
+                     _("An enabled add-on is known to cause desyncs. No replay will be written."))),
         UI::Align::kLeft,
         UI::MultilineTextarea::ScrollMode::kNoScrolling),
      win_condition_dropdown_(&right_column_content_box_,
@@ -318,8 +318,8 @@ void LaunchGame::load_win_conditions(const std::set<std::string>& tags) {
 	} catch (const std::exception& e) {
 		const std::string error_message =
 		   format(_("Unable to determine valid win conditions because the map ‘%s’ "
-		             "could not be loaded."),
-		           settings_.settings().mapfilename);
+		            "could not be loaded."),
+		          settings_.settings().mapfilename);
 		win_condition_dropdown_.set_errored(error_message);
 		log_err("Launch Game: Exception: %s %s\n", error_message.c_str(), e.what());
 	}

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -59,7 +59,7 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
         10,
         10,
         UI::PanelStyle::kFsMenu,
-        bformat("<rt><p>%s</p></rt>",
+        format("<rt><p>%s</p></rt>",
                 g_style_manager->font_style(UI::FontStyle::kWarning)
                    .as_font_tag(_(
                       "An enabled add-on is known to cause desyncs. No replay will be written."))),
@@ -317,7 +317,7 @@ void LaunchGame::load_win_conditions(const std::set<std::string>& tags) {
 		}
 	} catch (const std::exception& e) {
 		const std::string error_message =
-		   bformat(_("Unable to determine valid win conditions because the map ‘%s’ "
+		   format(_("Unable to determine valid win conditions because the map ‘%s’ "
 		             "could not be loaded."),
 		           settings_.settings().mapfilename);
 		win_condition_dropdown_.set_errored(error_message);

--- a/src/ui_fsmenu/launch_mpg.cc
+++ b/src/ui_fsmenu/launch_mpg.cc
@@ -291,7 +291,7 @@ void LaunchMPG::refresh() {
 		} catch (LuaScriptNotExistingError&) {
 			win_condition_dropdown_.set_label(_("Error"));
 			win_condition_dropdown_.set_tooltip(
-			   bformat(_("Unable to load the win condition script file ‘%s’."),
+			   format(_("Unable to load the win condition script file ‘%s’."),
 			           settings_.get_win_condition_script()));
 
 		} catch (LuaTableKeyError& e) {
@@ -350,7 +350,7 @@ void LaunchMPG::load_previous_playerdata() {
 	   settings_.settings().mapname, "", "", "", settings_.settings().players.size(), true);
 
 	for (uint8_t i = 1; i <= settings_.settings().players.size(); ++i) {
-		Section* s = prof.get_section(bformat("player_%u", static_cast<unsigned int>(i)));
+		Section* s = prof.get_section(format("player_%u", static_cast<unsigned int>(i)));
 		if (s == nullptr) {
 			// Due to asynchronous notifications, the client can crash on savegame change when number
 			// of players goes down. So, we abort if the section does not exist to prevent crashes.

--- a/src/ui_fsmenu/launch_mpg.cc
+++ b/src/ui_fsmenu/launch_mpg.cc
@@ -292,7 +292,7 @@ void LaunchMPG::refresh() {
 			win_condition_dropdown_.set_label(_("Error"));
 			win_condition_dropdown_.set_tooltip(
 			   format(_("Unable to load the win condition script file ‘%s’."),
-			           settings_.get_win_condition_script()));
+			          settings_.get_win_condition_script()));
 
 		} catch (LuaTableKeyError& e) {
 			log_err("LaunchMPG: Error loading win condition: %s %s\n",

--- a/src/ui_fsmenu/launch_spg.cc
+++ b/src/ui_fsmenu/launch_spg.cc
@@ -126,13 +126,13 @@ void LaunchSPG::clicked_ok() {
 		UI::WLMessageBox m(
 		   &capsule_.menu(), UI::WindowStyle::kFsMenu, _("File not found"),
 		   format(_("Widelands tried to start a game with a file that could not be "
-		             "found at the given path.\n"
-		             "The file was: %s\n"
-		             "If this happens in a network game, the host might have selected "
-		             "a file that you do not own. Normally, such a file should be sent "
-		             "from the host to you, but perhaps the transfer was not yet "
-		             "finished!?!"),
-		           filename),
+		            "found at the given path.\n"
+		            "The file was: %s\n"
+		            "If this happens in a network game, the host might have selected "
+		            "a file that you do not own. Normally, such a file should be sent "
+		            "from the host to you, but perhaps the transfer was not yet "
+		            "finished!?!"),
+		          filename),
 		   UI::WLMessageBox::MBoxType::kOk);
 		m.run<int>();
 		return;

--- a/src/ui_fsmenu/launch_spg.cc
+++ b/src/ui_fsmenu/launch_spg.cc
@@ -125,7 +125,7 @@ void LaunchSPG::clicked_ok() {
 	if (!preconfigured_ && !g_fs->file_exists(filename)) {
 		UI::WLMessageBox m(
 		   &capsule_.menu(), UI::WindowStyle::kFsMenu, _("File not found"),
-		   bformat(_("Widelands tried to start a game with a file that could not be "
+		   format(_("Widelands tried to start a game with a file that could not be "
 		             "found at the given path.\n"
 		             "The file was: %s\n"
 		             "If this happens in a network game, the host might have selected "

--- a/src/ui_fsmenu/login_box.cc
+++ b/src/ui_fsmenu/login_box.cc
@@ -57,7 +57,7 @@ LoginBox::LoginBox(MainMenu& parent, UI::UniqueWindow::Registry& r)
                        0,
                        180,
                        UI::PanelStyle::kFsMenu,
-                       bformat(_("In order to use a registered "
+                       format(_("In order to use a registered "
                                  "account, you need an account on the Widelands website. "
                                  "Please log in at %s and set an online "
                                  "gaming password on your profile page."),

--- a/src/ui_fsmenu/login_box.cc
+++ b/src/ui_fsmenu/login_box.cc
@@ -58,10 +58,10 @@ LoginBox::LoginBox(MainMenu& parent, UI::UniqueWindow::Registry& r)
                        180,
                        UI::PanelStyle::kFsMenu,
                        format(_("In order to use a registered "
-                                 "account, you need an account on the Widelands website. "
-                                 "Please log in at %s and set an online "
-                                 "gaming password on your profile page."),
-                               "\n\nhttps://widelands.org/accounts/register/\n\n")) {
+                                "account, you need an account on the Widelands website. "
+                                "Please log in at %s and set an online "
+                                "gaming password on your profile page."),
+                              "\n\nhttps://widelands.org/accounts/register/\n\n")) {
 	vbox1_.add_space(kMargin);
 	vbox1_.add(&ta_nickname_, UI::Box::Resizing::kExpandBoth);
 	vbox1_.add_space(kMargin);

--- a/src/ui_fsmenu/main.cc
+++ b/src/ui_fsmenu/main.cc
@@ -349,31 +349,31 @@ void MainMenu::set_labels() {
 				singleplayer_.add(
 				   _("Continue Playing"), MenuTarget::kContinueLastsave, nullptr, false,
 				   format("%s<br>%s<br>%s<br>%s<br>%s<br>%s",
-				           g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
-				              .as_font_tag(
-				                 /* strip leading "save/" and trailing ".wgf" */
-				                 filename_for_continue_playing_.substr(
-				                    kSaveDir.length() + 1, filename_for_continue_playing_.length() -
-				                                              kSaveDir.length() -
-				                                              kSavegameExtension.length() - 1)),
-				           format(_("Map: %s"),
-				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-				                      .as_font_tag(newest_singleplayer->mapname)),
-				           format(_("Win Condition: %s"),
-				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-				                      .as_font_tag(newest_singleplayer->wincondition)),
-				           format(_("Players: %s"),
-				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-				                      .as_font_tag(newest_singleplayer->nrplayers)),
-				           format(_("Gametime: %s"),
-				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-				                      .as_font_tag(newest_singleplayer->gametime)),
-				           /** TRANSLATORS: Information about when a game was saved, e.g. 'Saved: Today,
-				            * 10:30'
-				            */
-				           format(_("Saved: %s"),
-				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-				                      .as_font_tag(newest_singleplayer->savedatestring))),
+				          g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
+				             .as_font_tag(
+				                /* strip leading "save/" and trailing ".wgf" */
+				                filename_for_continue_playing_.substr(
+				                   kSaveDir.length() + 1, filename_for_continue_playing_.length() -
+				                                             kSaveDir.length() -
+				                                             kSavegameExtension.length() - 1)),
+				          format(_("Map: %s"),
+				                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+				                    .as_font_tag(newest_singleplayer->mapname)),
+				          format(_("Win Condition: %s"),
+				                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+				                    .as_font_tag(newest_singleplayer->wincondition)),
+				          format(_("Players: %s"),
+				                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+				                    .as_font_tag(newest_singleplayer->nrplayers)),
+				          format(_("Gametime: %s"),
+				                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+				                    .as_font_tag(newest_singleplayer->gametime)),
+				          /** TRANSLATORS: Information about when a game was saved, e.g. 'Saved: Today,
+				           * 10:30'
+				           */
+				          format(_("Saved: %s"),
+				                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+				                    .as_font_tag(newest_singleplayer->savedatestring))),
 				   shortcut_string_for(KeyboardShortcut::kMainMenuContinuePlaying));
 			}
 		}
@@ -413,24 +413,24 @@ void MainMenu::set_labels() {
 			editor_.add(
 			   _("Continue Editing"), MenuTarget::kEditorContinue, nullptr, false,
 			   format("%s<br>%s<br>%s<br>%s<br>%s",
-			           g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
-			              .as_font_tag(
-			                 /* strip leading "maps/My_Maps/" and trailing ".wgf" */
-			                 filename_for_continue_editing_.substr(
-			                    13, filename_for_continue_editing_.length() - 17)),
-			           format(_("Name: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(last_edited->first.localized_name)),
-			           format(_("Size: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(format(_("%1$u×%2$u"), last_edited->first.width,
-			                                           last_edited->first.height))),
-			           format(_("Players: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(std::to_string(last_edited->first.nrplayers))),
-			           format(_("Description: %s"),
-			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(last_edited->first.description))),
+			          g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
+			             .as_font_tag(
+			                /* strip leading "maps/My_Maps/" and trailing ".wgf" */
+			                filename_for_continue_editing_.substr(
+			                   13, filename_for_continue_editing_.length() - 17)),
+			          format(_("Name: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(last_edited->first.localized_name)),
+			          format(_("Size: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(format(_("%1$u×%2$u"), last_edited->first.width,
+			                                        last_edited->first.height))),
+			          format(_("Players: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(std::to_string(last_edited->first.nrplayers))),
+			          format(_("Description: %s"),
+			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+			                    .as_font_tag(last_edited->first.description))),
 			   shortcut_string_for(KeyboardShortcut::kMainMenuContinueEditing));
 		}
 	}
@@ -476,8 +476,8 @@ void MainMenu::set_labels() {
 	copyright_.set_text(
 	   /** TRANSLATORS: Placeholders are the copyright years */
 	   format(_("(C) %1%-%2% by the Widelands Development Team · Licensed under "
-	             "the GNU General Public License V2.0"),
-	           kWidelandsCopyrightStart, kWidelandsCopyrightEnd));
+	            "the GNU General Public License V2.0"),
+	          kWidelandsCopyrightStart, kWidelandsCopyrightEnd));
 }
 
 void MainMenu::set_button_visibility(const bool v) {

--- a/src/ui_fsmenu/main.cc
+++ b/src/ui_fsmenu/main.cc
@@ -230,7 +230,7 @@ Widelands::Game* MainMenu::create_safe_game(const bool show_error) {
 		if (show_error) {
 			UI::WLMessageBox m(
 			   this, UI::WindowStyle::kFsMenu, _("Error"),
-			   bformat(_("Unable to create a Game instance!\nError message:\n%s"), e.what()),
+			   format(_("Unable to create a Game instance!\nError message:\n%s"), e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 		}
@@ -348,7 +348,7 @@ void MainMenu::set_labels() {
 				filename_for_continue_playing_ = newest_singleplayer->filename;
 				singleplayer_.add(
 				   _("Continue Playing"), MenuTarget::kContinueLastsave, nullptr, false,
-				   bformat("%s<br>%s<br>%s<br>%s<br>%s<br>%s",
+				   format("%s<br>%s<br>%s<br>%s<br>%s<br>%s",
 				           g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
 				              .as_font_tag(
 				                 /* strip leading "save/" and trailing ".wgf" */
@@ -356,22 +356,22 @@ void MainMenu::set_labels() {
 				                    kSaveDir.length() + 1, filename_for_continue_playing_.length() -
 				                                              kSaveDir.length() -
 				                                              kSavegameExtension.length() - 1)),
-				           bformat(_("Map: %s"),
+				           format(_("Map: %s"),
 				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 				                      .as_font_tag(newest_singleplayer->mapname)),
-				           bformat(_("Win Condition: %s"),
+				           format(_("Win Condition: %s"),
 				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 				                      .as_font_tag(newest_singleplayer->wincondition)),
-				           bformat(_("Players: %s"),
+				           format(_("Players: %s"),
 				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 				                      .as_font_tag(newest_singleplayer->nrplayers)),
-				           bformat(_("Gametime: %s"),
+				           format(_("Gametime: %s"),
 				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 				                      .as_font_tag(newest_singleplayer->gametime)),
 				           /** TRANSLATORS: Information about when a game was saved, e.g. 'Saved: Today,
 				            * 10:30'
 				            */
-				           bformat(_("Saved: %s"),
+				           format(_("Saved: %s"),
 				                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 				                      .as_font_tag(newest_singleplayer->savedatestring))),
 				   shortcut_string_for(KeyboardShortcut::kMainMenuContinuePlaying));
@@ -412,23 +412,23 @@ void MainMenu::set_labels() {
 			filename_for_continue_editing_ = last_edited->first.filename;
 			editor_.add(
 			   _("Continue Editing"), MenuTarget::kEditorContinue, nullptr, false,
-			   bformat("%s<br>%s<br>%s<br>%s<br>%s",
+			   format("%s<br>%s<br>%s<br>%s<br>%s",
 			           g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
 			              .as_font_tag(
 			                 /* strip leading "maps/My_Maps/" and trailing ".wgf" */
 			                 filename_for_continue_editing_.substr(
 			                    13, filename_for_continue_editing_.length() - 17)),
-			           bformat(_("Name: %s"),
+			           format(_("Name: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                      .as_font_tag(last_edited->first.localized_name)),
-			           bformat(_("Size: %s"),
+			           format(_("Size: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-			                      .as_font_tag(bformat(_("%1$u×%2$u"), last_edited->first.width,
+			                      .as_font_tag(format(_("%1$u×%2$u"), last_edited->first.width,
 			                                           last_edited->first.height))),
-			           bformat(_("Players: %s"),
+			           format(_("Players: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                      .as_font_tag(std::to_string(last_edited->first.nrplayers))),
-			           bformat(_("Description: %s"),
+			           format(_("Description: %s"),
 			                   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                      .as_font_tag(last_edited->first.description))),
 			   shortcut_string_for(KeyboardShortcut::kMainMenuContinueEditing));
@@ -472,10 +472,10 @@ void MainMenu::set_labels() {
 
 	version_.set_text(
 	   /** TRANSLATORS: %1$s = version string, %2%s = "Debug" or "Release" */
-	   bformat(_("Version %1$s (%2$s)"), build_id(), build_type()));
+	   format(_("Version %1$s (%2$s)"), build_id(), build_type()));
 	copyright_.set_text(
 	   /** TRANSLATORS: Placeholders are the copyright years */
-	   bformat(_("(C) %1%-%2% by the Widelands Development Team · Licensed under "
+	   format(_("(C) %1%-%2% by the Widelands Development Team · Licensed under "
 	             "the GNU General Public License V2.0"),
 	           kWidelandsCopyrightStart, kWidelandsCopyrightEnd));
 }

--- a/src/ui_fsmenu/mapdetailsbox.cc
+++ b/src/ui_fsmenu/mapdetailsbox.cc
@@ -111,8 +111,8 @@ static std::string assemble_infotext_for_map(const Widelands::Map& map,
 	   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
 	      .as_font_tag(
 	         format(_("Size: %s"),
-	                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-	                    .as_font_tag(format(_("%1$u×%2$u"), map.get_width(), map.get_height())))));
+	                g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+	                   .as_font_tag(format(_("%1$u×%2$u"), map.get_width(), map.get_height())))));
 
 	format_arg_strings.emplace_back(
 	   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
@@ -123,8 +123,8 @@ static std::string assemble_infotext_for_map(const Widelands::Map& map,
 	format_arg_strings.emplace_back(
 	   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
 	      .as_font_tag(format(_("Description: %s"),
-	                           g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-	                              .as_font_tag(richtext_escape(map.get_description())))));
+	                          g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
+	                             .as_font_tag(richtext_escape(map.get_description())))));
 
 	if (!map.get_hint().empty()) {
 		format_arg_strings.emplace_back(

--- a/src/ui_fsmenu/mapdetailsbox.cc
+++ b/src/ui_fsmenu/mapdetailsbox.cc
@@ -36,7 +36,7 @@ static std::string tribe_of(const GameSettings& game_settings, const PlayerSetti
 		}
 	}
 	return g_style_manager->font_style(UI::FontStyle::kDisabled)
-	   .as_font_tag(bformat(_("invalid tribe ‘%s’"), p.tribe));
+	   .as_font_tag(format(_("invalid tribe ‘%s’"), p.tribe));
 }
 
 static std::string assemble_infotext_for_savegame(const GameSettings& game_settings) {
@@ -56,7 +56,7 @@ static std::string assemble_infotext_for_savegame(const GameSettings& game_setti
 
 		if (current_player.state == PlayerSettings::State::kClosed) {
 			format_arg_strings.emplace_back(g_style_manager->font_style(UI::FontStyle::kDisabled)
-			                                   .as_font_tag(bformat(_("Player %u: –"), (i + 1))));
+			                                   .as_font_tag(format(_("Player %u: –"), (i + 1))));
 			continue;
 		}
 
@@ -77,7 +77,7 @@ static std::string assemble_infotext_for_savegame(const GameSettings& game_setti
 
 		format_arg_strings.emplace_back(
 		   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
-		      .as_font_tag(bformat(
+		      .as_font_tag(format(
 		         /** TRANSLATORS: "Player 1 (Barbarians): Playername" */
 		         _("Player %1$u (%2$s): %3$s"), (i + 1), tribe_of(game_settings, current_player),
 		         g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
@@ -91,7 +91,7 @@ static std::string assemble_infotext_for_savegame(const GameSettings& game_setti
 		arg.second.string_val = str.c_str();
 		fmt_args.emplace_back(arg);
 	}
-	return bformat(infotext_fmt, fmt_args);
+	return format(infotext_fmt, fmt_args);
 }
 
 static std::string assemble_infotext_for_map(const Widelands::Map& map,
@@ -110,26 +110,26 @@ static std::string assemble_infotext_for_map(const Widelands::Map& map,
 	format_arg_strings.emplace_back(
 	   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
 	      .as_font_tag(
-	         bformat(_("Size: %s"),
+	         format(_("Size: %s"),
 	                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
-	                    .as_font_tag(bformat(_("%1$u×%2$u"), map.get_width(), map.get_height())))));
+	                    .as_font_tag(format(_("%1$u×%2$u"), map.get_width(), map.get_height())))));
 
 	format_arg_strings.emplace_back(
 	   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
-	      .as_font_tag(bformat(
+	      .as_font_tag(format(
 	         _("Players: %s"), g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 	                              .as_font_tag(std::to_string(game_settings.players.size())))));
 
 	format_arg_strings.emplace_back(
 	   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
-	      .as_font_tag(bformat(_("Description: %s"),
+	      .as_font_tag(format(_("Description: %s"),
 	                           g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 	                              .as_font_tag(richtext_escape(map.get_description())))));
 
 	if (!map.get_hint().empty()) {
 		format_arg_strings.emplace_back(
 		   g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelHeading)
-		      .as_font_tag(bformat(
+		      .as_font_tag(format(
 		         _("Hint: %s"), g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 		                           .as_font_tag(map.get_hint()))));
 	}
@@ -141,7 +141,7 @@ static std::string assemble_infotext_for_map(const Widelands::Map& map,
 		arg.second.string_val = str.c_str();
 		fmt_args.emplace_back(arg);
 	}
-	return bformat(infotext_fmt, fmt_args);
+	return format(infotext_fmt, fmt_args);
 }
 
 // MapDetailsBox implementation

--- a/src/ui_fsmenu/menu.cc
+++ b/src/ui_fsmenu/menu.cc
@@ -268,7 +268,7 @@ void MenuCapsule::add(BaseMenu& menu, const std::string& title) {
 	}
 
 	UI::Button* button = new UI::Button(&box_, title, 0, 0, 0, 0, UI::ButtonStyle::kFsMenuMenu,
-	                                    title, bformat(_("Back to ‘%s’"), title));
+	                                    title, format(_("Back to ‘%s’"), title));
 	UI::Panel* spacer1 = new UI::Panel(&box_, UI::PanelStyle::kFsMenu, 0, 0, kPadding, kPadding);
 	UI::Panel* spacer2 = new UI::Panel(&box_, UI::PanelStyle::kFsMenu, 0, 0, kPadding, kPadding);
 	UI::Panel* icon;

--- a/src/ui_fsmenu/mousewheel_options.cc
+++ b/src/ui_fsmenu/mousewheel_options.cc
@@ -215,7 +215,7 @@ KeymodAndDirBox::KeymodAndDirBox(UI::Panel* parent,
                                  bool two_d)
    : UI::Box(parent, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Horizontal, 0, kButtonSize, kPadding),
      title_area_(
-        this, UI::PanelStyle::kFsMenu, UI::FontStyle::kFsMenuLabel, bformat(_("%1%:"), title)),
+        this, UI::PanelStyle::kFsMenu, UI::FontStyle::kFsMenuLabel, format(_("%1%:"), title)),
      keymod_dropdown_(this),
      dir_dropdown_(this, two_d),
      title_(title),
@@ -277,7 +277,7 @@ bool KeymodAndDirBox::check_available(uint16_t keymod, uint8_t dir) {
 			      /** TRANSLATORS: %1 is a modifier key combination, e.g. "Ctrl+", or
 			                         empty if none is used. %2 is scrolling direction.
 			                         %3 is the name of the conflicting function. */
-			      bformat(_("‘%1$s%2$s’ conflicts with ‘%3$s’. "
+			      format(_("‘%1$s%2$s’ conflicts with ‘%3$s’. "
 			                "Please select a different combination or "
 			                "change the conflicting setting first."),
 			              keymod_string_for(keymod), _(sd_names[dir]), other->get_title()),
@@ -465,7 +465,7 @@ void MousewheelOptionsDialog::set_touchpad() {
 	if (conflict_speed || conflict_toolsize) {
 		UI::WLMessageBox warning(
 		   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Scroll Settings Conflict"),
-		   as_richtext_paragraph(bformat(_("‘%1$s’ or ‘%2$s’ conflicts with the recommended "
+		   as_richtext_paragraph(format(_("‘%1$s’ or ‘%2$s’ conflicts with the recommended "
 		                                   "settings. Change the conflicting setting(s) too?"),
 		                                 speed_box_.get_title(), toolsize_box_.get_title()),
 		                         UI::FontStyle::kFsMenuLabel, UI::Align::kCenter),

--- a/src/ui_fsmenu/mousewheel_options.cc
+++ b/src/ui_fsmenu/mousewheel_options.cc
@@ -278,9 +278,9 @@ bool KeymodAndDirBox::check_available(uint16_t keymod, uint8_t dir) {
 			                         empty if none is used. %2 is scrolling direction.
 			                         %3 is the name of the conflicting function. */
 			      format(_("‘%1$s%2$s’ conflicts with ‘%3$s’. "
-			                "Please select a different combination or "
-			                "change the conflicting setting first."),
-			              keymod_string_for(keymod), _(sd_names[dir]), other->get_title()),
+			               "Please select a different combination or "
+			               "change the conflicting setting first."),
+			             keymod_string_for(keymod), _(sd_names[dir]), other->get_title()),
 			      UI::FontStyle::kFsMenuLabel, UI::Align::kCenter),
 			   UI::WLMessageBox::MBoxType::kOk);
 			warning.run<UI::Panel::Returncodes>();
@@ -466,8 +466,8 @@ void MousewheelOptionsDialog::set_touchpad() {
 		UI::WLMessageBox warning(
 		   &get_topmost_forefather(), UI::WindowStyle::kFsMenu, _("Scroll Settings Conflict"),
 		   as_richtext_paragraph(format(_("‘%1$s’ or ‘%2$s’ conflicts with the recommended "
-		                                   "settings. Change the conflicting setting(s) too?"),
-		                                 speed_box_.get_title(), toolsize_box_.get_title()),
+		                                  "settings. Change the conflicting setting(s) too?"),
+		                                speed_box_.get_title(), toolsize_box_.get_title()),
 		                         UI::FontStyle::kFsMenuLabel, UI::Align::kCenter),
 		   UI::WLMessageBox::MBoxType::kOkCancel);
 		if (warning.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {

--- a/src/ui_fsmenu/multiplayersetupgroup.cc
+++ b/src/ui_fsmenu/multiplayersetupgroup.cc
@@ -48,7 +48,7 @@ struct MultiPlayerClientGroup : public UI::Box {
 	                       GameSettingsProvider* const settings)
 	   : UI::Box(parent, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Horizontal, 0, 0, kPadding),
 	     slot_dropdown_(this,
-	                    bformat("dropdown_slot%d", static_cast<unsigned int>(id)),
+	                    format("dropdown_slot%d", static_cast<unsigned int>(id)),
 	                    0,
 	                    0,
 	                    0,
@@ -98,7 +98,7 @@ struct MultiPlayerClientGroup : public UI::Box {
 					slot_dropdown_.toggle();
 					UI::WLMessageBox m(
 					   menu_parent_, UI::WindowStyle::kFsMenu, _("Divergent Player Name"),
-					   bformat(
+					   format(
 					      _("The player name of the selected slot (%1%) does not match your own (%2%). "
 					        "Are you sure that you want to occupy this slot?"),
 					      slotname, username),
@@ -129,7 +129,7 @@ struct MultiPlayerClientGroup : public UI::Box {
 		for (PlayerSlot slot = 0; slot < settings.players.size(); ++slot) {
 			if (settings.players.at(slot).state == PlayerSettings::State::kHuman ||
 			    settings.players.at(slot).state == PlayerSettings::State::kOpen) {
-				slot_dropdown_.add(bformat(_("Player %u"), static_cast<unsigned int>(slot + 1)), slot,
+				slot_dropdown_.add(format(_("Player %u"), static_cast<unsigned int>(slot + 1)), slot,
 				                   playercolor_image(settings.players[slot].color,
 				                                     "images/players/genstats_player.png"),
 				                   slot == user_setting.position);
@@ -183,9 +183,9 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 	             UI::ButtonStyle::kFsMenuSecondary,
 	             playercolor_image(settings_->settings().players[id].color,
 	                               "images/players/player_position_menu.png"),
-	             bformat(_("Player %u"), static_cast<unsigned int>(id_ + 1))),
+	             format(_("Player %u"), static_cast<unsigned int>(id_ + 1))),
 	     type_dropdown_(this,
-	                    bformat("dropdown_type%d", static_cast<unsigned int>(id)),
+	                    format("dropdown_type%d", static_cast<unsigned int>(id)),
 	                    0,
 	                    0,
 	                    h,
@@ -196,7 +196,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 	                    UI::PanelStyle::kFsMenu,
 	                    UI::ButtonStyle::kFsMenuSecondary),
 	     tribes_dropdown_(this,
-	                      bformat("dropdown_tribes%d", static_cast<unsigned int>(id)),
+	                      format("dropdown_tribes%d", static_cast<unsigned int>(id)),
 	                      0,
 	                      0,
 	                      h,
@@ -207,7 +207,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 	                      UI::PanelStyle::kFsMenu,
 	                      UI::ButtonStyle::kFsMenuSecondary),
 	     init_dropdown_(this,
-	                    bformat("dropdown_init%d", static_cast<unsigned int>(id)),
+	                    format("dropdown_init%d", static_cast<unsigned int>(id)),
 	                    0,
 	                    0,
 	                    h,
@@ -218,7 +218,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 	                    UI::PanelStyle::kFsMenu,
 	                    UI::ButtonStyle::kFsMenuSecondary),
 	     team_dropdown_(this,
-	                    bformat("dropdown_team%d", static_cast<unsigned int>(id)),
+	                    format("dropdown_team%d", static_cast<unsigned int>(id)),
 	                    0,
 	                    0,
 	                    h,
@@ -318,7 +318,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 		    (player_setting.tribe.empty() ||
 		     settings.get_tribeinfo(player_setting.tribe).suited_for_ai || can_change_hidden_tribe)) {
 			for (const auto* impl : AI::ComputerPlayer::get_implementations()) {
-				type_dropdown_.add(_(impl->descname), bformat("%s%s", kAiNamePrefix, impl->name),
+				type_dropdown_.add(_(impl->descname), format("%s%s", kAiNamePrefix, impl->name),
 				                   g_image_cache->get(impl->icon_filename), false, _(impl->descname));
 			}
 			/** TRANSLATORS: This is the name of an AI used in the game setup screens */
@@ -347,7 +347,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 		// Now select the entry according to server settings
 		if (player_setting.state == PlayerSettings::State::kHuman) {
 			type_dropdown_.set_image(g_image_cache->get("images/wui/stats/genstats_nrworkers.png"));
-			type_dropdown_.set_tooltip(bformat(_("%1%: %2%"), _("Type"), _("Human")));
+			type_dropdown_.set_tooltip(format(_("%1%: %2%"), _("Type"), _("Human")));
 		} else if (player_setting.state == PlayerSettings::State::kClosed) {
 			type_dropdown_.select("closed");
 		} else if (player_setting.state == PlayerSettings::State::kOpen) {
@@ -364,7 +364,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 					} else {
 						const AI::ComputerPlayer::Implementation* impl =
 						   AI::ComputerPlayer::get_implementation(player_setting.ai);
-						type_dropdown_.select(bformat("%s%s", kAiNamePrefix, impl->name));
+						type_dropdown_.select(format("%s%s", kAiNamePrefix, impl->name));
 					}
 				}
 			}
@@ -423,7 +423,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 					const std::string player_name =
 					   /** TRANSLATORS: This is an option in multiplayer setup for sharing
 					      another player's starting position. */
-					   bformat(_("Shared in Player %u"), static_cast<unsigned int>(i + 1));
+					   format(_("Shared in Player %u"), static_cast<unsigned int>(i + 1));
 					tribes_dropdown_.add(player_name, as_string(static_cast<unsigned int>(i + 1)),
 					                     player_image, (i + 1) == player_setting.shared_in, player_name);
 				}
@@ -562,7 +562,7 @@ struct MultiPlayerPlayerGroup : public UI::Box {
 #endif
 		for (Widelands::TeamNumber t = 1; t <= settings.players.size() / 2; ++t) {
 			assert(t < no_of_team_colors);
-			team_dropdown_.add(bformat(_("Team %d"), static_cast<unsigned int>(t)), t,
+			team_dropdown_.add(format(_("Team %d"), static_cast<unsigned int>(t)), t,
 			                   playercolor_image(kTeamColors[t], "images/players/team.png"));
 		}
 		team_dropdown_.select(player_setting.team);

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -488,7 +488,7 @@ void Options::add_screen_resolutions(const OptionsCtrl::OptionsStruct& opt) {
 				const bool selected = !resolution_dropdown_.has_selection() && this_res == current_res;
 				resolution_dropdown_.add(
 				   /** TRANSLATORS: Screen resolution, e.g. 800 × 600*/
-				   bformat(_("%1% × %2%"), this_res.xres, this_res.yres), this_res, nullptr, selected);
+				   format(_("%1% × %2%"), this_res.xres, this_res.yres), this_res, nullptr, selected);
 			}
 		}
 	}
@@ -496,7 +496,7 @@ void Options::add_screen_resolutions(const OptionsCtrl::OptionsStruct& opt) {
 	if (!resolution_dropdown_.has_selection()) {
 		resolution_dropdown_.add(
 		   /** TRANSLATORS: Screen resolution, e.g. 800 × 600*/
-		   bformat(_("%1% × %2%"), current_res.xres, current_res.yres), current_res, nullptr, true);
+		   format(_("%1% × %2%"), current_res.xres, current_res.yres), current_res, nullptr, true);
 	}
 }
 
@@ -648,9 +648,9 @@ void Options::update_language_stats() {
 				if (percent == 100) {
 					message =
 					   /** TRANSLATORS: %s = language name */
-					   bformat(_("The translation into %s is complete."), entry.descname);
+					   format(_("The translation into %s is complete."), entry.descname);
 				} else {
-					message = bformat(
+					message = format(
 					   /** TRANSLATORS: %1% = language name, %2% = percentage */
 					   _("The translation into %1% is %2%%% complete."), entry.descname, percent);
 				}
@@ -664,7 +664,7 @@ void Options::update_language_stats() {
 	// will catch up with the work later.
 	if (percent <= 90) {
 		message = message + " " +
-		          bformat(_("If you wish to help us translate, please visit %s"),
+		          format(_("If you wish to help us translate, please visit %s"),
 		                  "<font underline=1>widelands.org/wiki/TranslatingWidelands</font>");
 	}
 	// Make font a bit smaller so the link will fit at 800x600 resolution.

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -665,7 +665,7 @@ void Options::update_language_stats() {
 	if (percent <= 90) {
 		message = message + " " +
 		          format(_("If you wish to help us translate, please visit %s"),
-		                  "<font underline=1>widelands.org/wiki/TranslatingWidelands</font>");
+		                 "<font underline=1>widelands.org/wiki/TranslatingWidelands</font>");
 	}
 	// Make font a bit smaller so the link will fit at 800x600 resolution.
 	translation_info_.set_text(

--- a/src/ui_fsmenu/scenario_select.cc
+++ b/src/ui_fsmenu/scenario_select.cc
@@ -85,9 +85,9 @@ ScenarioSelect::ScenarioSelect(MenuCapsule& fsmm, CampaignData* camp)
 		const std::string subtitle1 = _("Pick a tutorial from the list, then hit “OK”.");
 		const std::string subtitle2 =
 		   _("You can see a description of the currently selected tutorial on the right.");
-		subtitle_.set_text(bformat("%s\n%s", subtitle1, subtitle2));
+		subtitle_.set_text(format("%s\n%s", subtitle1, subtitle2));
 	} else {
-		subtitle_.set_text(bformat("%s — %s", campaign_->tribename, campaign_->descname));
+		subtitle_.set_text(format("%s — %s", campaign_->tribename, campaign_->descname));
 	}
 
 	header_box_.add(&subtitle_, UI::Box::Resizing::kExpandBoth);
@@ -277,7 +277,7 @@ void ScenarioSelect::fill_table() {
 
 		// Now add to table
 		UI::Table<uintptr_t>::EntryRecord& te = table_.add(i);
-		te.set_string(0, bformat("%d", (i + 1)));
+		te.set_string(0, format("%d", (i + 1)));
 		te.set_picture(
 		   1, g_image_cache->get("images/ui_basic/ls_wlmap.png"), scenario_data->descname);
 		te.set_disabled(!scenario_data->playable);

--- a/src/ui_fsmenu/scenariodetails.cc
+++ b/src/ui_fsmenu/scenariodetails.cc
@@ -44,9 +44,9 @@ ScenarioDetails::ScenarioDetails(Panel* parent)
 
 void ScenarioDetails::update(const ScenarioData& scenariodata) {
 	name_label_.set_text(format("<rt>%s%s</rt>",
-	                             as_heading(scenariodata.is_tutorial ? _("Tutorial") : _("Scenario"),
-	                                        UI::PanelStyle::kFsMenu, true),
-	                             as_content(scenariodata.descname, UI::PanelStyle::kFsMenu)));
+	                            as_heading(scenariodata.is_tutorial ? _("Tutorial") : _("Scenario"),
+	                                       UI::PanelStyle::kFsMenu, true),
+	                            as_content(scenariodata.descname, UI::PanelStyle::kFsMenu)));
 
 	if (scenariodata.playable) {
 		const std::string authors_heading =
@@ -58,12 +58,12 @@ void ScenarioDetails::update(const ScenarioData& scenariodata) {
                _("Authors");
 		std::string description =
 		   format("%s%s", as_heading(authors_heading, UI::PanelStyle::kFsMenu),
-		           as_content(scenariodata.authors.get_names(), UI::PanelStyle::kFsMenu));
+		          as_content(scenariodata.authors.get_names(), UI::PanelStyle::kFsMenu));
 
 		description =
 		   format("%s%s", description, as_heading(_("Description"), UI::PanelStyle::kFsMenu));
-		description = format(
-		   "%s%s", description, as_content(scenariodata.description, UI::PanelStyle::kFsMenu));
+		description =
+		   format("%s%s", description, as_content(scenariodata.description, UI::PanelStyle::kFsMenu));
 
 		// Do we want to show add-on conflicts info for campaigns or scenarios?
 		// The official ones don't use add-ons, and add-on campaigns will tell users

--- a/src/ui_fsmenu/scenariodetails.cc
+++ b/src/ui_fsmenu/scenariodetails.cc
@@ -43,7 +43,7 @@ ScenarioDetails::ScenarioDetails(Panel* parent)
 }
 
 void ScenarioDetails::update(const ScenarioData& scenariodata) {
-	name_label_.set_text(bformat("<rt>%s%s</rt>",
+	name_label_.set_text(format("<rt>%s%s</rt>",
 	                             as_heading(scenariodata.is_tutorial ? _("Tutorial") : _("Scenario"),
 	                                        UI::PanelStyle::kFsMenu, true),
 	                             as_content(scenariodata.descname, UI::PanelStyle::kFsMenu)));
@@ -57,12 +57,12 @@ void ScenarioDetails::update(const ScenarioData& scenariodata) {
                   you need plural forms here, please let us know. */
                _("Authors");
 		std::string description =
-		   bformat("%s%s", as_heading(authors_heading, UI::PanelStyle::kFsMenu),
+		   format("%s%s", as_heading(authors_heading, UI::PanelStyle::kFsMenu),
 		           as_content(scenariodata.authors.get_names(), UI::PanelStyle::kFsMenu));
 
 		description =
-		   bformat("%s%s", description, as_heading(_("Description"), UI::PanelStyle::kFsMenu));
-		description = bformat(
+		   format("%s%s", description, as_heading(_("Description"), UI::PanelStyle::kFsMenu));
+		description = format(
 		   "%s%s", description, as_content(scenariodata.description, UI::PanelStyle::kFsMenu));
 
 		// Do we want to show add-on conflicts info for campaigns or scenarios?
@@ -71,7 +71,7 @@ void ScenarioDetails::update(const ScenarioData& scenariodata) {
 		// Plus, ScenarioData currently does not preload the scenario map, so fetching
 		// add-ons info there would introduce additional complexity.
 
-		description = bformat("<rt>%s</rt>", description);
+		description = format("<rt>%s</rt>", description);
 		descr_.set_text(description);
 	} else {
 		descr_.set_text("");

--- a/src/ui_fsmenu/singleplayerdropdown.cc
+++ b/src/ui_fsmenu/singleplayerdropdown.cc
@@ -82,7 +82,7 @@ void SinglePlayerTribeDropdown::rebuild() {
 				const std::string player_name =
 				   /** TRANSLATORS: This is an option in multiplayer setup for sharing
 				         another player's starting position. */
-				   bformat(_("Shared in Player %u"), static_cast<unsigned int>(i + 1));
+				   format(_("Shared in Player %u"), static_cast<unsigned int>(i + 1));
 				dropdown_.add(player_name, as_string(static_cast<unsigned int>(i + 1)), player_image,
 				              (i + 1) == player_setting.shared_in, player_name);
 			}
@@ -172,7 +172,7 @@ void SinglePlayerPlayerTypeDropdown::fill() {
 	// AIs
 	if (settings.get_tribeinfo(settings.players[id_].tribe).suited_for_ai) {
 		for (const auto* impl : AI::ComputerPlayer::get_implementations()) {
-			dropdown_.add(_(impl->descname), bformat("%s%s", kAiNamePrefix, impl->name),
+			dropdown_.add(_(impl->descname), format("%s%s", kAiNamePrefix, impl->name),
 			              g_image_cache->get(impl->icon_filename), false, _(impl->descname));
 		}
 		/** TRANSLATORS: This is the name of an AI used in the game setup screens */
@@ -195,7 +195,7 @@ void SinglePlayerPlayerTypeDropdown::select_entry() {
 	const PlayerSettings& player_setting = settings.players[id_];
 	if (player_setting.state == PlayerSettings::State::kHuman) {
 		dropdown_.set_image(g_image_cache->get("images/wui/stats/genstats_nrworkers.png"));
-		dropdown_.set_tooltip(bformat(_("%1%: %2%"), _("Type"), _("Human")));
+		dropdown_.set_tooltip(format(_("%1%: %2%"), _("Type"), _("Human")));
 		dropdown_.set_enabled(false);
 	} else if (player_setting.state == PlayerSettings::State::kClosed) {
 		dropdown_.select(kClosed);
@@ -208,7 +208,7 @@ void SinglePlayerPlayerTypeDropdown::select_entry() {
 			} else {
 				const AI::ComputerPlayer::Implementation* impl =
 				   AI::ComputerPlayer::get_implementation(player_setting.ai);
-				dropdown_.select(bformat("%s%s", kAiNamePrefix, impl->name));
+				dropdown_.select(format("%s%s", kAiNamePrefix, impl->name));
 			}
 		}
 	}
@@ -382,7 +382,7 @@ void SinglePlayerTeamDropdown::rebuild() {
 #endif
 	for (Widelands::TeamNumber t = 1; t <= settings.players.size() / 2; ++t) {
 		assert(t < no_of_team_colors);
-		dropdown_.add(bformat(_("Team %d"), static_cast<unsigned int>(t)), t,
+		dropdown_.add(format(_("Team %d"), static_cast<unsigned int>(t)), t,
 		              playercolor_image(kTeamColors[t], "images/players/team.png"));
 	}
 	dropdown_.select(player_setting.team);

--- a/src/ui_fsmenu/singleplayersetupbox.cc
+++ b/src/ui_fsmenu/singleplayersetupbox.cc
@@ -47,14 +47,14 @@ SinglePlayerActivePlayerGroup::SinglePlayerActivePlayerGroup(UI::Panel* const pa
              h,
              UI::ButtonStyle::kFsMenuSecondary,
              playercolor_image(),
-             bformat(_("Player %u"), static_cast<unsigned>(id_ + 1))),
+             format(_("Player %u"), static_cast<unsigned>(id_ + 1))),
      player_type_(
-        this, lg, bformat("dropdown_type%d", static_cast<unsigned>(id)), 0, 0, h, h, settings, id),
+        this, lg, format("dropdown_type%d", static_cast<unsigned>(id)), 0, 0, h, h, settings, id),
      tribe_(
-        this, lg, bformat("dropdown_tribe%d", static_cast<unsigned>(id)), 0, 0, h, h, settings, id),
+        this, lg, format("dropdown_tribe%d", static_cast<unsigned>(id)), 0, 0, h, h, settings, id),
      start_type(this,
                 lg,
-                bformat("dropdown_init%d", static_cast<unsigned>(id)),
+                format("dropdown_init%d", static_cast<unsigned>(id)),
                 0,
                 0,
                 8 * h,
@@ -62,7 +62,7 @@ SinglePlayerActivePlayerGroup::SinglePlayerActivePlayerGroup(UI::Panel* const pa
                 settings,
                 id),
      teams_(
-        this, lg, bformat("dropdown_team%d", static_cast<unsigned>(id)), 0, 0, h, h, settings, id) {
+        this, lg, format("dropdown_team%d", static_cast<unsigned>(id)), 0, 0, h, h, settings, id) {
 
 	add(&player_);
 	add(player_type_.get_dropdown());

--- a/src/website/create_spritesheet.cc
+++ b/src/website/create_spritesheet.cc
@@ -291,7 +291,7 @@ void write_animation_spritesheets(Widelands::EditorGameBase& egbase,
 					   "Missing directional animation '%s\'", directional_animname.c_str());
 				}
 				const std::string filename_base =
-				   bformat("%s%s_%d", animation_name, animation_direction_names[dir - 1], scale);
+				   format("%s%s_%d", animation_name, animation_direction_names[dir - 1], scale);
 				const Animation& directional_animation = g_animation_manager->get_animation(
 				   descr->get_animation(directional_animname, nullptr));
 				spritesheets_to_write.emplace_back(
@@ -300,7 +300,7 @@ void write_animation_spritesheets(Widelands::EditorGameBase& egbase,
 
 		} else {
 			spritesheets_to_write.emplace_back(new SpritesheetData(
-			   bformat("%s_%d", animation_name, scale), representative_animation, scale));
+			   format("%s_%d", animation_name, scale), representative_animation, scale));
 		}
 
 		// Find margins for trimming

--- a/src/website/map_object_info.cc
+++ b/src/website/map_object_info.cc
@@ -261,8 +261,7 @@ void write_tribes(const Widelands::EditorGameBase& egbase, FileSystem* out_files
 		// These go in separate files
 		std::unique_ptr<JSON::Object> json_tribe_for_file(new JSON::Object());
 		add_tribe_info(tribe_info, json_tribe_for_file.get());
-		json_tribe_for_file->write_to_file(
-		   *out_filesystem, format("tribe_%s.json", tribe_info.name));
+		json_tribe_for_file->write_to_file(*out_filesystem, format("tribe_%s.json", tribe_info.name));
 
 		const Widelands::TribeDescr& tribe =
 		   *descriptions.get_tribe_descr(descriptions.tribe_index(tribe_info.name));

--- a/src/website/map_object_info.cc
+++ b/src/website/map_object_info.cc
@@ -164,7 +164,7 @@ void write_buildings(const Widelands::TribeDescr& tribe, FileSystem* out_filesys
 		json_building->add_string("helptext", get_helptext(*building, tribe));
 	}
 
-	json->write_to_file(*out_filesystem, bformat("%s_buildings.json", tribe.name()));
+	json->write_to_file(*out_filesystem, format("%s_buildings.json", tribe.name()));
 	log_info("\n");
 }
 
@@ -189,7 +189,7 @@ void write_wares(const Widelands::TribeDescr& tribe, FileSystem* out_filesystem)
 		json_ware->add_string("helptext", get_helptext(ware, tribe));
 	}
 
-	json->write_to_file(*out_filesystem, bformat("%s_wares.json", tribe.name()));
+	json->write_to_file(*out_filesystem, format("%s_wares.json", tribe.name()));
 	log_info("\n");
 }
 
@@ -221,7 +221,7 @@ void write_workers(const Widelands::TribeDescr& tribe, FileSystem* out_filesyste
 		}
 	}
 
-	json->write_to_file(*out_filesystem, bformat("%s_workers.json", tribe.name()));
+	json->write_to_file(*out_filesystem, format("%s_workers.json", tribe.name()));
 	log_info("\n");
 }
 
@@ -262,7 +262,7 @@ void write_tribes(const Widelands::EditorGameBase& egbase, FileSystem* out_files
 		std::unique_ptr<JSON::Object> json_tribe_for_file(new JSON::Object());
 		add_tribe_info(tribe_info, json_tribe_for_file.get());
 		json_tribe_for_file->write_to_file(
-		   *out_filesystem, bformat("tribe_%s.json", tribe_info.name));
+		   *out_filesystem, format("tribe_%s.json", tribe_info.name));
 
 		const Widelands::TribeDescr& tribe =
 		   *descriptions.get_tribe_descr(descriptions.tribe_index(tribe_info.name));

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -773,8 +773,8 @@ void WLApplication::run() {
 			}
 		} catch (const Widelands::GameDataError& e) {
 			message = format(_("Widelands could not load the file \"%s\". The file format "
-			                    "seems to be incompatible."),
-			                  filename_.c_str());
+			                   "seems to be incompatible."),
+			                 filename_.c_str());
 			message = message + "\n\n" + _("Error message:") + "\n" + e.what();
 			title = _("Game data error");
 		} catch (const FileNotFoundError& e) {
@@ -1437,7 +1437,7 @@ void WLApplication::handle_commandline_parameters() {
 	if (commandline_.count("error")) {
 		throw ParameterError(CmdLineVerbosity::Normal,
 		                     format(_("Unknown command line parameter: %s\nMaybe a '=' is missing?"),
-		                             commandline_["error"]));
+		                            commandline_["error"]));
 	}
 
 	if (commandline_.count("datadir_for_testing")) {
@@ -1666,8 +1666,8 @@ void WLApplication::emergency_save(UI::Panel* panel,
 			UI::WLMessageBox m(
 			   panel, UI::WindowStyle::kFsMenu, _("Emergency save failed"),
 			   format(_("We are sorry, but Widelands was unable to create an emergency "
-			             "savegame for the following reason:\n\n%s"),
-			           e.what()),
+			            "savegame for the following reason:\n\n%s"),
+			          e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 		}

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -772,13 +772,13 @@ void WLApplication::run() {
 				game.run_load_game(filename_, script_to_run_);
 			}
 		} catch (const Widelands::GameDataError& e) {
-			message = bformat(_("Widelands could not load the file \"%s\". The file format "
+			message = format(_("Widelands could not load the file \"%s\". The file format "
 			                    "seems to be incompatible."),
 			                  filename_.c_str());
 			message = message + "\n\n" + _("Error message:") + "\n" + e.what();
 			title = _("Game data error");
 		} catch (const FileNotFoundError& e) {
-			message = bformat(_("Widelands could not find the file \"%s\"."), filename_.c_str());
+			message = format(_("Widelands could not find the file \"%s\"."), filename_.c_str());
 			message = message + "\n\n" + _("Error message:") + "\n" + e.what();
 			title = _("File system error");
 		} catch (const std::exception& e) {
@@ -888,7 +888,7 @@ bool WLApplication::handle_key(bool down, const SDL_Keycode& keycode, const int 
 		} else {
 			g_fs->ensure_directory_exists(kScreenshotsDir);
 			for (uint32_t nr = 0; nr < 10000; ++nr) {
-				const std::string filename = bformat("%s/shot%04u.png", kScreenshotsDir, nr);
+				const std::string filename = format("%s/shot%04u.png", kScreenshotsDir, nr);
 				if (g_fs->file_exists(filename)) {
 					continue;
 				}
@@ -1275,12 +1275,12 @@ void WLApplication::parse_commandline(int const argc, char const* const* const a
 void WLApplication::handle_commandline_parameters() {
 	auto throw_empty_value = [](const std::string& opt) {
 		throw ParameterError(
-		   CmdLineVerbosity::None, bformat(_("Empty value of command line parameter: %s"), opt));
+		   CmdLineVerbosity::None, format(_("Empty value of command line parameter: %s"), opt));
 	};
 
 	auto throw_exclusive = [](const std::string& opt) {
 		throw ParameterError(
-		   CmdLineVerbosity::None, bformat(_("%s can not be combined with other actions"), opt));
+		   CmdLineVerbosity::None, format(_("%s can not be combined with other actions"), opt));
 	};
 
 	if (commandline_.count("nosound")) {
@@ -1436,7 +1436,7 @@ void WLApplication::handle_commandline_parameters() {
 
 	if (commandline_.count("error")) {
 		throw ParameterError(CmdLineVerbosity::Normal,
-		                     bformat(_("Unknown command line parameter: %s\nMaybe a '=' is missing?"),
+		                     format(_("Unknown command line parameter: %s\nMaybe a '=' is missing?"),
 		                             commandline_["error"]));
 	}
 
@@ -1574,7 +1574,7 @@ void WLApplication::handle_commandline_parameters() {
 			}
 		} else {
 			throw ParameterError(
-			   CmdLineVerbosity::Normal, bformat(_("Unknown command line parameter: %s"), pair.first));
+			   CmdLineVerbosity::Normal, format(_("Unknown command line parameter: %s"), pair.first));
 		}
 	}
 
@@ -1612,7 +1612,7 @@ void WLApplication::emergency_save(UI::Panel* panel,
 		}
 		UI::WLMessageBox m(
 		   panel, UI::WindowStyle::kFsMenu, _("Error"),
-		   bformat(
+		   format(
 		      _("An error has occured. The error message is:\n\n%1$s\n\nPlease report "
 		        "this problem to help us improve Widelands. You will find related messages in the "
 		        "standard output (stdout.txt on Windows). You are using build %2$s "
@@ -1628,7 +1628,7 @@ void WLApplication::emergency_save(UI::Panel* panel,
 		   panel, UI::WindowStyle::kFsMenu,
 		   ask_for_bug_report ? _("Unexpected error during the game") : _("Game ended unexpectedly"),
 		   ask_for_bug_report ?
-            bformat(
+            format(
 		         _("An error occured during the game. The error message is:\n\n%1$s\n\nPlease report "
 		           "this problem to help us improve Widelands. You will find related messages in the "
 		           "standard output (stdout.txt on Windows). You are using build %2$s "
@@ -1637,7 +1637,7 @@ void WLApplication::emergency_save(UI::Panel* panel,
 		           "to attempt to create an emergency savegame? It is often – though not always – "
 		           "possible to load it and continue playing."),
 		         error, build_id(), build_type()) :
-            bformat(
+            format(
 		         _("The game ended unexpectedly for the following reason:\n\n%s\n\nWould you like "
 		           "Widelands to attempt to create an emergency savegame? It is often – though not "
 		           "always – possible to load it and continue playing."),
@@ -1665,7 +1665,7 @@ void WLApplication::emergency_save(UI::Panel* panel,
 		if (panel) {
 			UI::WLMessageBox m(
 			   panel, UI::WindowStyle::kFsMenu, _("Emergency save failed"),
-			   bformat(_("We are sorry, but Widelands was unable to create an emergency "
+			   format(_("We are sorry, but Widelands was unable to create an emergency "
 			             "savegame for the following reason:\n\n%s"),
 			           e.what()),
 			   UI::WLMessageBox::MBoxType::kOk);
@@ -1680,7 +1680,7 @@ void WLApplication::emergency_save(UI::Panel* panel,
  */
 void WLApplication::cleanup_replays() {
 	for (const std::string& filename : g_fs->filter_directory(kReplayDir, [](const std::string& fn) {
-		     return ends_with(fn, bformat("%s%s", kReplayExtension, kSyncstreamExtension));
+		     return ends_with(fn, format("%s%s", kReplayExtension, kSyncstreamExtension));
 	     })) {
 		if (is_autogenerated_and_expired(filename, kReplayKeepAroundTime)) {
 			log_info("Delete syncstream or replay %s\n", filename.c_str());

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -246,7 +246,7 @@ void show_usage(const std::string& build_id,
 	std::cout << std::string(kIndent + kTextWidth, '=')
 	          << std::endl
 	          /** TRANSLATORS: %s = version information */
-	          << bformat(_("This is Widelands Version %s"), bformat("%s(%s)", build_id, build_type))
+	          << format(_("This is Widelands Version %s"), format("%s(%s)", build_id, build_type))
 	          << std::endl;
 
 	if (verbosity != CmdLineVerbosity::None) {

--- a/src/wlapplication_options.cc
+++ b/src/wlapplication_options.cc
@@ -444,7 +444,7 @@ static std::map<KeyboardShortcut, KeyboardShortcutInfo> shortcuts_ = {
 		KeyboardShortcut::kEditorToolsize##radius,                                                   \
 		   KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kEditor}, keysym(SDLK_##key),          \
 		                        "editor_toolsize" #radius,                                           \
-		                        []() { return format(_("Set Toolsize to %d"), radius); })           \
+		                        []() { return format(_("Set Toolsize to %d"), radius); })            \
 	}
    EDITOR_TOOLSIZE(1, 1),
    EDITOR_TOOLSIZE(2, 2),
@@ -666,12 +666,12 @@ static std::map<KeyboardShortcut, KeyboardShortcutInfo> shortcuts_ = {
 	{KeyboardShortcut::kInGameQuicknavSet##i,                                                       \
 	 KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame},                                     \
 	                      keysym(SDLK_##i, kDefaultCtrlModifier), "game_quicknav_set_" #i,          \
-	                      []() { return format(_("Set Landmark #%d"), i); })},                     \
+	                      []() { return format(_("Set Landmark #%d"), i); })},                      \
 	{                                                                                               \
 		KeyboardShortcut::kInGameQuicknavGoto##i,                                                    \
 		   KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame}, keysym(SDLK_##i),              \
 		                        "game_quicknav_goto_" #i,                                            \
-		                        []() { return format(_("Go To Landmark #%d"), i); })                \
+		                        []() { return format(_("Go To Landmark #%d"), i); })                 \
 	}
    QUICKNAV(1),
    QUICKNAV(2),
@@ -1029,8 +1029,7 @@ std::string shortcut_string_for(const SDL_Keysym sym, const bool rt_escape) {
 		return _("(disabled)");
 	}
 
-	std::string result =
-	   format(_("%1$s%2$s"), keymod_string_for(sym.mod, false), key_name(sym.sym));
+	std::string result = format(_("%1$s%2$s"), keymod_string_for(sym.mod, false), key_name(sym.sym));
 
 	return rt_escape ? richtext_escape(result) : result;
 }

--- a/src/wlapplication_options.cc
+++ b/src/wlapplication_options.cc
@@ -444,7 +444,7 @@ static std::map<KeyboardShortcut, KeyboardShortcutInfo> shortcuts_ = {
 		KeyboardShortcut::kEditorToolsize##radius,                                                   \
 		   KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kEditor}, keysym(SDLK_##key),          \
 		                        "editor_toolsize" #radius,                                           \
-		                        []() { return bformat(_("Set Toolsize to %d"), radius); })           \
+		                        []() { return format(_("Set Toolsize to %d"), radius); })           \
 	}
    EDITOR_TOOLSIZE(1, 1),
    EDITOR_TOOLSIZE(2, 2),
@@ -666,12 +666,12 @@ static std::map<KeyboardShortcut, KeyboardShortcutInfo> shortcuts_ = {
 	{KeyboardShortcut::kInGameQuicknavSet##i,                                                       \
 	 KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame},                                     \
 	                      keysym(SDLK_##i, kDefaultCtrlModifier), "game_quicknav_set_" #i,          \
-	                      []() { return bformat(_("Set Landmark #%d"), i); })},                     \
+	                      []() { return format(_("Set Landmark #%d"), i); })},                     \
 	{                                                                                               \
 		KeyboardShortcut::kInGameQuicknavGoto##i,                                                    \
 		   KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame}, keysym(SDLK_##i),              \
 		                        "game_quicknav_goto_" #i,                                            \
-		                        []() { return bformat(_("Go To Landmark #%d"), i); })                \
+		                        []() { return format(_("Go To Landmark #%d"), i); })                \
 	}
    QUICKNAV(1),
    QUICKNAV(2),
@@ -934,7 +934,7 @@ std::string keymod_string_for(const uint16_t modstate, const bool rt_escape) {
 	// because all current uses need it anyway, and extra checks can
 	// be avoided both here and in the users this way
 	for (const std::string& m : mods) {
-		result = bformat(_("%1$s+%2$s"), m, result);
+		result = format(_("%1$s+%2$s"), m, result);
 	}
 
 	return rt_escape ? richtext_escape(result) : result;
@@ -1030,7 +1030,7 @@ std::string shortcut_string_for(const SDL_Keysym sym, const bool rt_escape) {
 	}
 
 	std::string result =
-	   bformat(_("%1$s%2$s"), keymod_string_for(sym.mod, false), key_name(sym.sym));
+	   format(_("%1$s%2$s"), keymod_string_for(sym.mod, false), key_name(sym.sym));
 
 	return rt_escape ? richtext_escape(result) : result;
 }
@@ -1054,8 +1054,8 @@ static void init_fastplace_shortcuts(const bool force_defaults) {
 			++counter;
 			shortcuts_.emplace(
 			   k, KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame}, keysym(SDLK_UNKNOWN),
-			                           bformat("%scustom_%i", kFastplaceGroupPrefix, counter),
-			                           [counter]() { return bformat(_("Fastplace #%i"), counter); }));
+			                           format("%scustom_%i", kFastplaceGroupPrefix, counter),
+			                           [counter]() { return format(_("Fastplace #%i"), counter); }));
 		}
 	}
 }

--- a/src/wui/actionconfirm.cc
+++ b/src/wui/actionconfirm.cc
@@ -299,7 +299,7 @@ EnhanceConfirm::EnhanceConfirm(InteractivePlayer& parent,
         parent,
         _("Enhance building?"),
         building.descr().type() == Widelands::MapObjectType::MILITARYSITE ?
-           bformat(
+           format(
               "%s\n\n%s",
               _("Do you really want to enhance this building?"),
               /** TRANSLATORS: Warning message when player wants to enhance a military building */
@@ -362,7 +362,7 @@ ShipSinkConfirm::ShipSinkConfirm(InteractivePlayer& parent, Widelands::Ship& shi
    : ActionConfirm(parent,
                    _("Sink the ship?"),
                    /** TRANSLATORS: %s is a ship name */
-                   bformat(_("Do you really want to sink %s?"), ship.get_shipname()),
+                   format(_("Do you really want to sink %s?"), ship.get_shipname()),
                    ship) {
 	// Nothing special to do
 }

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -164,7 +164,7 @@ void AttackWindow::think() {
 
 static inline std::string slider_heading(uint32_t num_attackers) {
 	/** TRANSLATORS: Number of soldiers that should attack. Used in the attack window. */
-	return bformat(ngettext("%u soldier", "%u soldiers", num_attackers), num_attackers);
+	return format(ngettext("%u soldier", "%u soldiers", num_attackers), num_attackers);
 }
 
 void AttackWindow::update(bool action_on_panel) {
@@ -279,7 +279,7 @@ void AttackWindow::init_soldier_lists(const std::vector<Widelands::Soldier*>& al
 		   add_text(mainbox_, _("Attackers:"), UI::Align::kLeft, UI::FontStyle::kWuiLabel);
 		// Needed so we can get tooltips
 		txt.set_handle_mouse(true);
-		txt.set_tooltip(bformat(
+		txt.set_tooltip(format(
 		   tooltip_format,
 		   g_style_manager->font_style(UI::FontStyle::kWuiTooltipHeader)
 		      .as_font_tag(_("Click on a soldier to remove him from the list of attackers")),
@@ -294,7 +294,7 @@ void AttackWindow::init_soldier_lists(const std::vector<Widelands::Soldier*>& al
 		UI::Textarea& txt =
 		   add_text(mainbox_, _("Not attacking:"), UI::Align::kLeft, UI::FontStyle::kWuiLabel);
 		txt.set_handle_mouse(true);
-		txt.set_tooltip(bformat(
+		txt.set_tooltip(format(
 		   tooltip_format,
 		   g_style_manager->font_style(UI::FontStyle::kWuiTooltipHeader)
 		      .as_font_tag(_("Click on a soldier to add him to the list of attackers")),
@@ -424,7 +424,7 @@ void AttackWindow::ListOfSoldiers::handle_mousein(bool) {
 bool AttackWindow::ListOfSoldiers::handle_mousemove(
    uint8_t, int32_t x, int32_t y, int32_t, int32_t) {
 	if (const Widelands::Soldier* soldier = soldier_at(x, y)) {
-		set_tooltip(bformat(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
+		set_tooltip(format(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
 		                    soldier->get_health_level(), soldier->descr().get_max_health_level(),
 		                    soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
 		                    soldier->get_defense_level(), soldier->descr().get_max_defense_level(),

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -425,10 +425,10 @@ bool AttackWindow::ListOfSoldiers::handle_mousemove(
    uint8_t, int32_t x, int32_t y, int32_t, int32_t) {
 	if (const Widelands::Soldier* soldier = soldier_at(x, y)) {
 		set_tooltip(format(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
-		                    soldier->get_health_level(), soldier->descr().get_max_health_level(),
-		                    soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
-		                    soldier->get_defense_level(), soldier->descr().get_max_defense_level(),
-		                    soldier->get_evade_level(), soldier->descr().get_max_evade_level()));
+		                   soldier->get_health_level(), soldier->descr().get_max_health_level(),
+		                   soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
+		                   soldier->get_defense_level(), soldier->descr().get_max_defense_level(),
+		                   soldier->get_evade_level(), soldier->descr().get_max_evade_level()));
 	} else {
 		set_tooltip(std::string());
 	}

--- a/src/wui/building_statistics_menu.cc
+++ b/src/wui/building_statistics_menu.cc
@@ -432,7 +432,7 @@ void BuildingStatisticsMenu::add_button(Widelands::DescriptionIndex id,
                                         UI::Box* row) {
 	UI::Box* button_box = new UI::Box(row, UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical);
 	building_buttons_[id] =
-	   new UI::Button(button_box, bformat("building_button%d", id), 0, 0, kBuildGridCellWidth,
+	   new UI::Button(button_box, format("building_button%d", id), 0, 0, kBuildGridCellWidth,
 	                  kBuildGridCellHeight, UI::ButtonStyle::kWuiBuildingStats,
 	                  descr.representative_image(&iplayer().get_player()->get_playercolor()), "",
 	                  UI::Button::VisualState::kFlat);
@@ -689,7 +689,7 @@ void BuildingStatisticsMenu::update() {
 
 				/** TRANSLATORS: Percent in building statistics window, e.g. 85% */
 				/** TRANSLATORS: If you wish to add a space, translate as '%i %%' */
-				const std::string perc_str = bformat(_("%i%%"), percent);
+				const std::string perc_str = format(_("%i%%"), percent);
 				set_labeltext(productivity_labels_[id], perc_str, color);
 			}
 			if (has_selection_ && id == current_building_type_) {
@@ -707,7 +707,7 @@ void BuildingStatisticsMenu::update() {
 				   (total_stationed_soldiers < total_soldier_capacity)     ? style_.medium_color() :
                                                                          style_.high_color();
 				const std::string perc_str =
-				   bformat(_("%1%/%2%"), total_stationed_soldiers, total_soldier_capacity);
+				   format(_("%1%/%2%"), total_stationed_soldiers, total_soldier_capacity);
 				set_labeltext(productivity_labels_[id], perc_str, color);
 			}
 			if (has_selection_ && id == current_building_type_) {
@@ -726,9 +726,9 @@ void BuildingStatisticsMenu::update() {
 		   player.tribe().has_building(id) && (building.is_buildable() || building.is_enhanced());
 		if (can_construct_this_building) {
 			/** TRANSLATORS: Buildings: owned / under construction */
-			owned_text = bformat(_("%1%/%2%"), nr_owned, nr_build);
+			owned_text = format(_("%1%/%2%"), nr_owned, nr_build);
 		} else {
-			owned_text = bformat(_("%1%/%2%"), nr_owned, "–");
+			owned_text = format(_("%1%/%2%"), nr_owned, "–");
 		}
 		set_labeltext(
 		   owned_labels_[id], owned_text, style_.building_statistics_details_font().color());

--- a/src/wui/buildingwindow.cc
+++ b/src/wui/buildingwindow.cc
@@ -296,7 +296,7 @@ void BuildingWindow::create_capsbuttons(UI::Box* capsbuttons, Widelands::Buildin
 			    owner.tribe().has_building(enhancement)) {
 				const Widelands::BuildingDescr& building_descr = *tribe.get_building_descr(enhancement);
 				std::string enhance_tooltip =
-				   bformat(_("Enhance to %s"), building_descr.descname()) + "<br>" +
+				   format(_("Enhance to %s"), building_descr.descname()) + "<br>" +
 				   g_style_manager->ware_info_style(UI::WareInfoStyle::kNormal)
 				      .header_font()
 				      .as_font_tag(_("Construction costs:")) +

--- a/src/wui/chat_msg_layout.cc
+++ b/src/wui/chat_msg_layout.cc
@@ -55,11 +55,11 @@ std::string format_as_richtext(const ChatMessage& chat_message) {
 		// Personal message handling
 		if (sanitized.compare(0, 3, "/me")) {
 			message = as_playercolor(chat_message.playern,
-			                         bformat("%s @%s: ", sender_escaped, recipient_escaped)) +
+			                         format("%s @%s: ", sender_escaped, recipient_escaped)) +
 			          g_style_manager->font_style(UI::FontStyle::kChatWhisper).as_font_tag(sanitized);
 		} else {
 			message = as_playercolor(chat_message.playern,
-			                         (bformat("@%s: %s", recipient_escaped, sender_escaped))) +
+			                         (format("@%s: %s", recipient_escaped, sender_escaped))) +
 			          g_style_manager->font_style(UI::FontStyle::kChatWhisper)
 			             .as_font_tag(sanitized.substr(3));
 		}
@@ -72,8 +72,8 @@ std::string format_as_richtext(const ChatMessage& chat_message) {
 			             .as_font_tag(sanitized.substr(3));
 		} else if (!chat_message.sender.empty()) {
 			const std::string sender_formatted =
-			   as_playercolor(chat_message.playern, bformat("%s:", sender_escaped));
-			message = bformat(
+			   as_playercolor(chat_message.playern, format("%s:", sender_escaped));
+			message = format(
 			   "%s %s", sender_formatted,
 			   g_style_manager->font_style(UI::FontStyle::kChatMessage).as_font_tag(sanitized));
 		} else {
@@ -85,7 +85,7 @@ std::string format_as_richtext(const ChatMessage& chat_message) {
 	char ts[12];
 	strftime(ts, sizeof(ts), "[%H:%M]", localtime(&chat_message.time));
 
-	return bformat("<p>%s %s</p>",
+	return format("<p>%s %s</p>",
 	               g_style_manager->font_style(UI::FontStyle::kChatTimestamp).as_font_tag(ts),
 	               message);
 }

--- a/src/wui/chat_msg_layout.cc
+++ b/src/wui/chat_msg_layout.cc
@@ -54,8 +54,8 @@ std::string format_as_richtext(const ChatMessage& chat_message) {
 	if (!chat_message.recipient.empty() && !chat_message.sender.empty()) {
 		// Personal message handling
 		if (sanitized.compare(0, 3, "/me")) {
-			message = as_playercolor(chat_message.playern,
-			                         format("%s @%s: ", sender_escaped, recipient_escaped)) +
+			message = as_playercolor(
+			             chat_message.playern, format("%s @%s: ", sender_escaped, recipient_escaped)) +
 			          g_style_manager->font_style(UI::FontStyle::kChatWhisper).as_font_tag(sanitized);
 		} else {
 			message = as_playercolor(chat_message.playern,
@@ -73,9 +73,9 @@ std::string format_as_richtext(const ChatMessage& chat_message) {
 		} else if (!chat_message.sender.empty()) {
 			const std::string sender_formatted =
 			   as_playercolor(chat_message.playern, format("%s:", sender_escaped));
-			message = format(
-			   "%s %s", sender_formatted,
-			   g_style_manager->font_style(UI::FontStyle::kChatMessage).as_font_tag(sanitized));
+			message =
+			   format("%s %s", sender_formatted,
+			          g_style_manager->font_style(UI::FontStyle::kChatMessage).as_font_tag(sanitized));
 		} else {
 			message =
 			   g_style_manager->font_style(UI::FontStyle::kChatServer).as_font_tag("*** " + sanitized);
@@ -86,6 +86,6 @@ std::string format_as_richtext(const ChatMessage& chat_message) {
 	strftime(ts, sizeof(ts), "[%H:%M]", localtime(&chat_message.time));
 
 	return format("<p>%s %s</p>",
-	               g_style_manager->font_style(UI::FontStyle::kChatTimestamp).as_font_tag(ts),
-	               message);
+	              g_style_manager->font_style(UI::FontStyle::kChatTimestamp).as_font_tag(ts),
+	              message);
 }

--- a/src/wui/constructionsitewindow.cc
+++ b/src/wui/constructionsitewindow.cc
@@ -136,7 +136,7 @@ void ConstructionSiteWindow::init(bool avoid_fastclick, bool workarea_preview_wa
 		build_settings_tab(construction_site);
 	}
 
-	set_title(bformat(_("(%s)"), construction_site->building().descname()));
+	set_title(format(_("(%s)"), construction_site->building().descname()));
 
 	think();
 	initialization_complete();
@@ -523,7 +523,7 @@ void ConstructionSoldierCapacityBox::change_current(int32_t delta) {
 }
 void ConstructionSoldierCapacityBox::update() {
 	cs_soldier_capacity_display_.set_text(
-	   bformat(ngettext("%u soldier", "%u soldiers", current_), current_));
+	   format(ngettext("%u soldier", "%u soldiers", current_), current_));
 	cs_soldier_capacity_decrease_.set_enabled(enabled_ && current_ > min_);
 	cs_soldier_capacity_increase_.set_enabled(enabled_ && current_ < max_);
 }

--- a/src/wui/encyclopedia_window.cc
+++ b/src/wui/encyclopedia_window.cc
@@ -143,7 +143,7 @@ void EncyclopediaWindow::init(InteractiveBase& parent, std::unique_ptr<LuaTable>
 		log_err_time(parent.egbase().get_gametime(), "Error loading script for encyclopedia:\n%s\n",
 		             err.what());
 		UI::WLMessageBox wmb(&parent, UI::WindowStyle::kWui, _("Error!"),
-		                     bformat("Error loading script for encyclopedia:\n%s", err.what()),
+		                     format("Error loading script for encyclopedia:\n%s", err.what()),
 		                     UI::WLMessageBox::MBoxType::kOk);
 		wmb.run<UI::Panel::Returncodes>();
 	}

--- a/src/wui/fieldaction.cc
+++ b/src/wui/fieldaction.cc
@@ -450,7 +450,7 @@ void FieldActionWindow::add_buttons_auto() {
 						} else {
 							tooltip = it->second;
 						}
-						tooltip = bformat(
+						tooltip = format(
 						   "<rt><p>%s</p><p>%s</p></rt>",
 						   g_style_manager->font_style(UI::FontStyle::kDisabled)
 						      .as_font_tag(_("Send scout to explore surroundings")),

--- a/src/wui/game_client_disconnected.cc
+++ b/src/wui/game_client_disconnected.cc
@@ -120,7 +120,7 @@ GameClientDisconnected::GameClientDisconnected(InteractiveGameBase* gb,
 		                   false,
 		                   /** TRANSLATORS: Dropdown selection. Parameter is the name of the AI that
 		                      will be used as replacement for a disconnected player */
-		                   bformat(_("Replace player with %s"), impl->descname));
+		                   format(_("Replace player with %s"), impl->descname));
 	}
 
 	// Set default mode to normal AI

--- a/src/wui/game_debug_ui.cc
+++ b/src/wui/game_debug_ui.cc
@@ -109,7 +109,7 @@ void MapObjectDebugWindow::think() {
 		}
 		UI::Window::think();
 	} else {
-		set_title(bformat("DEAD: %u", serial_));
+		set_title(format("DEAD: %u", serial_));
 	}
 }
 
@@ -172,7 +172,7 @@ void FieldDebugWindow::think() {
 	   dynamic_cast<const InteractiveBase&>(*get_parent()).egbase();
 	{
 		Widelands::PlayerNumber const owner = coords_.field->get_owned_by();
-		str += bformat("(%i, %i)\nheight: %u\nowner: %u\n", coords_.x, coords_.y,
+		str += format("(%i, %i)\nheight: %u\nowner: %u\n", coords_.x, coords_.y,
 		               static_cast<unsigned int>(coords_.field->get_height()),
 		               static_cast<unsigned int>(owner));
 
@@ -206,18 +206,18 @@ void FieldDebugWindow::think() {
 	Widelands::PlayerNumber const nr_players = map_.get_nrplayers();
 	iterate_players_existing_const(plnum, nr_players, egbase, player) {
 		const Widelands::Player::Field& player_field = player->fields()[i];
-		str += bformat("Player %u:\n", static_cast<unsigned int>(plnum));
-		str += bformat("  military influence: %u\n", player_field.military_influence);
+		str += format("Player %u:\n", static_cast<unsigned int>(plnum));
+		str += format("  military influence: %u\n", player_field.military_influence);
 
 		Widelands::Vision const vision = player_field.vision;
-		str += bformat("  vision: %u\n", vision.value());
+		str += format("  vision: %u\n", vision.value());
 		{
 			Time const time_last_surveyed =
 			   player_field.time_triangle_last_surveyed[static_cast<int>(Widelands::TriangleIndex::D)];
 
 			if (time_last_surveyed.is_valid()) {
 				str +=
-				   bformat("  D triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
+				   format("  D triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
 				           static_cast<unsigned int>(player_field.resource_amounts.d));
 
 			} else {
@@ -230,7 +230,7 @@ void FieldDebugWindow::think() {
 
 			if (time_last_surveyed.is_valid()) {
 				str +=
-				   bformat("  R triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
+				   format("  R triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
 				           static_cast<unsigned int>(player_field.resource_amounts.r));
 
 			} else {
@@ -245,7 +245,7 @@ void FieldDebugWindow::think() {
 			if (player_field.map_object_descr) {
 				animation_name = "(seen an animation)";
 			}
-			str += bformat("  last seen at %u:\n"
+			str += format("  last seen at %u:\n"
 			               "    owner: %u\n"
 			               "    immovable animation:\n%s\n"
 			               "      ",
@@ -259,7 +259,7 @@ void FieldDebugWindow::think() {
 			} else if (vision.is_hidden()) {
 				str += "  permanently hidden\n";
 			}
-			str += bformat("  seen %u times\n", vision.seers());
+			str += format("  seen %u times\n", vision.seers());
 		}
 	}
 	{
@@ -271,10 +271,10 @@ void FieldDebugWindow::think() {
 			const Widelands::ResourceAmount ramount = coords_.field->get_resources_amount();
 			const Widelands::ResourceAmount initial_amount = coords_.field->get_initial_res_amount();
 
-			str += bformat("Resource: %s\n",
+			str += format("Resource: %s\n",
 			               ibase().egbase().descriptions().get_resource_descr(ridx)->name().c_str());
 
-			str += bformat("  Amount: %i/%i\n", static_cast<unsigned int>(ramount),
+			str += format("  Amount: %i/%i\n", static_cast<unsigned int>(ramount),
 			               static_cast<unsigned int>(initial_amount));
 		}
 	}
@@ -287,7 +287,7 @@ void FieldDebugWindow::think() {
 
 	// Immovable information
 	if (Widelands::BaseImmovable* const imm = coords_.field->get_immovable()) {
-		ui_immovable_.set_title(bformat("%s (%u)", imm->descr().name(), imm->serial()));
+		ui_immovable_.set_title(format("%s (%u)", imm->descr().name(), imm->serial()));
 		ui_immovable_.set_enabled(true);
 	} else {
 		ui_immovable_.set_title("no immovable");
@@ -328,7 +328,7 @@ void FieldDebugWindow::think() {
 	// Add remaining
 	for (const Widelands::Bob* temp_bob : bobs) {
 		ui_bobs_.add(
-		   bformat("%s (%u)", temp_bob->descr().name(), temp_bob->serial()), temp_bob->serial());
+		   format("%s (%u)", temp_bob->descr().name(), temp_bob->serial()), temp_bob->serial());
 	}
 }
 

--- a/src/wui/game_debug_ui.cc
+++ b/src/wui/game_debug_ui.cc
@@ -173,8 +173,8 @@ void FieldDebugWindow::think() {
 	{
 		Widelands::PlayerNumber const owner = coords_.field->get_owned_by();
 		str += format("(%i, %i)\nheight: %u\nowner: %u\n", coords_.x, coords_.y,
-		               static_cast<unsigned int>(coords_.field->get_height()),
-		               static_cast<unsigned int>(owner));
+		              static_cast<unsigned int>(coords_.field->get_height()),
+		              static_cast<unsigned int>(owner));
 
 		if (owner) {
 			Widelands::NodeCaps const buildcaps = egbase.player(owner).get_buildcaps(coords_);
@@ -216,9 +216,8 @@ void FieldDebugWindow::think() {
 			   player_field.time_triangle_last_surveyed[static_cast<int>(Widelands::TriangleIndex::D)];
 
 			if (time_last_surveyed.is_valid()) {
-				str +=
-				   format("  D triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
-				           static_cast<unsigned int>(player_field.resource_amounts.d));
+				str += format("  D triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
+				              static_cast<unsigned int>(player_field.resource_amounts.d));
 
 			} else {
 				str += "  D triangle never surveyed\n";
@@ -229,9 +228,8 @@ void FieldDebugWindow::think() {
 			   player_field.time_triangle_last_surveyed[static_cast<int>(Widelands::TriangleIndex::R)];
 
 			if (time_last_surveyed.is_valid()) {
-				str +=
-				   format("  R triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
-				           static_cast<unsigned int>(player_field.resource_amounts.r));
+				str += format("  R triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
+				              static_cast<unsigned int>(player_field.resource_amounts.r));
 
 			} else {
 				str += "  R triangle never surveyed\n";
@@ -246,11 +244,11 @@ void FieldDebugWindow::think() {
 				animation_name = "(seen an animation)";
 			}
 			str += format("  last seen at %u:\n"
-			               "    owner: %u\n"
-			               "    immovable animation:\n%s\n"
-			               "      ",
-			               player_field.time_node_last_unseen.get(),
-			               static_cast<unsigned int>(player_field.owner), animation_name.c_str());
+			              "    owner: %u\n"
+			              "    immovable animation:\n%s\n"
+			              "      ",
+			              player_field.time_node_last_unseen.get(),
+			              static_cast<unsigned int>(player_field.owner), animation_name.c_str());
 		} else if (!vision.is_seen_by_us()) {
 			str += "  seen only by teammate(s)\n";
 		} else {
@@ -272,10 +270,10 @@ void FieldDebugWindow::think() {
 			const Widelands::ResourceAmount initial_amount = coords_.field->get_initial_res_amount();
 
 			str += format("Resource: %s\n",
-			               ibase().egbase().descriptions().get_resource_descr(ridx)->name().c_str());
+			              ibase().egbase().descriptions().get_resource_descr(ridx)->name().c_str());
 
 			str += format("  Amount: %i/%i\n", static_cast<unsigned int>(ramount),
-			               static_cast<unsigned int>(initial_amount));
+			              static_cast<unsigned int>(initial_amount));
 		}
 	}
 

--- a/src/wui/game_main_menu_save_game.cc
+++ b/src/wui/game_main_menu_save_game.cc
@@ -264,7 +264,7 @@ bool GameMainMenuSaveGame::save_game(std::string filename, bool binary) {
 
 	//  Check if file exists. If so, show a warning.
 	if (g_fs->file_exists(complete_filename)) {
-		const std::string s = bformat(_("A file with the name ‘%s’ already exists. Overwrite?"),
+		const std::string s = format(_("A file with the name ‘%s’ already exists. Overwrite?"),
 		                              FileSystem::fs_filename(filename.c_str()));
 		UI::WLMessageBox mbox(this, UI::WindowStyle::kWui, _("Error Saving Game!"), s,
 		                      UI::WLMessageBox::MBoxType::kOkCancel);

--- a/src/wui/game_main_menu_save_game.cc
+++ b/src/wui/game_main_menu_save_game.cc
@@ -265,7 +265,7 @@ bool GameMainMenuSaveGame::save_game(std::string filename, bool binary) {
 	//  Check if file exists. If so, show a warning.
 	if (g_fs->file_exists(complete_filename)) {
 		const std::string s = format(_("A file with the name ‘%s’ already exists. Overwrite?"),
-		                              FileSystem::fs_filename(filename.c_str()));
+		                             FileSystem::fs_filename(filename.c_str()));
 		UI::WLMessageBox mbox(this, UI::WindowStyle::kWui, _("Error Saving Game!"), s,
 		                      UI::WLMessageBox::MBoxType::kOkCancel);
 		if (mbox.run<UI::Panel::Returncodes>() == UI::Panel::Returncodes::kBack) {

--- a/src/wui/game_message_menu.cc
+++ b/src/wui/game_message_menu.cc
@@ -626,7 +626,7 @@ void GameMessageMenu::update_archive_button_tooltip() {
 			    * message.
 			    * DO NOT omit the placeholder in your translation.
 			    */
-			   bformat(ngettext("Restore the selected %d message", "Restore the selected %d messages",
+			   format(ngettext("Restore the selected %d message", "Restore the selected %d messages",
 			                    no_selections),
 			           no_selections);
 		} else {
@@ -641,7 +641,7 @@ void GameMessageMenu::update_archive_button_tooltip() {
 			    * message.
 			    * DO NOT omit the placeholder in your translation.
 			    */
-			   bformat(ngettext("Archive the selected %d message", "Archive the selected %d messages",
+			   format(ngettext("Archive the selected %d message", "Archive the selected %d messages",
 			                    no_selections),
 			           no_selections);
 		} else {

--- a/src/wui/game_message_menu.cc
+++ b/src/wui/game_message_menu.cc
@@ -627,8 +627,8 @@ void GameMessageMenu::update_archive_button_tooltip() {
 			    * DO NOT omit the placeholder in your translation.
 			    */
 			   format(ngettext("Restore the selected %d message", "Restore the selected %d messages",
-			                    no_selections),
-			           no_selections);
+			                   no_selections),
+			          no_selections);
 		} else {
 			/** TRANSLATORS: Tooltip in the messages window */
 			button_tooltip = _("Restore selected message");
@@ -642,8 +642,8 @@ void GameMessageMenu::update_archive_button_tooltip() {
 			    * DO NOT omit the placeholder in your translation.
 			    */
 			   format(ngettext("Archive the selected %d message", "Archive the selected %d messages",
-			                    no_selections),
-			           no_selections);
+			                   no_selections),
+			          no_selections);
 		} else {
 			/** TRANSLATORS: Tooltip in the messages window */
 			button_tooltip = _("Archive selected message");

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -207,7 +207,7 @@ void GameSummaryScreen::fill_data() {
 		te.set_picture(0, player_image, p->get_name());
 		// Team
 		std::string teastr_ =
-		   p->team_number() == 0 ? "—" : bformat("%1$u", static_cast<unsigned int>(p->team_number()));
+		   p->team_number() == 0 ? "—" : format("%1$u", static_cast<unsigned int>(p->team_number()));
 		te.set_string(1, teastr_);
 		// Status
 		std::string stat_str;
@@ -248,9 +248,9 @@ void GameSummaryScreen::fill_data() {
 		}
 	} else {
 		if (team_won == 0) {
-			title_area_->set_text(bformat(_("%s won!"), won_name));
+			title_area_->set_text(format(_("%s won!"), won_name));
 		} else {
-			title_area_->set_text(bformat(_("Team %u won!"), static_cast<unsigned int>(team_won)));
+			title_area_->set_text(format(_("Team %u won!"), static_cast<unsigned int>(team_won)));
 		}
 	}
 	if (!players_status.empty()) {
@@ -308,11 +308,11 @@ std::string GameSummaryScreen::parse_player_info(const std::string& info) {
 
 		const std::string key = pair.at(0);
 		if (key == "score") {
-			info_str += bformat("%1% : %2%\n", _("Score"), pair.at(1));
+			info_str += format("%1% : %2%\n", _("Score"), pair.at(1));
 		} else if (key == "team_score") {
-			info_str += bformat("%1% : %2%\n", _("Team Score"), pair.at(1));
+			info_str += format("%1% : %2%\n", _("Team Score"), pair.at(1));
 		} else if (key == "resign_reason") {
-			info_str += bformat("%1%\n", pair.at(1));
+			info_str += format("%1%\n", pair.at(1));
 		}
 	}
 

--- a/src/wui/gamedetails.cc
+++ b/src/wui/gamedetails.cc
@@ -121,8 +121,8 @@ void GameDetails::show(const std::vector<SavegameData>& gamedata) {
 	std::string combined_header = as_richtext(as_heading_with_content(
 	   /** TRANSLATORS: %1% = number of selected directories, %2% = number of selected files*/
 	   format(ngettext("Selected %1% directory and %2%:", "Selected %1% directories and %2%:",
-	                    number_of_directories),
-	           number_of_directories, header_second_part),
+	                   number_of_directories),
+	          number_of_directories, header_second_part),
 	   "", panel_style_, true));
 
 	name_label_.set_text(combined_header);
@@ -170,22 +170,22 @@ void GameDetails::show_game_description(const SavegameData& gamedata) {
 	   gamedata.gametime, panel_style_);
 
 	description = format("%s%s", description,
-	                      as_heading_with_content(_("Players:"), gamedata.nrplayers, panel_style_));
+	                     as_heading_with_content(_("Players:"), gamedata.nrplayers, panel_style_));
 
 	description =
 	   format("%s%s", description,
-	           as_heading_with_content(_("Widelands Version:"), gamedata.version, panel_style_));
+	          as_heading_with_content(_("Widelands Version:"), gamedata.version, panel_style_));
 
 	description =
 	   format("%s%s", description,
-	           as_heading_with_content(_("Win Condition:"), gamedata.wincondition, panel_style_));
+	          as_heading_with_content(_("Win Condition:"), gamedata.wincondition, panel_style_));
 
 	AddOns::AddOnConflict addons = AddOns::check_requirements(gamedata.required_addons);
 	has_conflicts_ = addons.second;
 
 	description =
 	   format("%s%s", description,
-	           as_heading_with_content(_("Add-Ons:"), addons.first, panel_style_, false, true));
+	          as_heading_with_content(_("Add-Ons:"), addons.first, panel_style_, false, true));
 
 	std::string filename = gamedata.filename;
 	// Remove first directory from filename. This will be the save/ or replays/ folder

--- a/src/wui/gamedetails.cc
+++ b/src/wui/gamedetails.cc
@@ -116,11 +116,11 @@ void GameDetails::show(const std::vector<SavegameData>& gamedata) {
 
 	const std::string header_second_part(
 	   /** TRANSLATORS: This is the second part of "Selected %1% directory/directories and %2%" */
-	   bformat(ngettext("%d file", "%d files", number_of_files), number_of_files));
+	   format(ngettext("%d file", "%d files", number_of_files), number_of_files));
 
 	std::string combined_header = as_richtext(as_heading_with_content(
 	   /** TRANSLATORS: %1% = number of selected directories, %2% = number of selected files*/
-	   bformat(ngettext("Selected %1% directory and %2%:", "Selected %1% directories and %2%:",
+	   format(ngettext("Selected %1% directory and %2%:", "Selected %1% directories and %2%:",
 	                    number_of_directories),
 	           number_of_directories, header_second_part),
 	   "", panel_style_, true));
@@ -169,22 +169,22 @@ void GameDetails::show_game_description(const SavegameData& gamedata) {
             _("Game Time:"),
 	   gamedata.gametime, panel_style_);
 
-	description = bformat("%s%s", description,
+	description = format("%s%s", description,
 	                      as_heading_with_content(_("Players:"), gamedata.nrplayers, panel_style_));
 
 	description =
-	   bformat("%s%s", description,
+	   format("%s%s", description,
 	           as_heading_with_content(_("Widelands Version:"), gamedata.version, panel_style_));
 
 	description =
-	   bformat("%s%s", description,
+	   format("%s%s", description,
 	           as_heading_with_content(_("Win Condition:"), gamedata.wincondition, panel_style_));
 
 	AddOns::AddOnConflict addons = AddOns::check_requirements(gamedata.required_addons);
 	has_conflicts_ = addons.second;
 
 	description =
-	   bformat("%s%s", description,
+	   format("%s%s", description,
 	           as_heading_with_content(_("Add-Ons:"), addons.first, panel_style_, false, true));
 
 	std::string filename = gamedata.filename;
@@ -193,12 +193,12 @@ void GameDetails::show_game_description(const SavegameData& gamedata) {
 	filename.erase(0, filename.find('/') + 1);
 	assert(!filename.empty());
 	description =
-	   bformat("%s%s", description, as_heading_with_content(_("Filename:"), filename, panel_style_));
+	   format("%s%s", description, as_heading_with_content(_("Filename:"), filename, panel_style_));
 
 	const std::string err = show_minimap(gamedata);
 	if (!err.empty()) {
 		// Critical error, put this on top
-		description = bformat(
+		description = format(
 		   "%s%s", as_heading_with_content(_("Game data error:"), err, panel_style_), description);
 	}
 

--- a/src/wui/helpwindow.cc
+++ b/src/wui/helpwindow.cc
@@ -42,7 +42,7 @@ BuildingHelpWindow::BuildingHelpWindow(Panel* const parent,
                       &reg,
                       width,
                       height,
-                      bformat(_("Help: %s"), building_description.descname())),
+                      format(_("Help: %s"), building_description.descname())),
      textarea_(new MultilineTextarea(this, 5, 5, width - 10, height - 10, UI::PanelStyle::kWui)) {
 	assert(tribe.has_building(tribe.building_index(building_description.name())) ||
 	       building_description.type() == Widelands::MapObjectType::MILITARYSITE);

--- a/src/wui/info_panel.cc
+++ b/src/wui/info_panel.cc
@@ -382,14 +382,14 @@ void InfoPanel::set_fps_string(const bool show,
 		text_fps_.set_text("");
 		text_fps_.set_tooltip("");
 	} else {
-		const std::string text = bformat("%5.1f fps (avg: %5.1f fps)", fps, average);
+		const std::string text = format("%5.1f fps (avg: %5.1f fps)", fps, average);
 		// The FPS string overlaps with the coords string at low resolution.
 		// Therefore abbreviate it if the available width is less than an arbitrary threshold.
 		if (cheating) {
 			text_fps_.set_text(_("Cheat mode enabled"));
 			text_fps_.set_tooltip(text);
 		} else if (get_w() < 970) {
-			text_fps_.set_text(bformat("%.1f / %.1f", fps, average));
+			text_fps_.set_text(format("%.1f / %.1f", fps, average));
 			text_fps_.set_tooltip(text);
 		} else {
 			text_fps_.set_text(text);
@@ -434,13 +434,13 @@ void InfoPanel::update_time_speed_string() {
 		text_time_speed_.set_text(*non_empty.back());
 		break;
 	case 2:
-		text_time_speed_.set_text(bformat(
+		text_time_speed_.set_text(format(
 		   /** TRANSLATORS: (Gametime · Realtime) or (Gametime · Gamespeed) or (Realtime · Gamespeed)
 		    */
 		   _("%1$s · %2$s"), *non_empty[0], *non_empty[1]));
 		break;
 	case 3:
-		text_time_speed_.set_text(bformat(
+		text_time_speed_.set_text(format(
 		   /** TRANSLATORS: Gametime · Realtime · Gamespeed */
 		   _("%1$s · %2$s · %3$s"), *non_empty[0], *non_empty[1], *non_empty[2]));
 		break;

--- a/src/wui/inputqueuedisplay.cc
+++ b/src/wui/inputqueuedisplay.cc
@@ -117,7 +117,7 @@ InputQueueDisplay::InputQueueDisplay(UI::Panel* parent,
 }
 
 static inline std::string create_tooltip(const bool increase) {
-	return bformat(
+	return format(
 	   "<p>%s%s%s</p>",
 	   g_style_manager->font_style(UI::FontStyle::kWuiTooltipHeader)
 	      .as_font_tag(increase ?

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -725,9 +725,9 @@ void InteractiveBase::think() {
 	UI::Panel::think();
 	if (in_road_building_mode()) {
 		if (in_road_building_mode(RoadBuildingType::kRoad)) {
-			set_tooltip(bformat(_("Road length: %u"), get_build_road_path().get_nsteps()));
+			set_tooltip(format(_("Road length: %u"), get_build_road_path().get_nsteps()));
 		} else {
-			set_tooltip(bformat(_("Waterway length: %1$u/%2$u"), get_build_road_path().get_nsteps(),
+			set_tooltip(format(_("Waterway length: %1$u/%2$u"), get_build_road_path().get_nsteps(),
 			                    egbase().map().get_waterway_max_length()));
 		}
 	}
@@ -755,7 +755,7 @@ void InteractiveBase::draw_overlay(RenderTarget&) {
 	if (!egbase().is_game() || get_display_flag(dfDebug)) {
 		// Blit node information in the editor, and in debug mode also for games
 		const int32_t height = egbase().map()[sel_.pos.node].get_height();
-		node_text = bformat("(%i, %i, %i)", sel_.pos.node.x, sel_.pos.node.y, height);
+		node_text = format("(%i, %i, %i)", sel_.pos.node.x, sel_.pos.node.y, height);
 	}
 	info_panel_.set_coords_string(node_text);
 
@@ -1456,7 +1456,7 @@ UI::UniqueWindow* InteractiveBase::show_building_window(const Widelands::Coords&
 	upcast(Widelands::Building, building, immovable);
 	assert(building);
 	UI::UniqueWindow::Registry& registry =
-	   unique_windows().get_registry(bformat("building_%d", building->serial()));
+	   unique_windows().get_registry(format("building_%d", building->serial()));
 
 	switch (building->descr().type()) {
 	case Widelands::MapObjectType::CONSTRUCTIONSITE:
@@ -1509,7 +1509,7 @@ UI::UniqueWindow* InteractiveBase::show_building_window(const Widelands::Coords&
 
 UI::UniqueWindow& InteractiveBase::show_ship_window(Widelands::Ship* ship) {
 	UI::UniqueWindow::Registry& registry =
-	   unique_windows().get_registry(bformat("ship_%d", ship->serial()));
+	   unique_windows().get_registry(format("ship_%d", ship->serial()));
 	registry.open_window = [this, &registry, ship] { new ShipWindow(*this, registry, ship); };
 	registry.create();
 	return *registry.window;
@@ -1619,7 +1619,7 @@ void InteractiveBase::cmd_map_object(const std::vector<std::string>& args) {
 	MapObject* obj = egbase().objects().get_object(serial);
 
 	if (!obj) {
-		DebugConsole::write(bformat("No MapObject with serial number %1%", serial));
+		DebugConsole::write(format("No MapObject with serial number %1%", serial));
 		return;
 	}
 

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -728,7 +728,7 @@ void InteractiveBase::think() {
 			set_tooltip(format(_("Road length: %u"), get_build_road_path().get_nsteps()));
 		} else {
 			set_tooltip(format(_("Waterway length: %1$u/%2$u"), get_build_road_path().get_nsteps(),
-			                    egbase().map().get_waterway_max_length()));
+			                   egbase().map().get_waterway_max_length()));
 		}
 	}
 }

--- a/src/wui/interactive_gamebase.cc
+++ b/src/wui/interactive_gamebase.cc
@@ -51,7 +51,7 @@ namespace {
 std::string speed_string(int const speed) {
 	if (speed) {
 		/** TRANSLATORS: This is a game speed value */
-		return bformat(_("%1$u.%2$u×"), (speed / 1000), (speed / 100 % 10));
+		return format(_("%1$u.%2$u×"), (speed / 1000), (speed / 100 % 10));
 	}
 	return _("PAUSE");
 }
@@ -528,7 +528,7 @@ void InteractiveGameBase::draw_overlay(RenderTarget& dst) {
 				game_speed = speed_string(real);
 			}
 		} else {
-			game_speed = bformat
+			game_speed = format
 			   /** TRANSLATORS: actual_speed (desired_speed) */
 			   (_("%1$s (%2$s)"), speed_string(real), speed_string(desired));
 		}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -456,7 +456,7 @@ void InteractivePlayer::think() {
 		if (uint32_t const nr_new_messages =
 		       player().messages().nr_messages(Widelands::Message::Status::kNew)) {
 			msg_icon = "images/wui/menus/message_new.png";
-			msg_tooltip = bformat(
+			msg_tooltip = format(
 			   ngettext("%u new message", "%u new messages", nr_new_messages), nr_new_messages);
 		}
 		toggle_message_menu_->set_pic(g_image_cache->get(msg_icon));
@@ -722,7 +722,7 @@ UI::Window* InteractivePlayer::show_attack_window(const Widelands::Coords& c,
 			if (const Widelands::AttackTarget* attack_target = building->attack_target()) {
 				if (player().is_hostile(building->owner()) && attack_target->can_be_attacked()) {
 					UI::UniqueWindow::Registry& registry =
-					   unique_windows().get_registry(bformat("attack_%d", building->serial()));
+					   unique_windows().get_registry(format("attack_%d", building->serial()));
 					registry.open_window = [this, &registry, building, &c, fastclick]() {
 						new AttackWindow(*this, registry, *building, c, fastclick);
 					};
@@ -854,11 +854,11 @@ void InteractivePlayer::cmdSwitchPlayer(const std::vector<std::string>& args) {
 
 	int const n = stoi(args[1]);
 	if (n < 1 || n > kMaxPlayers || !game().get_player(n)) {
-		DebugConsole::write(bformat("Player #%d does not exist.", n));
+		DebugConsole::write(format("Player #%d does not exist.", n));
 		return;
 	}
 
-	DebugConsole::write(bformat("Switching from #%d to #%d.", static_cast<int>(player_number_), n));
+	DebugConsole::write(format("Switching from #%d to #%d.", static_cast<int>(player_number_), n));
 	player_number_ = n;
 
 	if (UI::UniqueWindow* const building_statistics_window = menu_windows_.stats_buildings.window) {

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -456,8 +456,8 @@ void InteractivePlayer::think() {
 		if (uint32_t const nr_new_messages =
 		       player().messages().nr_messages(Widelands::Message::Status::kNew)) {
 			msg_icon = "images/wui/menus/message_new.png";
-			msg_tooltip = format(
-			   ngettext("%u new message", "%u new messages", nr_new_messages), nr_new_messages);
+			msg_tooltip =
+			   format(ngettext("%u new message", "%u new messages", nr_new_messages), nr_new_messages);
 		}
 		toggle_message_menu_->set_pic(g_image_cache->get(msg_icon));
 		toggle_message_menu_->set_tooltip(as_tooltip_text_with_hotkey(

--- a/src/wui/mapdata.cc
+++ b/src/wui/mapdata.cc
@@ -164,13 +164,13 @@ MapData MapData::create_parent_dir(const std::string& current_dir) {
 // static
 std::string MapData::parent_name() {
 	/** TRANSLATORS: Parent directory/folder */
-	return bformat("<%s>", _("parent"));
+	return format("<%s>", _("parent"));
 }
 
 // static
 MapData MapData::create_empty_dir(const std::string& current_dir) {
 	/** TRANSLATORS: This label is shown when a folder is empty */
-	return MapData(current_dir, bformat("<%s>", _("empty")));
+	return MapData(current_dir, format("<%s>", _("empty")));
 }
 
 // static

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -127,12 +127,12 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
 	bool loadable = true;
 	// Show directory information
 	if (mapdata.maptype == MapData::MapType::kDirectory) {
-		name_label_.set_text(bformat("<rt>%s%s</rt>", as_heading(_("Directory"), style_, true),
+		name_label_.set_text(format("<rt>%s%s</rt>", as_heading(_("Directory"), style_, true),
 		                             as_content(mapdata.localized_name, style_)));
 		main_box_.set_size(main_box_.get_w(), get_h());
 
 	} else {  // Show map information
-		name_label_.set_text(bformat(
+		name_label_.set_text(format(
 		   "<rt>%s%s</rt>",
 		   as_heading(mapdata.maptype == MapData::MapType::kScenario ? _("Scenario") : _("Map"),
 		              style_, true),
@@ -144,13 +144,13 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
 				   /** TRANSLATORS: Tooltip in map description when translated map names are being
 				      displayed. */
 				   /** TRANSLATORS: %s is the English name of the map. */
-				   (bformat(_("The original name of this map: %s"), mapdata.name));
+				   (format(_("The original name of this map: %s"), mapdata.name));
 			} else {
 				name_label_.set_tooltip
 				   /** TRANSLATORS: Tooltip in map description when map names are being displayed in
 				      English. */
 				   /** TRANSLATORS: %s is the localized name of the map. */
-				   (bformat(_("The name of this map in your language: %s"), mapdata.localized_name));
+				   (format(_("The name of this map in your language: %s"), mapdata.localized_name));
 			}
 		} else {
 			name_label_.set_tooltip("");
@@ -165,32 +165,32 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
                forms here, please let us know. */
                _("Authors");
 		std::string description = as_heading(authors_heading, style_);
-		description = bformat("%s%s", description, as_content(mapdata.authors.get_names(), style_));
+		description = format("%s%s", description, as_content(mapdata.authors.get_names(), style_));
 
 		std::vector<std::string> tags;
 		for (const auto& tag : mapdata.tags) {
 			tags.push_back(localize_tag(tag));
 		}
 		std::sort(tags.begin(), tags.end());
-		description = bformat("%s%s", description, as_heading(_("Tags"), style_));
+		description = format("%s%s", description, as_heading(_("Tags"), style_));
 		description =
-		   bformat("%s%s", description,
+		   format("%s%s", description,
 		           as_content(i18n::localize_list(tags, i18n::ConcatenateWith::COMMA), style_));
 
 		AddOns::AddOnConflict addons = AddOns::check_requirements(mapdata.required_addons);
 		loadable = !addons.second;
 
 		description =
-		   bformat("%s%s", description,
+		   format("%s%s", description,
 		           as_heading_with_content(_("Add-Ons:"), addons.first, style_, false, true));
 
-		description = bformat("%s%s", description, as_heading(_("Description"), style_));
-		description = bformat("%s%s", description, as_content(mapdata.description, style_));
+		description = format("%s%s", description, as_heading(_("Description"), style_));
+		description = format("%s%s", description, as_content(mapdata.description, style_));
 
 		if (!mapdata.hint.empty()) {
 			/** TRANSLATORS: Map hint header when selecting a map. */
-			description = bformat("%s%s", description, as_heading(_("Hint"), style_));
-			description = bformat("%s%s", description, as_content(mapdata.hint, style_));
+			description = format("%s%s", description, as_heading(_("Hint"), style_));
+			description = format("%s%s", description, as_content(mapdata.hint, style_));
 		}
 
 		// Render minimap
@@ -213,8 +213,8 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
 					}
 				} catch (const Widelands::GameDataError& e) {
 					// Put error message on top for better visibility
-					description = bformat("%s%s", as_content(e.what(), style_), description);
-					description = bformat("%s%s", as_heading(_("Game data error"), style_), description);
+					description = format("%s%s", as_content(e.what(), style_), description);
+					description = format("%s%s", as_heading(_("Game data error"), style_), description);
 					loadable = false;
 				}
 			}

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -128,7 +128,7 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
 	// Show directory information
 	if (mapdata.maptype == MapData::MapType::kDirectory) {
 		name_label_.set_text(format("<rt>%s%s</rt>", as_heading(_("Directory"), style_, true),
-		                             as_content(mapdata.localized_name, style_)));
+		                            as_content(mapdata.localized_name, style_)));
 		main_box_.set_size(main_box_.get_w(), get_h());
 
 	} else {  // Show map information
@@ -175,14 +175,14 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
 		description = format("%s%s", description, as_heading(_("Tags"), style_));
 		description =
 		   format("%s%s", description,
-		           as_content(i18n::localize_list(tags, i18n::ConcatenateWith::COMMA), style_));
+		          as_content(i18n::localize_list(tags, i18n::ConcatenateWith::COMMA), style_));
 
 		AddOns::AddOnConflict addons = AddOns::check_requirements(mapdata.required_addons);
 		loadable = !addons.second;
 
 		description =
 		   format("%s%s", description,
-		           as_heading_with_content(_("Add-Ons:"), addons.first, style_, false, true));
+		          as_heading_with_content(_("Add-Ons:"), addons.first, style_, false, true));
 
 		description = format("%s%s", description, as_heading(_("Description"), style_));
 		description = format("%s%s", description, as_content(mapdata.description, style_));

--- a/src/wui/maptable.cc
+++ b/src/wui/maptable.cc
@@ -47,7 +47,7 @@ void MapTable::fill(const std::vector<MapData>& entries, MapData::DisplayType ty
 			   1, g_image_cache->get("images/ui_basic/ls_dir.png"), mapdata.localized_name);
 			te.set_string(2, "");
 		} else {
-			te.set_string(0, bformat("(%i)", mapdata.nrplayers));
+			te.set_string(0, format("(%i)", mapdata.nrplayers));
 
 			std::string picture = "images/ui_basic/ls_wlmap.png";
 			if (mapdata.maptype == MapData::MapType::kScenario) {
@@ -69,7 +69,7 @@ void MapTable::fill(const std::vector<MapData>& entries, MapData::DisplayType ty
 				}
 			}
 
-			te.set_string(2, bformat("%u x %u", mapdata.width, mapdata.height));
+			te.set_string(2, format("%u x %u", mapdata.width, mapdata.height));
 		}
 	}
 	sort();

--- a/src/wui/plot_area.cc
+++ b/src/wui/plot_area.cc
@@ -61,7 +61,7 @@ enum class Units {
 };
 
 std::string ytick_text_style(const std::string& text, const UI::FontStyleInfo& style) {
-	return bformat("<rt keep_spaces=1><p>%s</p></rt>", style.as_font_tag(text));
+	return format("<rt keep_spaces=1><p>%s</p></rt>", style.as_font_tag(text));
 }
 
 std::string xtick_text_style(const std::string& text) {
@@ -101,13 +101,13 @@ std::string get_value_with_unit(Units unit, int value) {
 	switch (unit) {
 	case Units::kDayNarrow:
 		/** TRANSLATORS: day(s). Keep this as short as possible. Used in statistics. */
-		return bformat(npgettext("unit_narrow", "%1%d", "%1%d", value), value);
+		return format(npgettext("unit_narrow", "%1%d", "%1%d", value), value);
 	case Units::kHourNarrow:
 		/** TRANSLATORS: hour(s). Keep this as short as possible. Used in statistics. */
-		return bformat(npgettext("unit_narrow", "%1%h", "%1%h", value), value);
+		return format(npgettext("unit_narrow", "%1%h", "%1%h", value), value);
 	case Units::kMinutesNarrow:
 		/** TRANSLATORS: minute(s). Keep this as short as possible. Used in statistics. */
-		return bformat(npgettext("unit_narrow", "%1%m", "%1%m", value), value);
+		return format(npgettext("unit_narrow", "%1%m", "%1%m", value), value);
 	case Units::kMinutesGeneric:
 	case Units::kHourGeneric:
 	case Units::kDayGeneric:
@@ -264,7 +264,7 @@ void draw_diagram(uint32_t time_ms,
 		// over the number, not to the left
 		if (how_many_ticks != 0 && i != 0) {
 			std::shared_ptr<const UI::RenderedText> xtick =
-			   UI::g_fh->render(xtick_text_style(bformat("-%u ", (max_x / how_many_ticks * i))));
+			   UI::g_fh->render(xtick_text_style(format("-%u ", (max_x / how_many_ticks * i))));
 			Vector2i pos(posx, inner_h - kSpaceBottom + 10);
 			UI::center_vertically(xtick->height(), &pos);
 			xtick->draw(dst, pos, UI::Align::kCenter);
@@ -732,7 +732,7 @@ void DifferentialPlotArea::draw(RenderTarget& dst) {
 	// Draw data and diagram
 	draw_plot(dst, yoffset, std::to_string(highest_scale_), 2 * highest_scale_);
 	// Print the min value
-	draw_value(bformat("-%u", (highest_scale_)),
+	draw_value(format("-%u", (highest_scale_)),
 	           g_style_manager->statistics_plot_style().y_min_value_font(),
 	           Vector2i(get_inner_w() - kSpaceRight + 3, get_inner_h() - kSpaceBottom + 10), dst);
 }

--- a/src/wui/portdockwaresdisplay.cc
+++ b/src/wui/portdockwaresdisplay.cc
@@ -94,7 +94,7 @@ public:
 
 			UI::Dropdown<std::pair<Widelands::WareWorker, Widelands::DescriptionIndex>>& d =
 			   *new UI::Dropdown<std::pair<Widelands::WareWorker, Widelands::DescriptionIndex>>(
-			      box, bformat("additional_%u", c), 0, 0, kWareMenuPicWidth, 8, kWareMenuPicHeight,
+			      box, format("additional_%u", c), 0, 0, kWareMenuPicWidth, 8, kWareMenuPicHeight,
 			      _("Additional item"), UI::DropdownType::kPictorial, UI::PanelStyle::kWui,
 			      UI::ButtonStyle::kWuiSecondary);
 			d.add(_("(Empty)"), kEmptySlot, g_image_cache->get(kNoWare), true, _("(Empty)"));

--- a/src/wui/productionsitewindow.cc
+++ b/src/wui/productionsitewindow.cc
@@ -232,7 +232,7 @@ void ProductionSiteWindow::update_worker_table(Widelands::ProductionSite* produc
 				/** TRANSLATORS: %1% = the experience a worker has */
 				/** TRANSLATORS: %2% = the experience a worker needs to reach the next level */
 				er.set_string(1, format(_("%1%/%2%"), worker->get_current_experience(),
-				                         worker->descr().get_needed_experience()));
+				                        worker->descr().get_needed_experience()));
 				er.set_string(
 				   2, worker->owner().tribe().get_worker_descr(worker->descr().becomes())->descname());
 			} else {

--- a/src/wui/productionsitewindow.cc
+++ b/src/wui/productionsitewindow.cc
@@ -231,7 +231,7 @@ void ProductionSiteWindow::update_worker_table(Widelands::ProductionSite* produc
 				// Fill upgrade status
 				/** TRANSLATORS: %1% = the experience a worker has */
 				/** TRANSLATORS: %2% = the experience a worker needs to reach the next level */
-				er.set_string(1, bformat(_("%1%/%2%"), worker->get_current_experience(),
+				er.set_string(1, format(_("%1%/%2%"), worker->get_current_experience(),
 				                         worker->descr().get_needed_experience()));
 				er.set_string(
 				   2, worker->owner().tribe().get_worker_descr(worker->descr().becomes())->descname());

--- a/src/wui/savegamedata.cc
+++ b/src/wui/savegamedata.cc
@@ -123,13 +123,13 @@ const std::string as_filename_list(const std::vector<SavegameData>& savefiles) {
 	std::string message;
 	for (const SavegameData& gamedata : savefiles) {
 		if (gamedata.is_directory() || !gamedata.errormessage.empty()) {
-			message = bformat("%s\n%s", message, richtext_escape(gamedata.filename));
+			message = format("%s\n%s", message, richtext_escape(gamedata.filename));
 		} else if (gamedata.errormessage.empty()) {
 			std::vector<std::string> listme;
 			listme.push_back(richtext_escape(gamedata.mapname));
 			listme.push_back(gamedata.savedonstring);
 			message =
-			   bformat("%s\n%s", message, i18n::localize_list(listme, i18n::ConcatenateWith::COMMA));
+			   format("%s\n%s", message, i18n::localize_list(listme, i18n::ConcatenateWith::COMMA));
 		}
 	}
 	return message;

--- a/src/wui/savegamedeleter.cc
+++ b/src/wui/savegamedeleter.cc
@@ -27,7 +27,7 @@ bool SavegameDeleter::show_confirmation_window(const std::vector<SavegameData>& 
 	size_t no_selections = selections.size();
 	std::string confirmation_window_header = create_header_for_confirmation_window(no_selections);
 	const std::string message =
-	   bformat("%s\n%s", confirmation_window_header, as_filename_list(selections));
+	   format("%s\n%s", confirmation_window_header, as_filename_list(selections));
 
 	UI::WLMessageBox confirmationBox(
 	   parent_->get_parent()->get_parent(), style_,
@@ -42,7 +42,7 @@ SavegameDeleter::create_header_for_confirmation_window(const size_t no_selection
 	   no_selections == 1    ? _("Do you really want to delete this game?") :
                               /** TRANSLATORS: Used with multiple games, 1 game has a separate
                                  string. DO NOT omit the placeholder in your translation. */
-                              bformat(ngettext("Do you really want to delete this %d game?",
+                              format(ngettext("Do you really want to delete this %d game?",
                           "Do you really want to delete these %d games?", no_selections),
                  no_selections);
 
@@ -77,7 +77,7 @@ void SavegameDeleter::notify_deletion_failed(const std::vector<SavegameData>& to
 	const std::string caption =
 	   (no_failed == 1) ? _("Error Deleting File!") : _("Error Deleting Files!");
 	std::string header = create_header_for_deletion_failed_window(to_be_deleted.size(), no_failed);
-	std::string message = bformat("%s\n%s", header, as_filename_list(to_be_deleted));
+	std::string message = format("%s\n%s", header, as_filename_list(to_be_deleted));
 
 	UI::WLMessageBox msgBox(parent_->get_parent()->get_parent(), style_, caption, message,
 	                        UI::WLMessageBox::MBoxType::kOk);
@@ -89,7 +89,7 @@ std::string SavegameDeleter::create_header_for_deletion_failed_window(size_t no_
 	if (no_to_be_deleted == 1) {
 		return _("The game could not be deleted.");
 	}
-	return bformat(
+	return format(
 	   /** TRANSLATORS: Used with multiple games, 1 game has a separate string. DO NOT omit the
 	    * placeholder in your translation. */
 	   ngettext("%d game could not be deleted.", "%d games could not be deleted.", no_failed),
@@ -106,7 +106,7 @@ ReplayDeleter::create_header_for_confirmation_window(const size_t no_selections)
                             _("Do you really want to delete this replay?") :
                             /** TRANSLATORS: Used with multiple replays, 1 replay has a
                                                separate string. DO NOT omit the placeholder in your translation. */
-                            bformat(ngettext("Do you really want to delete this %d replay?",
+                            format(ngettext("Do you really want to delete this %d replay?",
                           "Do you really want to delete these %d replays?", no_selections),
                  no_selections);
 
@@ -118,7 +118,7 @@ std::string ReplayDeleter::create_header_for_deletion_failed_window(size_t no_to
 	if (no_to_be_deleted == 1) {
 		return _("The replay could not be deleted.");
 	}
-	return bformat(
+	return format(
 	   /** TRANSLATORS: Used with multiple replays, 1 replay has a separate string. DO NOT omit the
 	    * placeholder in your translation. */
 	   ngettext("%d replay could not be deleted.", "%d replays could not be deleted.", no_failed),

--- a/src/wui/savegamedeleter.cc
+++ b/src/wui/savegamedeleter.cc
@@ -43,8 +43,8 @@ SavegameDeleter::create_header_for_confirmation_window(const size_t no_selection
                               /** TRANSLATORS: Used with multiple games, 1 game has a separate
                                  string. DO NOT omit the placeholder in your translation. */
                               format(ngettext("Do you really want to delete this %d game?",
-                          "Do you really want to delete these %d games?", no_selections),
-                 no_selections);
+                         "Do you really want to delete these %d games?", no_selections),
+                no_selections);
 
 	return header;
 }
@@ -107,8 +107,8 @@ ReplayDeleter::create_header_for_confirmation_window(const size_t no_selections)
                             /** TRANSLATORS: Used with multiple replays, 1 replay has a
                                                separate string. DO NOT omit the placeholder in your translation. */
                             format(ngettext("Do you really want to delete this %d replay?",
-                          "Do you really want to delete these %d replays?", no_selections),
-                 no_selections);
+                         "Do you really want to delete these %d replays?", no_selections),
+                no_selections);
 
 	return header;
 }

--- a/src/wui/savegameloader.cc
+++ b/src/wui/savegameloader.cc
@@ -96,7 +96,7 @@ void SavegameLoader::add_general_information(SavegameData& gamedata,
 
 void SavegameLoader::add_error_info(SavegameData& gamedata, std::string errormessage) const {
 	replace_all(errormessage, "\n", "<br>");
-	gamedata.errormessage = bformat(
+	gamedata.errormessage = format(
 	   "<p>%s</p><p>%s</p><p>%s</p>",
 	   /** TRANSLATORS: Error message introduction for when an old savegame can't be loaded */
 	   _("This file has the wrong format and can’t be loaded."
@@ -126,17 +126,17 @@ void SavegameLoader::add_time_info(SavegameData& gamedata,
 
 			// Adding the 0 padding in a separate statement so translators won't have to deal
 			// with it
-			const std::string minute = bformat("%02u", savedate->tm_min);
+			const std::string minute = format("%02u", savedate->tm_min);
 
 			gamedata.savedatestring =
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    hour:minute */
-			   bformat(_("Today, %1%:%2%"), savedate->tm_hour, minute);
+			   format(_("Today, %1%:%2%"), savedate->tm_hour, minute);
 			gamedata.savedonstring =
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    hour:minute. This is part of a list.
 			    */
-			   bformat(_("saved today at %1%:%2%"), savedate->tm_hour, minute);
+			   format(_("saved today at %1%:%2%"), savedate->tm_hour, minute);
 		} else if ((savedate->tm_year == current_year && savedate->tm_mon == current_month &&
 		            savedate->tm_mday == current_day - 1) ||
 		           (savedate->tm_year == current_year - 1 && savedate->tm_mon == 11 &&
@@ -144,28 +144,28 @@ void SavegameLoader::add_time_info(SavegameData& gamedata,
 		            current_day == 1)) {  // Yesterday
 			// Adding the 0 padding in a separate statement so translators won't have to deal
 			// with it
-			const std::string minute = bformat("%02u", savedate->tm_min);
+			const std::string minute = format("%02u", savedate->tm_min);
 
 			gamedata.savedatestring =
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    hour:minute */
-			   bformat(_("Yesterday, %1%:%2%"), savedate->tm_hour, minute);
+			   format(_("Yesterday, %1%:%2%"), savedate->tm_hour, minute);
 			gamedata.savedonstring =
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    hour:minute. This is part of a list.
 			    */
-			   bformat(_("saved yesterday at %1%:%2%"), savedate->tm_hour, minute);
+			   format(_("saved yesterday at %1%:%2%"), savedate->tm_hour, minute);
 		} else {  // Older
 			gamedata.savedatestring =
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    month day, year */
-			   bformat(_("%1% %2%, %3%"), localize_month(savedate->tm_mon), savedate->tm_mday,
+			   format(_("%1% %2%, %3%"), localize_month(savedate->tm_mon), savedate->tm_mday,
 			           (1900 + savedate->tm_year));
 			gamedata.savedonstring =
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    month (short name) day (number),
 			      year (number). This is part of a list. */
-			   bformat(_("saved on %1$s %2$u, %3$u"), localize_month(savedate->tm_mon),
+			   format(_("saved on %1$s %2$u, %3$u"), localize_month(savedate->tm_mon),
 			           savedate->tm_mday, (1900 + savedate->tm_year));
 		}
 	}

--- a/src/wui/savegameloader.cc
+++ b/src/wui/savegameloader.cc
@@ -96,13 +96,13 @@ void SavegameLoader::add_general_information(SavegameData& gamedata,
 
 void SavegameLoader::add_error_info(SavegameData& gamedata, std::string errormessage) const {
 	replace_all(errormessage, "\n", "<br>");
-	gamedata.errormessage = format(
-	   "<p>%s</p><p>%s</p><p>%s</p>",
-	   /** TRANSLATORS: Error message introduction for when an old savegame can't be loaded */
-	   _("This file has the wrong format and can’t be loaded."
-	     " Maybe it was created with an older version of Widelands."),
-	   /** TRANSLATORS: This text is on a separate line with an error message below */
-	   _("Error message:"), errormessage);
+	gamedata.errormessage =
+	   format("<p>%s</p><p>%s</p><p>%s</p>",
+	          /** TRANSLATORS: Error message introduction for when an old savegame can't be loaded */
+	          _("This file has the wrong format and can’t be loaded."
+	            " Maybe it was created with an older version of Widelands."),
+	          /** TRANSLATORS: This text is on a separate line with an error message below */
+	          _("Error message:"), errormessage);
 
 	gamedata.mapname = FileSystem::filename_without_ext(gamedata.filename.c_str());
 }
@@ -160,13 +160,13 @@ void SavegameLoader::add_time_info(SavegameData& gamedata,
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    month day, year */
 			   format(_("%1% %2%, %3%"), localize_month(savedate->tm_mon), savedate->tm_mday,
-			           (1900 + savedate->tm_year));
+			          (1900 + savedate->tm_year));
 			gamedata.savedonstring =
 			   /** TRANSLATORS: Display date for choosing a savegame/replay. Placeholders are:
 			                                                    month (short name) day (number),
 			      year (number). This is part of a list. */
 			   format(_("saved on %1$s %2$u, %3$u"), localize_month(savedate->tm_mon),
-			           savedate->tm_mday, (1900 + savedate->tm_year));
+			          savedate->tm_mday, (1900 + savedate->tm_year));
 		}
 	}
 }

--- a/src/wui/savegametable.cc
+++ b/src/wui/savegametable.cc
@@ -25,14 +25,14 @@ const std::string SavegameTable::map_filename(const std::string& filename,
 		split(autosave_name, result, {'_'});
 		if (autosave_name.empty() || autosave_name.size() < 3) {
 			/** TRANSLATORS: %1% is a map's name. */
-			result = bformat(_("Autosave: %1%"), mapname);
+			result = format(_("Autosave: %1%"), mapname);
 		} else {
 			/** TRANSLATORS: %1% is a number, %2% a map's name. */
-			result = bformat(_("Autosave %1%: %2%"), autosave_name.back(), mapname);
+			result = format(_("Autosave %1%: %2%"), autosave_name.back(), mapname);
 		}
 	} else if (!starts_with(result, mapname)) {
 		/** TRANSLATORS: %1% is a filename, %2% a map's name. */
-		result = bformat(pgettext("filename_mapname", "%1%: %2%"), result, mapname);
+		result = format(pgettext("filename_mapname", "%1%: %2%"), result, mapname);
 	}
 	return result;
 }
@@ -52,7 +52,7 @@ const std::string SavegameTable::find_game_type(const SavegameData& savegame) co
 		/** TRANSLATORS: Make sure that this translation is consistent with the
 		        tooltip. */
 		/** TRANSLATORS: %1% is the number of players */
-		return bformat(_("H (%1%)"), savegame.nrplayers);
+		return format(_("H (%1%)"), savegame.nrplayers);
 	}
 	if (savegame.is_multiplayer_client()) {
 		/** TRANSLATORS: "Multiplayer" entry in the Game Mode table column. */
@@ -61,7 +61,7 @@ const std::string SavegameTable::find_game_type(const SavegameData& savegame) co
 		/** TRANSLATORS: Make sure that this translation is consistent with the
 		        tooltip. */
 		/** TRANSLATORS: %1% is the number of players */
-		return bformat(_("MP (%1%)"), savegame.nrplayers);
+		return format(_("MP (%1%)"), savegame.nrplayers);
 	}
 	if (savegame.is_replay()) {
 		return "";
@@ -93,7 +93,7 @@ void SavegameTable::create_error_entry(UI::Table<uintptr_t const>::EntryRecord& 
 	for (size_t col_index = 0; col_index < last_column_index; col_index++) {
 		te.set_string(col_index, "");
 	}
-	te.set_string(last_column_index, bformat(_("Incompatible: %s"), savegame.mapname));
+	te.set_string(last_column_index, format(_("Incompatible: %s"), savegame.mapname));
 }
 
 void SavegameTable::create_directory_entry(UI::Table<const uintptr_t>::EntryRecord& te,
@@ -105,7 +105,7 @@ void SavegameTable::create_directory_entry(UI::Table<const uintptr_t>::EntryReco
 	if (savegame.is_parent_directory()) {
 		te.set_picture(last_column_index, g_image_cache->get("images/ui_basic/ls_dir.png"),
 		               /** TRANSLATORS: Parent directory/folder */
-		               bformat("<%s>", _("parent")));
+		               format("<%s>", _("parent")));
 	} else if (savegame.is_sub_directory()) {
 		te.set_picture(last_column_index, g_image_cache->get("images/ui_basic/ls_dir.png"),
 		               FileSystem::filename_without_ext(savegame.filename.c_str()));
@@ -198,7 +198,7 @@ void SavegameTableReplay::create_valid_entry(UI::Table<uintptr_t const>::EntryRe
 		   show_filenames_ ? map_filename(savegame.filename, savegame.mapname) : savegame.mapname;
 		te.set_picture(
 		   2, g_image_cache->get("images/ui_basic/ls_wlmap.png"),
-		   bformat(pgettext("mapname_gametime", "%1% (%2%)"), map_basename, savegame.gametime));
+		   format(pgettext("mapname_gametime", "%1% (%2%)"), map_basename, savegame.gametime));
 	}
 }
 

--- a/src/wui/seafaring_statistics_menu.cc
+++ b/src/wui/seafaring_statistics_menu.cc
@@ -135,7 +135,7 @@ SeafaringStatisticsMenu::SeafaringStatisticsMenu(InteractivePlayer& plr,
         kButtonSize,
         UI::ButtonStyle::kWuiPrimary,
         g_image_cache->get("images/ui_basic/fsel.png"),
-        bformat(
+        format(
            "%s<br>%s",
            as_tooltip_text_with_hotkey(
               /** TRANSLATORS: Tooltip in the seafaring statistics window */

--- a/src/wui/seafaring_statistics_menu.cc
+++ b/src/wui/seafaring_statistics_menu.cc
@@ -135,18 +135,17 @@ SeafaringStatisticsMenu::SeafaringStatisticsMenu(InteractivePlayer& plr,
         kButtonSize,
         UI::ButtonStyle::kWuiPrimary,
         g_image_cache->get("images/ui_basic/fsel.png"),
-        format(
-           "%s<br>%s",
-           as_tooltip_text_with_hotkey(
-              /** TRANSLATORS: Tooltip in the seafaring statistics window */
-              _("Open the selected ship’s window"),
-              shortcut_string_for(KeyboardShortcut::kInGameSeafaringstatsOpenShipWindow),
-              UI::PanelStyle::kWui),
-           as_tooltip_text_with_hotkey(
-              /** TRANSLATORS: Tooltip in the seafaring statistics window */
-              _("Go to the selected ship and open its window"),
-              shortcut_string_for(KeyboardShortcut::kInGameSeafaringstatsOpenShipWindowAndGoto),
-              UI::PanelStyle::kWui))),
+        format("%s<br>%s",
+               as_tooltip_text_with_hotkey(
+                  /** TRANSLATORS: Tooltip in the seafaring statistics window */
+                  _("Open the selected ship’s window"),
+                  shortcut_string_for(KeyboardShortcut::kInGameSeafaringstatsOpenShipWindow),
+                  UI::PanelStyle::kWui),
+               as_tooltip_text_with_hotkey(
+                  /** TRANSLATORS: Tooltip in the seafaring statistics window */
+                  _("Go to the selected ship and open its window"),
+                  shortcut_string_for(KeyboardShortcut::kInGameSeafaringstatsOpenShipWindowAndGoto),
+                  UI::PanelStyle::kWui))),
      centerviewbtn_(&navigation_box_,
                     "seafaring_stats_center_main_mapview_button",
                     0,

--- a/src/wui/soldier_statistics_menu.cc
+++ b/src/wui/soldier_statistics_menu.cc
@@ -69,11 +69,11 @@ SoldierStatisticsPanel::SoldierStatisticsPanel(UI::Panel& parent,
 					icons_all_.push_back(icon3);
 					icons_all_.push_back(icon4);
 					labels_all_.push_back(txt);
-					const std::string tt = bformat("%s<br>%s<br>%s<br>%s",              //
-					                               bformat(_("Health: %u"), health),    //
-					                               bformat(_("Attack: %u"), attack),    //
-					                               bformat(_("Defense: %u"), defense),  //
-					                               bformat(_("Evade: %u"), evade));
+					const std::string tt = format("%s<br>%s<br>%s<br>%s",              //
+					                               format(_("Health: %u"), health),    //
+					                               format(_("Attack: %u"), attack),    //
+					                               format(_("Defense: %u"), defense),  //
+					                               format(_("Evade: %u"), evade));
 					txt->set_handle_mouse(true);
 					icon1->set_tooltip(tt);
 					icon2->set_tooltip(tt);
@@ -162,7 +162,7 @@ SoldierStatisticsMenu::SoldierStatisticsMenu(InteractivePlayer& parent,
 		hbox1->add(txt, UI::Box::Resizing::kAlign);
 		icons_detail_.push_back(i);
 		labels_detail_.push_back(txt);
-		const std::string tt = bformat(_("Health: %u"), h);
+		const std::string tt = format(_("Health: %u"), h);
 		i->set_handle_mouse(true);
 		txt->set_handle_mouse(true);
 		i->set_tooltip(tt);
@@ -177,7 +177,7 @@ SoldierStatisticsMenu::SoldierStatisticsMenu(InteractivePlayer& parent,
 		hbox2->add(txt, UI::Box::Resizing::kAlign);
 		icons_detail_.push_back(i);
 		labels_detail_.push_back(txt);
-		const std::string tt = bformat(_("Attack: %u"), a);
+		const std::string tt = format(_("Attack: %u"), a);
 		i->set_handle_mouse(true);
 		txt->set_handle_mouse(true);
 		i->set_tooltip(tt);
@@ -192,7 +192,7 @@ SoldierStatisticsMenu::SoldierStatisticsMenu(InteractivePlayer& parent,
 		hbox3->add(txt, UI::Box::Resizing::kAlign);
 		icons_detail_.push_back(i);
 		labels_detail_.push_back(txt);
-		const std::string tt = bformat(_("Defense: %u"), d);
+		const std::string tt = format(_("Defense: %u"), d);
 		i->set_handle_mouse(true);
 		txt->set_handle_mouse(true);
 		i->set_tooltip(tt);
@@ -207,7 +207,7 @@ SoldierStatisticsMenu::SoldierStatisticsMenu(InteractivePlayer& parent,
 		hbox4->add(txt, UI::Box::Resizing::kAlign);
 		icons_detail_.push_back(i);
 		labels_detail_.push_back(txt);
-		const std::string tt = bformat(_("Evade: %u"), e);
+		const std::string tt = format(_("Evade: %u"), e);
 		i->set_handle_mouse(true);
 		txt->set_handle_mouse(true);
 		i->set_tooltip(tt);
@@ -236,25 +236,25 @@ void SoldierStatisticsMenu::update() {
 	for (unsigned h = 0; h <= max_health_; ++h) {
 		const uint32_t nr = player_.count_soldiers_h(h);
 		icons_detail_[index]->set_grey_out(nr == 0);
-		labels_detail_[index]->set_text(bformat(_("×%u"), nr));
+		labels_detail_[index]->set_text(format(_("×%u"), nr));
 		++index;
 	}
 	for (unsigned a = 0; a <= max_attack_; ++a) {
 		const uint32_t nr = player_.count_soldiers_a(a);
 		icons_detail_[index]->set_grey_out(nr == 0);
-		labels_detail_[index]->set_text(bformat(_("×%u"), nr));
+		labels_detail_[index]->set_text(format(_("×%u"), nr));
 		++index;
 	}
 	for (unsigned d = 0; d <= max_defense_; ++d) {
 		const uint32_t nr = player_.count_soldiers_d(d);
 		icons_detail_[index]->set_grey_out(nr == 0);
-		labels_detail_[index]->set_text(bformat(_("×%u"), nr));
+		labels_detail_[index]->set_text(format(_("×%u"), nr));
 		++index;
 	}
 	for (unsigned e = 0; e <= max_evade_; ++e) {
 		const uint32_t nr = player_.count_soldiers_e(e);
 		icons_detail_[index]->set_grey_out(nr == 0);
-		labels_detail_[index]->set_text(bformat(_("×%u"), nr));
+		labels_detail_[index]->set_text(format(_("×%u"), nr));
 		++index;
 	}
 }

--- a/src/wui/soldier_statistics_menu.cc
+++ b/src/wui/soldier_statistics_menu.cc
@@ -69,11 +69,11 @@ SoldierStatisticsPanel::SoldierStatisticsPanel(UI::Panel& parent,
 					icons_all_.push_back(icon3);
 					icons_all_.push_back(icon4);
 					labels_all_.push_back(txt);
-					const std::string tt = format("%s<br>%s<br>%s<br>%s",              //
-					                               format(_("Health: %u"), health),    //
-					                               format(_("Attack: %u"), attack),    //
-					                               format(_("Defense: %u"), defense),  //
-					                               format(_("Evade: %u"), evade));
+					const std::string tt = format("%s<br>%s<br>%s<br>%s",             //
+					                              format(_("Health: %u"), health),    //
+					                              format(_("Attack: %u"), attack),    //
+					                              format(_("Defense: %u"), defense),  //
+					                              format(_("Evade: %u"), evade));
 					txt->set_handle_mouse(true);
 					icon1->set_tooltip(tt);
 					icon2->set_tooltip(tt);

--- a/src/wui/soldierlist.cc
+++ b/src/wui/soldierlist.cc
@@ -413,11 +413,11 @@ SoldierList::SoldierList(UI::Panel& parent, InteractiveBase& ib, Widelands::Buil
 	int w = UI::g_fh
 	           ->render(as_richtext_paragraph(
 	              format("%s "  // We need some extra space to fix bug 724169
-	                      ,
-	                      format(
-	                         /** TRANSLATORS: Health, Attack, Defense, Evade */
-	                         _("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"), 8, 8,
-	                         8, 8, 8, 8, 8, 8)),
+	                     ,
+	                     format(
+	                        /** TRANSLATORS: Health, Attack, Defense, Evade */
+	                        _("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"), 8, 8, 8,
+	                        8, 8, 8, 8, 8)),
 	              font_style_))
 	           ->width();
 	uint32_t maxtextwidth = std::max(
@@ -479,11 +479,10 @@ void SoldierList::mouseover(const Soldier* soldier) {
 	}
 
 	infotext_.set_text(format(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
-	                           soldier->get_health_level(), soldier->descr().get_max_health_level(),
-	                           soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
-	                           soldier->get_defense_level(),
-	                           soldier->descr().get_max_defense_level(), soldier->get_evade_level(),
-	                           soldier->descr().get_max_evade_level()));
+	                          soldier->get_health_level(), soldier->descr().get_max_health_level(),
+	                          soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
+	                          soldier->get_defense_level(), soldier->descr().get_max_defense_level(),
+	                          soldier->get_evade_level(), soldier->descr().get_max_evade_level()));
 }
 
 void SoldierList::eject(const Soldier* soldier) {

--- a/src/wui/soldierlist.cc
+++ b/src/wui/soldierlist.cc
@@ -412,9 +412,9 @@ SoldierList::SoldierList(UI::Panel& parent, InteractiveBase& ib, Widelands::Buil
 	// We don't want translators to translate this twice, so it's a bit involved.
 	int w = UI::g_fh
 	           ->render(as_richtext_paragraph(
-	              bformat("%s "  // We need some extra space to fix bug 724169
+	              format("%s "  // We need some extra space to fix bug 724169
 	                      ,
-	                      bformat(
+	                      format(
 	                         /** TRANSLATORS: Health, Attack, Defense, Evade */
 	                         _("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"), 8, 8,
 	                         8, 8, 8, 8, 8, 8)),
@@ -478,7 +478,7 @@ void SoldierList::mouseover(const Soldier* soldier) {
 		return;
 	}
 
-	infotext_.set_text(bformat(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
+	infotext_.set_text(format(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
 	                           soldier->get_health_level(), soldier->descr().get_max_health_level(),
 	                           soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
 	                           soldier->get_defense_level(),

--- a/src/wui/stock_menu.cc
+++ b/src/wui/stock_menu.cc
@@ -34,7 +34,7 @@ static const char pic_tab_workers_warehouse[] = "images/wui/stats/menu_tab_worke
 
 static inline std::string
 color_tag(const RGBColor& c, const std::string& text1, const std::string& text2) {
-	return bformat(_("%1$s %2$s"), StyleManager::color_tag(text1, c), text2);
+	return format(_("%1$s %2$s"), StyleManager::color_tag(text1, c), text2);
 }
 
 StockMenu::StockMenu(InteractivePlayer& plr, UI::UniqueWindow::Registry& registry)
@@ -51,7 +51,7 @@ StockMenu::StockMenu(InteractivePlayer& plr, UI::UniqueWindow::Registry& registr
            different background colors; each icon's color indicates whether the stock is higher or
            lower than the economy target setting. Very little space is available. */
         _("Evaluate"),
-        bformat(
+        format(
            "<rt><p>%s</p><p>%s<br>%s<br>%s</p></rt>",
            g_style_manager->font_style(UI::FontStyle::kWuiTooltipHeader)
               .as_font_tag(_("Compare stocked amounts to economy target quantities")),

--- a/src/wui/tribal_encyclopedia.cc
+++ b/src/wui/tribal_encyclopedia.cc
@@ -54,7 +54,7 @@ TribalEncyclopedia::TribalEncyclopedia(InteractivePlayer& parent,
 		log_err_time(parent.egbase().get_gametime(),
 		             "Error loading script for tribal encyclopedia:\n%s\n", err.what());
 		UI::WLMessageBox wmb(&parent, UI::WindowStyle::kWui, _("Error!"),
-		                     bformat("Error loading script for tribal encyclopedia:\n%s", err.what()),
+		                     format("Error loading script for tribal encyclopedia:\n%s", err.what()),
 		                     UI::WLMessageBox::MBoxType::kOk);
 		wmb.run<UI::Panel::Returncodes>();
 	}

--- a/src/wui/waresdisplay.cc
+++ b/src/wui/waresdisplay.cc
@@ -554,7 +554,7 @@ std::string StockMenuWaresDisplay::info_for_ware(const Widelands::DescriptionInd
          StyleManager::color_tag(_("="), colors.alternative_medium_color());
 	/** TRANSLATORS: The first placeholder is the stock amount of a ware/worker, and the second is an
 	 * icon indicating a trend. Very little space is available. */
-	return bformat(_("%1$s%2$s"), text, indicator);
+	return format(_("%1$s%2$s"), text, indicator);
 }
 
 RGBAColor
@@ -606,7 +606,7 @@ std::string get_amount_string(uint32_t amount, bool cutoff1k) {
 		amount /= 1000;
 		size++;
 	}
-	return bformat(unit_suffixes[size], amount);
+	return format(unit_suffixes[size], amount);
 }
 
 uint32_t WaresDisplay::amount_of(const Widelands::DescriptionIndex ware) {


### PR DESCRIPTION
The Lua function can't be renamed though as this would break scripting compatibility.

Replacement was done with a simple shell script, except for `lua_globals.cc`