### PR TITLE
fix pause and jump in empire mill working animation

### DIFF
--- a/data/tribes/buildings/productionsites/empire/mill/init.lua
+++ b/data/tribes/buildings/productionsites/empire/mill/init.lua
@@ -29,8 +29,8 @@ descriptions:new_productionsite_type {
 
    spritesheets = {
       working = {
-         fps = 25,
-         frames = 20,
+         fps = 15,
+         frames = 19,
          rows = 5,
          columns = 4,
          hotspot = { 41, 87 }


### PR DESCRIPTION
The Empire mill animation has a glitch, because the first and the last frames are identical, so there is a pause at the end of each cycle (after one quarter turn of the sails). This is fixed by ignoring the last frame.

There's another glitch at the end of the programmed animation, because the framerate is 25 and the working duration is 10s, so 250 frames are played, which means that the animation ends right in the middle of the cycle, at which time the sails jump to the starting position in the `idle` image. Fixing this is not trivial after setting the frames to 19, because the animation code actually uses an integer frametime of int(1000/fps), so with 19FPS the rounding causes the animation to overshoot a little at the end of the program, so there's still a small jump back. FPS of 15 or 24 (it can't be float either) result in good approximations. 15 is actually smoother, because 24 skips a frame at the end (ie. it has a small jump forward, though it's harder to spot and not as disturbing as a jump back).