### PR TITLE
Move definition of WL_INSTALL_BINDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,13 @@ wl_set_if_unset(WL_INSTALL_BASEDIR ".")
 # Packagers (or people using make install) have to set this variable to an absolute path.
 wl_set_if_unset(WL_INSTALL_DATADIR "./data")
 
+# To override this, use '-DWL_INSTALL_BINDIR=<absolute path>' when configuring or change
+# 'CMAKE_INSTALL_PREFIX'.
+# Example: to have the bin installed to "/usr/games", just use '-DCMAKE_INSTALL_PREFIX=/usr'
+# and don't specify '-DWL_INSTALL_BINDIR' when configuring.
+# Note: 'CMAKE_INSTALL_PREFIX' defaults to /usr/local on UNIX and c:/Program Files/${PROJECT_NAME} on Windows
+set(WL_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/games" CACHE PATH "Destination of executable files (if installing)")
+
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
     message(FATAL_ERROR "Widelands needs GCC >= 4.8 to compile.")
@@ -554,13 +561,6 @@ install(
   COMPONENT DocFiles
   PATTERN "CMakeLists.txt" EXCLUDE
 )
-
-# To override this, use '-DWL_INSTALL_BINDIR=<absolute path>' when configuring or change
-# 'CMAKE_INSTALL_PREFIX'.
-# Example: to have the bin installed to "/usr/games", just use '-DCMAKE_INSTALL_PREFIX=/usr'
-# and don't specify '-DWL_INSTALL_BINDIR' when configuring.
-# Note: 'CMAKE_INSTALL_PREFIX' defaults to /usr/local on UNIX and c:/Program Files/${PROJECT_NAME} on Windows
-set(WL_INSTALL_BINDIR "${CMAKE_INSTALL_PREFIX}/games" CACHE PATH "Destination of executable files (if installing)")
 
 if(OPTION_BUILD_TRANSLATIONS)
   set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${WL_INSTALL_DATADIR}/locale)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,10 +69,11 @@ else()
   )
 endif()
 
-# unset these two if they are cached
-unset(MINIZIP_FOUND)
-set(MINIZIP_STATIC_LIBRARIES "")
-if(NOT OPTION_FORCE_EMBEDDED_MINIZIP)
+if(OPTION_FORCE_EMBEDDED_MINIZIP)
+    # unset these two if they are cached
+    unset(MINIZIP_FOUND)
+    set(MINIZIP_STATIC_LIBRARIES "")
+else()
    # If pkg-config is ever needed to find other libraries, move the include outside the if() block
   include(FindPkgConfig)
   if(PKG_CONFIG_FOUND)


### PR DESCRIPTION
Fixes https://github.com/widelands/widelands/pull/5359#issuecomment-1114222800
I also added a condition for minizip, because currently the system library is only detected in a fresh build directory but reset to the embedded one after rerunning cmake.