### PR TITLE
Remove NOCOM comments

### DIFF
--- a/src/ai/ai_help_structs.h
+++ b/src/ai/ai_help_structs.h
@@ -413,9 +413,6 @@ struct BuildableField {
 	int16_t ally_military_presence;
 	// stationed (manned) military buildings nearby
 	int16_t military_stationed;
-	// unconnected buildings nearby
-	// bool unconnected_nearby; NOCOM
-	// average_flag_dist_to_wh;
 	uint32_t average_flag_dist_to_wh;
 	int16_t military_unstationed;
 	int16_t own_non_military_nearby;

--- a/src/ai/defaultai.h
+++ b/src/ai/defaultai.h
@@ -186,7 +186,6 @@ private:
 	check_building_necessity(BuildingObserver& bo, PerfEvaluation purpose, const Time&);
 	BuildingNecessity check_warehouse_necessity(BuildingObserver&, const Time& gametime);
 	void sort_task_pool();
-	// void sort_by_priority(); NOCOM
 	void set_taskpool_task_time(const Time&, SchedulerTaskId);
 	const Time& get_taskpool_task_time(SchedulerTaskId);
 	std::chrono::high_resolution_clock::time_point time_point;


### PR DESCRIPTION
I couldn't find any other occurrences referencing the commented-out function and variable, so I guess all related code was already removed in the past and this was the only oversight.

Fixes #5405