### PR TITLE
Force `signed char` in `AbstractNode`

### DIFF
--- a/src/base/format/abstract_node.h
+++ b/src/base/format/abstract_node.h
@@ -46,7 +46,7 @@ struct AbstractNode {
 	}
 
 	union Argument {
-		char char_val;
+		signed char char_val;
 		const char* string_val;
 		double float_val;
 		bool boolean_val;


### PR DESCRIPTION
Should fix #5177
The standard does not prescribe whether `char` is signed or unsigned. We can safely implicitly cast to `signed char` on platforms where it's unsigned by default – when we write it to the buffer (which is of type `char[]`), the stored value will be implicitly cast back to the platform-specific default sign anyway.