### PR TITLE
Added static SDL2 targets for transitioning

### DIFF
--- a/cmake/Modules/FindSDL2.cmake
+++ b/cmake/Modules/FindSDL2.cmake
@@ -186,7 +186,7 @@ endif()
 # SDL-2.0 is the name used by FreeBSD ports...
 # don't confuse it for the version number.
 find_library(SDL2_LIBRARY
-  NAMES SDL2 SDL-2.0
+  NAMES SDL2 SDL-2.0 SDL2-static
   HINTS
     ENV SDL2DIR
     ${SDL2_NO_DEFAULT_PATH_CMD}

--- a/cmake/Modules/FindSDL2_image.cmake
+++ b/cmake/Modules/FindSDL2_image.cmake
@@ -166,7 +166,7 @@ endif()
 
 # Search for the SDL2_image library
 find_library(SDL2_IMAGE_LIBRARY
-  NAMES SDL2_image
+  NAMES SDL2_image SDL2_image-static
   HINTS
     ENV SDL2IMAGEDIR
     ENV SDL2DIR

--- a/cmake/Modules/FindSDL2_mixer.cmake
+++ b/cmake/Modules/FindSDL2_mixer.cmake
@@ -164,7 +164,7 @@ endif()
 
 # Search for the SDL2_mixer library
 find_library(SDL2_MIXER_LIBRARY
-  NAMES SDL2_mixer
+  NAMES SDL2_mixer SDL2_mixer-static
   HINTS
     ENV SDL2MIXERDIR
     ENV SDL2DIR

--- a/cmake/Modules/FindSDL2_ttf.cmake
+++ b/cmake/Modules/FindSDL2_ttf.cmake
@@ -166,7 +166,7 @@ endif()
 
 # Search for the SDL2_ttf library
 find_library(SDL2_TTF_LIBRARY
-  NAMES SDL2_ttf
+  NAMES SDL2_ttf SDL2_ttf-static
   HINTS
     ENV SDL2TTFDIR
     ENV SDL2DIR


### PR DESCRIPTION
Fixes msvc builds.
Newer SDL2 versions use a different naming, which resulted in broken builds. For now we can find the libraries with a small addition to the local find modules, but for the future we should consider using the now provided config.cmake modules `find_package(SDL2_mixer CONFIG)`.
Also see the linked topic in the commit.