### PR TITLE
Unify test executable layout

### DIFF
--- a/src/notifications/test/CMakeLists.txt
+++ b/src/notifications/test/CMakeLists.txt
@@ -1,6 +1,7 @@
-wl_test(notifications_test
+wl_test(test_notifications
   SRCS
-    notifications_test.cc
+    notifications_test_main.cc
+    test_notifications.cc
   DEPENDS
     base_test
     notifications

--- a/src/notifications/test/notifications_test_main.cc
+++ b/src/notifications/test/notifications_test_main.cc
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2006-2022 by the Widelands Development Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "base/test.h"
+TEST_EXECUTABLE(notifications, true)

--- a/src/notifications/test/test_notifications.cc
+++ b/src/notifications/test/test_notifications.cc
@@ -21,8 +21,6 @@
 #include "base/test.h"
 #include "notifications/notifications.h"
 
-TEST_EXECUTABLE(notifications, true)
-
 struct SimpleNote {
 	CAN_BE_SENT_AS_NOTE(100)
 


### PR DESCRIPTION
Re #5433

The only difference to other testcases is the file layout of the executable. So my guess is that gcc 12 has some quirks here (the last successful appveyor build was gcc 11.3.0, the first failing one gcc 12.1.0).

@hessenfarmer can you try this on a clean build and see, whether it changes anything? Also, is there any log output after "Adding testcase SimpleTest"?