### PR TITLE
Run apt-get upgrade to prevent dependency mismatches

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -33,6 +33,7 @@ if [ "${GITHUB_JOB}" = "appimage" ]; then
 fi
 
 sudo apt-get update
+sudo apt-get upgrade
 sudo apt-get install -y \
   cmake \
   gettext \


### PR DESCRIPTION
This resolves the testsuite errors on ubuntu-22.04.