### PR TITLE
Fix fake-modal in-game load dialog releasing modal grab

### DIFF
--- a/src/wui/game_main_menu_save_game.cc
+++ b/src/wui/game_main_menu_save_game.cc
@@ -87,7 +87,7 @@ GameMainMenuSaveGame::GameMainMenuSaveGame(InteractiveGameBase& parent,
 
      curdir_(kSaveDir),
      illegal_filename_tooltip_(FileSystemHelper::illegal_filename_tooltip()),
-     modal_(*this) {
+     modal_(new UI::Panel::ModalGuard(*this)) {
 	filename_box_.set_visible(type_ == Type::kSave);
 
 	layout();
@@ -205,6 +205,7 @@ void GameMainMenuSaveGame::ok() {
 		case Type::kLoad: {
 			if (load_or_save_.has_selection()) {
 				igbase().game().set_next_game_to_load(load_or_save_.entry_selected()->filename);
+				modal_.reset();
 				igbase().end_modal<UI::Panel::Returncodes>(UI::Panel::Returncodes::kBack);
 			}
 		} break;

--- a/src/wui/game_main_menu_save_game.h
+++ b/src/wui/game_main_menu_save_game.h
@@ -19,6 +19,8 @@
 #ifndef WL_WUI_GAME_MAIN_MENU_SAVE_GAME_H
 #define WL_WUI_GAME_MAIN_MENU_SAVE_GAME_H
 
+#include <memory>
+
 #include "base/i18n.h"
 #include "ui_basic/box.h"
 #include "ui_basic/button.h"
@@ -85,7 +87,7 @@ private:
 
 	std::string curdir_;
 	const std::string illegal_filename_tooltip_;
-	UI::Panel::ModalGuard modal_;
+	std::unique_ptr<UI::Panel::ModalGuard> modal_;
 };
 
 #endif  // end of include guard: WL_WUI_GAME_MAIN_MENU_SAVE_GAME_H


### PR DESCRIPTION
This window is not *truly* modal, it just pretends to be, sort of. So we need to release its modality grab manually before it may tell the actually modal window to die.