### PR TITLE
readme.md:correct spelling ('recommended')

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The master branch and open pull requests will be formatted automatically by a Gi
 
 You need to enable *local and third-party actions* in the Actions tab of your fork's settings to enable automatic formatting. If you disable actions, no formatting will take place on your branches.
 
-In order to ensure that our continuous integration suite will work properly for branches in your fork, it is strongly recommened that you create a personal access token for our formatting action:
+In order to ensure that our continuous integration suite will work properly for branches in your fork, it is strongly recommended that you create a personal access token for our formatting action:
 1. Create a Personal Access Token in your **profile** (https://github.com/settings/tokens). Select the scope `Repo → public_repo` for the new token. The token's note does not matter (use e.g. "Widelands Formatting Bot"). Copy the token's hash.
 2. Create a secret in your **widelands fork** (`https://github.com/<username>/widelands/settings/secrets`). The secret must be named `WIDELANDS_FORMAT_TOKEN`. Its value must be the hash of the token you just created.
 


### PR DESCRIPTION
[skip ci]