### PR TITLE
Update github action to windows-2022

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -191,7 +191,7 @@ jobs:
           - x64
           - x86
     name: Windows ${{ matrix.config }} ${{ matrix.arch }} Build (MSVC)
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       VCPKG_ROOT: C:\vcpkg
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
@@ -217,6 +217,7 @@ jobs:
           ${{ hashFiles( '.github/workflows/build.yaml' ) }}-${{ steps.prepare.outputs.head }}-${{ matrix.arch }}
     - name: Installing dependencies
       run: |
+        choco install innosetup
         vcpkg install --disable-metrics --triplet=${{ env.VCPKG_TARGET_TRIPLET }} asio gettext libpng icu glbinding sdl2 sdl2-ttf sdl2-mixer[libvorbis,libflac,mpg123] sdl2-image[libjpeg-turbo,tiff] graphite2 harfbuzz opusfile libwebp
     - name: Configure MSVC development console
       uses: ilammy/msvc-dev-cmd@v1
@@ -257,7 +258,7 @@ jobs:
           - x64
           - x86
     name: Windows ${{ matrix.config }} ${{ matrix.arch }} Build (MinGW)
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - name: Installing dependencies
       run: |
@@ -269,8 +270,9 @@ jobs:
         } else {
           $env:archname = "i686"
         }
-        pacman.exe --noconfirm -S mingw-w64-$env:archname-ninja mingw-w64-$env:archname-SDL2_ttf mingw-w64-$env:archname-SDL2_mixer mingw-w64-$env:archname-SDL2_image mingw-w64-$env:archname-glew mingw-w64-$env:archname-asio mingw-w64-$env:archname-icu
+        pacman.exe --noconfirm -S mingw-w64-$env:archname-gcc mingw-w64-$env:archname-ninja mingw-w64-$env:archname-SDL2_ttf mingw-w64-$env:archname-SDL2_mixer mingw-w64-$env:archname-SDL2_image mingw-w64-$env:archname-glew mingw-w64-$env:archname-asio mingw-w64-$env:archname-icu
         # pacman.exe --noconfirm -U https://repo.msys2.org/mingw/$env:archname/mingw-w64-$env:archname-libtiff-4.3.0-3-any.pkg.tar.zst
+        choco install innosetup
     - name: Checkout
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
windows-latest workflows will use windows-2022 soon. (See annotation on any completed build action) 
Innosetup needs to be installed manually then, so better update now than waiting for broken builds.