### PR TITLE
Fix syncreport requesting during game startup

### DIFF
--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -1989,6 +1989,9 @@ void GameHost::update_network_speed() {
  */
 void GameHost::request_sync_reports() {
 	assert(!d->syncreport_pending);
+	if (!d->game->is_loaded()) {
+		return;
+	}
 
 	d->syncreport_pending = true;
 	d->syncreport_arrived = false;


### PR DESCRIPTION
Fixes #4917
Thanks to @matthiakl for detecting the cause in https://github.com/widelands/widelands/issues/4917#issuecomment-1113468786

Problem was that the first sync report request was enqueued before the game actually starts running, and the command queue is later flushed, so the report was pending forever. Now a desync in the game (which can be triggered by modding some Lua file on one client) is detected instantly.