### PR TITLE
Fix legacy scenario units load order

### DIFF
--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -238,6 +238,7 @@ void Game::check_legacy_addons_desync_magic() {
 		}
 	}
 	if (!needed) {
+		postload_addons(true);
 		return;
 	}
 


### PR DESCRIPTION
Fixes #5346

This only affects savegames using the legacy load order, new-style savegames do not use this loading path at all.

`postload_addons` is poorly named now, it does a lot of other magic as well, so we need to call it even if we don't use any add-ons. Don't have a better name though.