### PR TITLE
Fix mingw path order

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -275,7 +275,7 @@ jobs:
         } else {
           $env:bits = "32"
         }
-        $env:Path = "C:/msys64/mingw$env:bits/include;C:/msys64/mingw$env:bits/lib;C:/msys64/usr/bin;C:/msys64/mingw$env:bits/bin;$env:Path"
+        $env:Path = "C:/msys64/mingw$env:bits/include;C:/msys64/mingw$env:bits/lib;C:/msys64/mingw$env:bits/bin;C:/msys64/usr/bin;$env:Path"
         $env:CC = "C:/msys64/mingw$env:bits/bin/gcc.exe"
         $env:CXX = "C:/msys64/mingw$env:bits/bin/g++.exe"
         mkdir $env:GITHUB_WORKSPACE\build


### PR DESCRIPTION
Re https://github.com/widelands/widelands/pull/5164#issuecomment-999369873
Resolve current x86 mingw build errors.
The problem was, that windres was used from the system (x64) path instead of the architecture path.