### PR TITLE
compile.sh fix and tweaks

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -580,7 +580,8 @@ buildtool="" #Use ninja by default, fall back to make if that is not available.
       return 0
     fi
       $RUN rm -f update.sh || true
-      $RUN cat > update.sh << END_SCRIPT
+      if [ -z "$RUN" ]; then
+        cat > update.sh << END_SCRIPT
 #!/bin/sh
 echo "################################################"
 echo "#            Widelands update script.          #"
@@ -606,8 +607,17 @@ echo "#      Widelands was updated successfully.     #"
 echo "# You should be able to run it via ./widelands #"
 echo "################################################"
 END_SCRIPT
+
+      else  # dry run
+        echo 'cat > update.sh <<END_SCRIPT'
+        echo "   # ..."
+        echo "   $COMMANDLINE"
+        echo "   # ..."
+        echo "END_SCRIPT"
+      fi
+
       $RUN chmod +x ./update.sh
-      if [ $QUIET -eq 0 ]; then
+      if [ $QUIET -eq 0 -a -z "$RUN" ]; then
         echo "The update script has successfully been created."
       fi
   }

--- a/compile.sh
+++ b/compile.sh
@@ -352,6 +352,18 @@ if [ $QUIET -eq 0 ]; then
   fi
 fi
 
+if [ -n "$RUN" ]; then
+  if [ $QUIET -eq 0 ]; then
+    echo " "
+    echo "#################################################################"
+    echo "#  Dry run: Nothing will be changed, commands will be printed.  #"
+    echo "#################################################################"
+    echo " "
+  else
+    echo "###  Dry run: Nothing will be changed, commands will be printed."
+  fi
+fi
+
 ## Get command and options to use in update.sh
 COMMANDLINE="$0"
 CMD_ADD () {
@@ -696,6 +708,6 @@ echo "###########################################################"
 elif [ -z "$RUN" ]; then
   echo "Widelands has been built successfully."
 else
-  echo "###  compile.sh completed successfully."
+  echo "###  Dry run of compile.sh has completed successfully."
 fi  # End of verbose output section
 ######################################

--- a/compile.sh
+++ b/compile.sh
@@ -200,7 +200,7 @@ do
     ;;
     -j|--cores)
       case $2 in
-        *[^0-9]*|'')
+        *[!0-9]*|'')
           echo "Call -j/--cores with a number, e.g. '-j $MAXCORES'"
           exit 1
         ;;

--- a/compile.sh
+++ b/compile.sh
@@ -695,5 +695,7 @@ echo "###########################################################"
 
 elif [ -z "$RUN" ]; then
   echo "Widelands has been built successfully."
+else
+  echo "###  compile.sh completed successfully."
 fi  # End of verbose output section
 ######################################

--- a/compile.sh
+++ b/compile.sh
@@ -527,7 +527,15 @@ buildtool="" #Use ninja by default, fall back to make if that is not available.
 
   # Compile Widelands
   compile_widelands () {
-    cmake $GENERATOR .. $EXTRA_OPTS -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DOPTION_BUILD_WEBSITE_TOOLS=$BUILD_WEBSITE -DOPTION_BUILD_TRANSLATIONS=$BUILD_TRANSLATIONS -DOPTION_BUILD_TESTS=$BUILD_TESTS -DOPTION_ASAN=$USE_ASAN -DOPTION_TSAN=$USE_TSAN -DUSE_XDG=$USE_XDG -DUSE_FLTO_IF_AVAILABLE=${USE_FLTO}
+    cmake $GENERATOR .. $EXTRA_OPTS                       \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE                  \
+          -DOPTION_BUILD_WEBSITE_TOOLS=$BUILD_WEBSITE     \
+          -DOPTION_BUILD_TRANSLATIONS=$BUILD_TRANSLATIONS \
+          -DOPTION_BUILD_TESTS=$BUILD_TESTS               \
+          -DOPTION_ASAN=$USE_ASAN                         \
+          -DOPTION_TSAN=$USE_TSAN                         \
+          -DUSE_XDG=$USE_XDG                              \
+          -DUSE_FLTO_IF_AVAILABLE=${USE_FLTO}
 
     $buildtool -j $CORES
 


### PR DESCRIPTION
fixes #5463

Plus adds --dry-run option for testing and breaks up the cmake command line for readibility. I'll revert them if they are too much for this PR.