### PR TITLE
More Stringfixes

### DIFF
--- a/src/ui_fsmenu/addons/packager_box.cc
+++ b/src/ui_fsmenu/addons/packager_box.cc
@@ -372,7 +372,7 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 			UI::WLMessageBox mbox(
 			   &main_menu_, UI::WindowStyle::kFsMenu, _("Zipped Map"),
 			   format(_("The map ‘%s’ is not a directory. "
-			            "Please consider disabling the ‘Compress widelands data files’ option "
+			            "Please consider disabling the ‘Compress Widelands data files’ option "
 			            "in the options menu and resaving the map in the editor."
 			            "\n\nDo you want to add this map anyway?"),
 			          filename),

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -230,7 +230,7 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
      zip_(&box_saving_,
           UI::PanelStyle::kFsMenu,
           Vector2i::zero(),
-          _("Compress widelands data files (maps, replays and savegames)"),
+          _("Compress Widelands data files (maps, replays, and savegames)"),
           "",
           0),
      write_syncstreams_(&box_saving_,

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -53,14 +53,14 @@ void fill_parameter_vector() {
 	  {"", _("widelands <save.wgf>/<replay.wrpl>"), "--", "", false},
 	  /// Paths
 	  {_("Options:"), "datadir", _("DIRNAME"),
-		_("Use the specified directory for the widelands data files."), false},
+		_("Use the specified directory for the Widelands data files."), false},
 	  {"", "homedir", _("DIRNAME"),
-		format(_("Use the specified directory for widelands config files, savegames and replays. "
+		format(_("Use the specified directory for Widelands config files, savegames, and replays. "
 		         "Default is `%s`."),
 		       kDefaultHomedir),
 		false},
 	  {"", "localedir", _("DIRNAME"),
-		_("Use the specified directory for the widelands locale files."), false},
+		_("Use the specified directory for the Widelands locale files."), false},
 	  {"", "language",
 		/** TRANSLATORS: The … is not used on purpose to increase readability on monospaced terminals
 		 */

--- a/src/wlapplication_options.cc
+++ b/src/wlapplication_options.cc
@@ -586,7 +586,7 @@ static std::map<KeyboardShortcut, KeyboardShortcutInfo> shortcuts_ = {
     KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame},
                          keysym(SDLK_0, KMOD_ALT),
                          "game_msg_filter_all",
-                         []() { return _("Messages: Show "); })},
+                         []() { return _("Messages: Show All"); })},
    {KeyboardShortcut::kInGameMessagesFilterGeologists,
     KeyboardShortcutInfo({KeyboardShortcutInfo::Scope::kGame},
                          keysym(SDLK_1, KMOD_ALT),


### PR DESCRIPTION
One real bug, and several instances of missing capitalization of the name ‘Widelands’.