### PR TITLE
Pan map view to keep it centered when resizing game window.

### DIFF
--- a/src/wui/info_panel.cc
+++ b/src/wui/info_panel.cc
@@ -383,7 +383,7 @@ void InfoPanel::set_fps_string(const bool show,
 		text_fps_.set_text("");
 		text_fps_.set_tooltip("");
 	} else {
-		const std::string text = format("%5.1f fps (avg: %5.1f fps)", fps, average);
+		const std::string text = format("%05.1f fps (avg: %05.1f fps)", fps, average);
 		// The FPS string overlaps with the coords string at low resolution.
 		// Therefore abbreviate it if the available width is less than an arbitrary threshold.
 		if (cheating) {

--- a/src/wui/info_panel.cc
+++ b/src/wui/info_panel.cc
@@ -383,7 +383,7 @@ void InfoPanel::set_fps_string(const bool show,
 		text_fps_.set_text("");
 		text_fps_.set_tooltip("");
 	} else {
-		const std::string text = format("%05.1f fps (avg: %05.1f fps)", fps, average);
+		const std::string text = format("%5.1f fps (avg: %5.1f fps)", fps, average);
 		// The FPS string overlaps with the coords string at low resolution.
 		// Therefore abbreviate it if the available width is less than an arbitrary threshold.
 		if (cheating) {

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -188,6 +188,9 @@ InteractiveBase::InteractiveBase(EditorGameBase& the_egbase, Section& global_s, 
 	   [this](const GraphicResolutionChanged& message) {
 		   set_size(message.new_width, message.new_height);
 		   map_view_.set_size(message.new_width, message.new_height);
+		   map_view_.pan_by(Vector2i(-(message.new_width - message.old_width) / 2,
+		                             -(message.new_height - message.old_height) / 2),
+		                    MapView::Transition::Jump);
 		   resize_chat_overlay();
 		   finalize_toolbar();
 		   info_panel_.layout();

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -188,8 +188,8 @@ InteractiveBase::InteractiveBase(EditorGameBase& the_egbase, Section& global_s, 
 	   [this](const GraphicResolutionChanged& message) {
 		   set_size(message.new_width, message.new_height);
 		   map_view_.set_size(message.new_width, message.new_height);
-		   map_view_.pan_by(Vector2i(-(message.new_width - message.old_width) / 2,
-		                             -(message.new_height - message.old_height) / 2),
+		   map_view_.pan_by(Vector2i((message.old_width - message.new_width) / 2,
+		                             (message.old_height - message.new_height) / 2),
 		                    MapView::Transition::Jump);
 		   resize_chat_overlay();
 		   finalize_toolbar();


### PR DESCRIPTION
Fixes #4863.