### PR TITLE
Fix linking the OpenGL library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ endif()
 
 # This is set to avoid linker errors when using GLVND-libs on Linux
 if("${OpenGL_GL_PREFERENCE}" STREQUAL "GLVND")
-   link_libraries("GL")
+   link_libraries(OpenGL::GL)
    add_compile_definitions(WL_USE_GLVND)
    message(STATUS "Adding linker flags for GLVND.")
 endif()


### PR DESCRIPTION
You can't just link the library by its name, as the path to it is not known to cmake and it may be named differently (on FreeBSD: `-- Found OpenGL: /usr/local/lib/libOpenGL.so` which comes from libglvnd)