### PR TITLE
Fix too-early add-on descriptions registries

### DIFF
--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -1077,7 +1077,6 @@ void EditorInteractive::do_run_editor(const EditorInteractive::Init init,
 		Notifications::publish(UI::NoteLoadingMessage(format(_("Loading map “%s”…"), filename)));
 		eia.load(filename);
 
-		egbase.postload_addons();
 		egbase.postload();
 		eia.start();
 		if (!script_to_run.empty()) {
@@ -1092,7 +1091,6 @@ void EditorInteractive::do_run_editor(const EditorInteractive::Init init,
 			throw wexception("EditorInteractive::run_editor: Script given when none was expected");
 		}
 
-		egbase.postload_addons();
 		egbase.postload();
 
 		egbase.mutable_map()->create_empty_map(

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -1077,7 +1077,7 @@ void EditorInteractive::do_run_editor(const EditorInteractive::Init init,
 		Notifications::publish(UI::NoteLoadingMessage(format(_("Loading map “%s”…"), filename)));
 		eia.load(filename);
 
-		egbase.postload_addons(true);
+		egbase.postload_addons();
 		egbase.postload();
 		eia.start();
 		if (!script_to_run.empty()) {
@@ -1092,7 +1092,7 @@ void EditorInteractive::do_run_editor(const EditorInteractive::Init init,
 			throw wexception("EditorInteractive::run_editor: Script given when none was expected");
 		}
 
-		egbase.postload_addons(true);
+		egbase.postload_addons();
 		egbase.postload();
 
 		egbase.mutable_map()->create_empty_map(

--- a/src/game_io/game_class_packet.cc
+++ b/src/game_io/game_class_packet.cc
@@ -63,7 +63,6 @@ void GameClassPacket::read(FileSystem& fs, Game& game, MapObjectLoader* /* mol *
 					Notifications::publish(NoteMapObjectDescription(
 					   fr.string(), NoteMapObjectDescription::LoadType::kObject));
 				}
-				game.postload_tribes();
 			} else {
 				game.check_legacy_addons_desync_magic();
 			}

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -308,6 +308,9 @@ void EditorGameBase::allocate_player_maps() {
 void EditorGameBase::postload() {
 	create_tempfile_and_save_mapdata(FileSystem::ZIP);
 	assert(descriptions_);
+
+	postload_addons(false);
+	postload_tribes();
 }
 
 void EditorGameBase::postload_addons(bool also_postload_tribes) {

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -309,11 +309,11 @@ void EditorGameBase::postload() {
 	create_tempfile_and_save_mapdata(FileSystem::ZIP);
 	assert(descriptions_);
 
-	postload_addons(false);
+	postload_addons();
 	postload_tribes();
 }
 
-void EditorGameBase::postload_addons(bool also_postload_tribes) {
+void EditorGameBase::postload_addons() {
 	if (did_postload_addons_) {
 		return;
 	}
@@ -343,10 +343,6 @@ void EditorGameBase::postload_addons(bool also_postload_tribes) {
 				lua_->run_script(script);
 			}
 		}
-	}
-
-	if (also_postload_tribes) {
-		postload_tribes();
 	}
 }
 

--- a/src/logic/editor_game_base.h
+++ b/src/logic/editor_game_base.h
@@ -112,7 +112,7 @@ public:
 	void load_all_tribes();
 	void allocate_player_maps();
 	virtual void postload();
-	void postload_addons(bool also_postload_tribes);
+	void postload_addons();
 	void postload_tribes();
 	virtual void cleanup_for_load();
 	virtual void full_cleanup();

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -332,8 +332,7 @@ void Game::init_newgame(const GameSettings& settings) {
 		maploader->preload_map(settings.scenario, &enabled_addons());
 	}
 
-	postload_addons(false);
-	did_postload_addons_before_loading_ = true;
+	postload_addons_before_loading();
 
 	std::vector<PlayerSettings> shared;
 	std::vector<uint8_t> shared_num;

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -225,7 +225,7 @@ void Game::postload_addons_before_loading() {
 	did_postload_addons_before_loading_ = true;
 	delete_world_and_tribes();
 	mutable_descriptions()->ensure_tribes_are_registered();
-	postload_addons(false);
+	postload_addons();
 }
 
 // TODO(Nordfriese): Needed for v1.0 savegame compatibility, remove after v1.1
@@ -239,7 +239,7 @@ void Game::check_legacy_addons_desync_magic() {
 		}
 	}
 	if (!needed) {
-		postload_addons(true);
+		postload_addons();
 		return;
 	}
 
@@ -253,7 +253,7 @@ void Game::check_legacy_addons_desync_magic() {
 	EditorInteractive::load_world_units(nullptr, *this);
 	load_all_tribes();
 
-	postload_addons(true);
+	postload_addons();
 }
 
 bool Game::run_splayer_scenario_direct(const std::list<std::string>& list_of_scenarios,
@@ -448,7 +448,7 @@ void Game::init_savegame(const GameSettings& settings) {
 
 		// Discover the links between resources and geologist flags,
 		// dependencies of productionsites etc.
-		postload_addons(true);
+		postload_addons();
 
 		// Players might have selected a different AI type
 		for (uint8_t i = 0; i < settings.players.size(); ++i) {
@@ -497,7 +497,7 @@ bool Game::run_load_game(const std::string& filename, const std::string& script_
 		set_ibase(ipl);
 
 		gl.load_game();
-		postload_addons(true);
+		postload_addons();
 
 		ipl->info_panel_fast_forward_message_queue();
 	}
@@ -733,7 +733,7 @@ bool Game::run(StartGameType const start_game_type,
 		}
 	}
 
-	postload_addons(true);
+	postload_addons();
 
 	sync_reset();
 	Notifications::publish(UI::NoteLoadingMessage(_("Initializing…")));

--- a/src/logic/map_objects/descriptions.cc
+++ b/src/logic/map_objects/descriptions.cc
@@ -665,7 +665,7 @@ void Descriptions::add_immovable_relation(const std::string& a, const std::strin
 }
 void Descriptions::postload_immovable_relations() {
 	for (const auto& pair : immovable_relations_) {
-		get_mutable_immovable_descr(load_immovable(pair.second))->add_became_from(pair.first);
+		get_mutable_immovable_descr(load_immovable(pair.second))->add_became_from(*this, pair.first);
 	}
 	immovable_relations_.clear();
 }

--- a/src/logic/map_objects/immovable.cc
+++ b/src/logic/map_objects/immovable.cc
@@ -248,11 +248,17 @@ void ImmovableDescr::make_sure_default_program_is_there() {
 }
 
 void ImmovableDescr::add_collected_by(const Descriptions& descriptions,
-                                      const std::string& prodsite) {
+                                      const std::string& prodsite,
+                                      std::set<const ImmovableDescr*> recursion_protect) {
+	if (recursion_protect.count(this) != 0) {
+		return;
+	}
+	recursion_protect.insert(this);
+
 	collected_by_.insert(prodsite);
 	for (const std::string& immo : became_from_) {
 		descriptions.get_mutable_immovable_descr(descriptions.safe_immovable_index(immo))
-		   ->add_collected_by(descriptions, prodsite);
+		   ->add_collected_by(descriptions, prodsite, recursion_protect);
 	}
 }
 

--- a/src/logic/map_objects/immovable.cc
+++ b/src/logic/map_objects/immovable.cc
@@ -249,13 +249,17 @@ void ImmovableDescr::make_sure_default_program_is_there() {
 
 void ImmovableDescr::add_collected_by(const Descriptions& descriptions,
                                       const std::string& prodsite) {
-	if (collected_by_.count(prodsite) != 0u) {
-		return;  // recursion break
-	}
 	collected_by_.insert(prodsite);
 	for (const std::string& immo : became_from_) {
 		descriptions.get_mutable_immovable_descr(descriptions.safe_immovable_index(immo))
 		   ->add_collected_by(descriptions, prodsite);
+	}
+}
+
+void ImmovableDescr::add_became_from(const Descriptions& descriptions, const std::string& immo) {
+	became_from_.insert(immo);
+	for (const std::string& prodsite : collected_by_) {
+		add_collected_by(descriptions, prodsite);
 	}
 }
 

--- a/src/logic/map_objects/immovable.h
+++ b/src/logic/map_objects/immovable.h
@@ -164,7 +164,7 @@ public:
 	const std::set<std::string> collected_by() const {
 		return collected_by_;
 	}
-	void add_collected_by(const Descriptions& descriptions, const std::string& prodsite);
+	void add_collected_by(const Descriptions& descriptions, const std::string& prodsite, std::set<const ImmovableDescr*> recursion_protect = {});
 
 	void register_immovable_relation(const std::string&, const std::string&);
 	void add_became_from(const Descriptions& descriptions, const std::string&);

--- a/src/logic/map_objects/immovable.h
+++ b/src/logic/map_objects/immovable.h
@@ -167,9 +167,7 @@ public:
 	void add_collected_by(const Descriptions& descriptions, const std::string& prodsite);
 
 	void register_immovable_relation(const std::string&, const std::string&);
-	void add_became_from(const std::string& s) {
-		became_from_.insert(s);
-	}
+	void add_became_from(const Descriptions& descriptions, const std::string&);
 
 protected:
 	Descriptions& descriptions_;

--- a/src/logic/map_objects/immovable.h
+++ b/src/logic/map_objects/immovable.h
@@ -164,7 +164,9 @@ public:
 	const std::set<std::string> collected_by() const {
 		return collected_by_;
 	}
-	void add_collected_by(const Descriptions& descriptions, const std::string& prodsite, std::set<const ImmovableDescr*> recursion_protect = {});
+	void add_collected_by(const Descriptions& descriptions,
+	                      const std::string& prodsite,
+	                      std::set<const ImmovableDescr*> recursion_protect = {});
 
 	void register_immovable_relation(const std::string&, const std::string&);
 	void add_became_from(const Descriptions& descriptions, const std::string&);

--- a/src/logic/replay.cc
+++ b/src/logic/replay.cc
@@ -116,7 +116,7 @@ ReplayReader::ReplayReader(Game& game, const std::string& filename) : replaytime
 		gl.preload_game(gpdp);
 		game.set_win_condition_displayname(gpdp.get_win_condition());
 		gl.load_game();
-		game.postload_addons(true);
+		game.postload_addons();
 	}
 
 	if (!g_fs->file_exists(filename)) {

--- a/src/ui_fsmenu/keyboard_options.cc
+++ b/src/ui_fsmenu/keyboard_options.cc
@@ -310,7 +310,7 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 			game_.reset(new Widelands::Game());
 			game_->create_loader_ui({}, false, "", "", this);
 			game_->load_all_tribes();
-			game_->postload_addons(true);
+			game_->postload_addons();
 
 			init_fastplace_default_shortcuts();
 


### PR DESCRIPTION
Should fix #4907 
Should fix #5483

This also fixes a regression in master where you can mark only Old trees but not younger trees for targeted removal.

Please test all the usual regressions - immovable targeting, geologists, SP & MP new games, SP & MP loading, replays, editor, with & without World add-ons, with & without Tribes add-ons.