### PR TITLE
Fix null pointer dereference in BaseListselect::handle_key()

### DIFF
--- a/src/ui_basic/listselect.cc
+++ b/src/ui_basic/listselect.cc
@@ -563,15 +563,21 @@ bool BaseListselect::handle_key(bool const down, SDL_Keysym const code) {
 	if (down) {
 		switch (code.sym) {
 		case SDLK_BACKSPACE:
-			linked_dropdown->delete_last_of_filter();
-			return true;
-		case SDLK_ESCAPE:
-			if (linked_dropdown->is_filtered()) {
-				linked_dropdown->clear_filter();
-			} else {
-				linked_dropdown->set_list_visibility(false);
+			if (linked_dropdown != nullptr) {
+				linked_dropdown->delete_last_of_filter();
+				return true;
 			}
-			return true;
+			return UI::Panel::handle_key(down, code);
+		case SDLK_ESCAPE:
+			if (linked_dropdown != nullptr) {
+				if (linked_dropdown->is_filtered()) {
+					linked_dropdown->clear_filter();
+				} else {
+					linked_dropdown->set_list_visibility(false);
+				}
+				return true;
+			}
+			return UI::Panel::handle_key(down, code);
 		default:
 			break;
 		}


### PR DESCRIPTION
fixes #5210 

I'm unsure about `handle_mousepress()` (line 527). It checks for dropdown selection mode, which is only set by BaseDropdown in theory, but not for the actual value of `linked_dropdown`. Should I add at least an assert here as well?