### PR TITLE
Auto-Cancel Redundant CI Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build
-concurrency: ${{ github.ref }}
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     types: [ opened, reopened, synchronize ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,5 @@
 name: Build
+concurrency: ${{ github.ref }}
 on:
   pull_request:
     types: [ opened, reopened, synchronize ]

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,4 +1,5 @@
 name: Formatting your code
+concurrency: ${{ github.ref }}
 on:
   # We are interested only in master and PRs, but GitHub explicitly forbids
   # pushing to the fork when an event is triggered on the base repo.

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,5 +1,7 @@
 name: Formatting your code
-concurrency: ${{ github.ref }}
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 on:
   # We are interested only in master and PRs, but GitHub explicitly forbids
   # pushing to the fork when an event is triggered on the base repo.

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -1,4 +1,5 @@
 name: Translations Update
+concurrency: ${{ github.ref }}
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -1,5 +1,4 @@
 name: Translations Update
-concurrency: ${{ github.ref }}
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -1,4 +1,7 @@
 name: Translations Update
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/launchpad_mirror.yaml
+++ b/.github/workflows/launchpad_mirror.yaml
@@ -1,5 +1,4 @@
 name: Launchpad Mirror
-concurrency: ${{ github.ref }}
 on:
   push:
     branches:

--- a/.github/workflows/launchpad_mirror.yaml
+++ b/.github/workflows/launchpad_mirror.yaml
@@ -1,4 +1,5 @@
 name: Launchpad Mirror
+concurrency: ${{ github.ref }}
 on:
   push:
     branches:

--- a/.github/workflows/launchpad_mirror.yaml
+++ b/.github/workflows/launchpad_mirror.yaml
@@ -1,4 +1,7 @@
 name: Launchpad Mirror
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches:


### PR DESCRIPTION
That way, when you push eight new commits to a PR in rapid succession, seven of the triggered builds are cancelled immediately and only the latest commit of each branch is built.

I missed this feature after the migration from Travis, but now it's available for GitHub actions as well.

Example: https://github.com/Noordfrees/widelands/actions/runs/1669061749