### PR TITLE
Fix clicking a window not changing tool in editor

### DIFF
--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -509,6 +509,8 @@ bool Window::handle_mousepress(const uint8_t btn, int32_t mx, int32_t my) {
 		drag_start_mouse_x_ = get_x() + get_lborder() + mx;
 		drag_start_mouse_y_ = get_y() + get_tborder() + my;
 		grab_mouse(true);
+                clicked();
+                focus();
 	} else if (btn == SDL_BUTTON_RIGHT && !pinned_) {
 		play_click();
 		die();


### PR DESCRIPTION
This fixes window clicking a window in the editor to make the tool active. I assume it is a bug, because the code to select the tool was already there, but the windows didn't emit a clicked event.