### PR TITLE
Preallocate task stack before program update

### DIFF
--- a/src/logic/map_objects/bob.cc
+++ b/src/logic/map_objects/bob.cc
@@ -191,7 +191,7 @@ void Bob::do_act(Game& game) {
 	if (cap == stack_.size()) {
 		// preallocate one element to keep references to task and top_state
 		// valid during update which may add a task to the stack
-		stack_.reserve(cap+1);
+		stack_.reserve(cap + 1);
 	}
 	in_act_ = true;
 

--- a/src/logic/map_objects/bob.cc
+++ b/src/logic/map_objects/bob.cc
@@ -187,6 +187,12 @@ void Bob::do_act(Game& game) {
 	assert(!in_act_);
 	assert(!stack_.empty());
 
+	size_t cap = stack_.capacity();
+	if (cap == stack_.size()) {
+		// preallocate one element to keep references to task and top_state
+		// valid during update which may add a task to the stack
+		stack_.reserve(cap+1);
+	}
 	in_act_ = true;
 
 	const Task& task = *top_state().task;


### PR DESCRIPTION
Fixes #5404 (the linked autosave now loads correctly)
Not sure, if this is a good place to put the code, but it works.
Thanks @attet for finding and reporting these issues :wink: 