### PR TITLE
fixing 5375 - update buildable fields crash

### DIFF
--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -1364,14 +1364,14 @@ void DefaultAI::update_all_buildable_fields(const Time& gametime) {
 		}
 	}
 
-	verb_log_dbg_time(gametime,
-	                  " first round: %2d of %3" PRIuS " fields updated. Fields unupdated: Spec: %d, Mid: "
-	                  "%d, Big: %d. Invalid "
-	                  "fields found: %3d\n",
-	                  updated_fields_count, buildable_fields.size(),
-	                  special_fields_to_prefer[kSpecialFieldPos],
-	                  special_fields_to_prefer[kMediumlFieldPos],
-	                  special_fields_to_prefer[kBigFieldPos], invalidated_bf_count);
+	verb_log_dbg_time(
+	   gametime,
+	   " first round: %2d of %3" PRIuS " fields updated. Fields unupdated: Spec: %d, Mid: "
+	   "%d, Big: %d. Invalid "
+	   "fields found: %3d\n",
+	   updated_fields_count, buildable_fields.size(), special_fields_to_prefer[kSpecialFieldPos],
+	   special_fields_to_prefer[kMediumlFieldPos], special_fields_to_prefer[kBigFieldPos],
+	   invalidated_bf_count);
 
 	// Stage #2: get rid of invalid files / and rotate the deque
 	// Must be signed, to avoid underflow

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -1364,20 +1364,21 @@ void DefaultAI::update_all_buildable_fields(const Time& gametime) {
 		}
 	}
 
-	verb_log_dbg_time(
-	   gametime,
-	   " first round: %2d of %3lu fields updated. Fields unupdated: Spec: %d, Mid: %d, Big: %d. Invalid "
-	   "fields found: %3d\n",
-	   updated_fields_count, buildable_fields.size(), special_fields_to_prefer[kSpecialFieldPos],
-	   special_fields_to_prefer[kMediumlFieldPos], special_fields_to_prefer[kBigFieldPos],
-	   invalidated_bf_count);
+	verb_log_dbg_time(gametime,
+	                  " first round: %2d of %3lu fields updated. Fields unupdated: Spec: %d, Mid: "
+	                  "%d, Big: %d. Invalid "
+	                  "fields found: %3d\n",
+	                  updated_fields_count, buildable_fields.size(),
+	                  special_fields_to_prefer[kSpecialFieldPos],
+	                  special_fields_to_prefer[kMediumlFieldPos],
+	                  special_fields_to_prefer[kBigFieldPos], invalidated_bf_count);
 
 	// Stage #2: get rid of invalid files / and rotate the deque
 	// Must be signed, to avoid underflow
 	int16_t fields_to_rotate =
 	   buildable_fields.size() / 15;  // rotating at least this number of fields/members
 	while ((fields_to_rotate-- > 0) || (invalidated_bf_count != 0u)) {
-		assert(!buildable_fields.empty()); // should not happend, would lead to crash
+		assert(!buildable_fields.empty());  // should not happend, would lead to crash
 		BuildableField& bf = *buildable_fields.front();
 		if (bf.invalidated) {
 			invalidated_bf_count--;

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -1365,7 +1365,7 @@ void DefaultAI::update_all_buildable_fields(const Time& gametime) {
 	}
 
 	verb_log_dbg_time(gametime,
-	                  " first round: %2d of %3llu fields updated. Fields unupdated: Spec: %d, Mid: "
+	                  " first round: %2d of %3" PRIuS " fields updated. Fields unupdated: Spec: %d, Mid: "
 	                  "%d, Big: %d. Invalid "
 	                  "fields found: %3d\n",
 	                  updated_fields_count, buildable_fields.size(),

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -1366,16 +1366,18 @@ void DefaultAI::update_all_buildable_fields(const Time& gametime) {
 
 	verb_log_dbg_time(
 	   gametime,
-	   " first round: %2d fields updated. Fields unupdated: Spec: %d, Mid: %d, Big: %d. Invalid "
+	   " first round: %2d of %3lu fields updated. Fields unupdated: Spec: %d, Mid: %d, Big: %d. Invalid "
 	   "fields found: %3d\n",
-	   updated_fields_count, special_fields_to_prefer[kSpecialFieldPos],
+	   updated_fields_count, buildable_fields.size(), special_fields_to_prefer[kSpecialFieldPos],
 	   special_fields_to_prefer[kMediumlFieldPos], special_fields_to_prefer[kBigFieldPos],
 	   invalidated_bf_count);
 
 	// Stage #2: get rid of invalid files / and rotate the deque
-	uint16_t min_fields_rotated =
-	   buildable_fields.size() / 15;  // rotating at least this number of items
-	while ((invalidated_bf_count != 0u) || ((min_fields_rotated--) != 0u)) {
+	// Must be signed, to avoid underflow
+	int16_t fields_to_rotate =
+	   buildable_fields.size() / 15;  // rotating at least this number of fields/members
+	while ((fields_to_rotate-- > 0) || (invalidated_bf_count != 0u)) {
+		assert(!buildable_fields.empty()); // should not happend, would lead to crash
 		BuildableField& bf = *buildable_fields.front();
 		if (bf.invalidated) {
 			invalidated_bf_count--;

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -1365,7 +1365,7 @@ void DefaultAI::update_all_buildable_fields(const Time& gametime) {
 	}
 
 	verb_log_dbg_time(gametime,
-	                  " first round: %2d of %3lu fields updated. Fields unupdated: Spec: %d, Mid: "
+	                  " first round: %2d of %3llu fields updated. Fields unupdated: Spec: %d, Mid: "
 	                  "%d, Big: %d. Invalid "
 	                  "fields found: %3d\n",
 	                  updated_fields_count, buildable_fields.size(),


### PR DESCRIPTION
Calling front() on empty deque... caused by wrongly constructed while and unsigned int underflow
