### PR TITLE
Optimized height calculation for map preview

### DIFF
--- a/src/logic/map.cc
+++ b/src/logic/map.cc
@@ -232,6 +232,15 @@ void Map::recalc_whole_map(const EditorGameBase& egbase) {
 	recalculate_allows_seafaring();
 }
 
+void Map::recalc_whole_map_brightness() {
+	for (int16_t y = 0; y < height_; ++y) {
+		for (int16_t x = 0; x < width_; ++x) {
+			FCoords f = get_fcoords(Coords(x, y));
+			recalc_brightness(f);
+		}
+	}
+}
+
 void Map::recalc_default_resources(const Descriptions& descriptions) {
 	for (int16_t y = 0; y < height_; ++y) {
 		for (int16_t x = 0; x < width_; ++x) {

--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -234,6 +234,7 @@ public:
 	    const std::string& description = _("No description defined"));
 
 	void recalc_whole_map(const EditorGameBase&);
+	void recalc_whole_map_brightness();
 	void recalc_for_field_area(const EditorGameBase&, Area<FCoords>);
 
 	/**

--- a/src/map_io/widelands_map_loader.cc
+++ b/src/map_io/widelands_map_loader.cc
@@ -172,7 +172,7 @@ int32_t WidelandsMapLoader::load_map_for_render(EditorGameBase& egbase, AddOns::
 		p.read(*fs_, egbase, false, *mol_);
 	}
 
-	map_.recalc_whole_map(egbase);
+	map_.recalc_whole_map_brightness();
 
 	return 0;
 }


### PR DESCRIPTION
Optimized solution for #4950. I noticed that the preview now takes much longer, when selecting a map.
This PR reduces the loading time of the map previews: For Europa in Debug builds from ~4900ms to ~450ms in Release builds from ~230ms to ~45ms.