### PR TITLE
Don't require Homebrew to be installed at /usr/local.

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -83,8 +83,8 @@ if [ -z "$DISTRO" ]; then
       DISTRO="debian"
    elif [ -f /etc/solus-release ]; then
       DISTRO="solus"
-   elif [ -f /usr/local/Homebrew/bin/brew ]; then
-      DISTRO="homebrew"
+   elif brew --prefix > /dev/null 2>&1; then
+     DISTRO="homebrew"
    fi
 fi
 


### PR DESCRIPTION
It is very common for it to be installed elsewhere, and to rely on the
`brew` tool being in the user's PATH.