### PR TITLE
v1.0 Backwards Compatibility for World/Tribe Add-Ons

### DIFF
--- a/src/logic/map_objects/description_manager.cc
+++ b/src/logic/map_objects/description_manager.cc
@@ -148,9 +148,10 @@ void DescriptionManager::register_description(const std::string& description_nam
 	case RegistryCallerType::kTribeAddon:
 	case RegistryCallerType::kWorldAddon:
 		if (!skip && !replace) {
-			throw GameDataError("DescriptionManager::register_description %s: add-on entities must "
-			                    "define either '__skip_if_exists' or '__replace_if_exists'",
-			                    description_name.c_str());
+			log_warn("DescriptionManager::register_description %s: add-on entities "
+			         "should define '__skip_if_exists' or '__replace_if_exists'",
+			         description_name.c_str());
+			replace = true;
 		}
 		break;
 	}
@@ -168,6 +169,7 @@ void DescriptionManager::register_description(const std::string& description_nam
 			skip = std::find(registered_attributes.begin(), registered_attributes.end(),
 			                 "__replace_if_exists") != registered_attributes.end();
 			assert(!(replace && skip));
+			replace |= !skip;  // Default to replace if policy is not set.
 		}
 		if (skip) {
 			verb_log_info("%s: using '%s' instead of '%s'", description_name.c_str(),


### PR DESCRIPTION
If neither `__skip_if_exists` nor `__replace_if_exists` is set, default to replace and print warnings instead of generating a game data error. Affects the White Summer and Tropics add-ons.