### PR TITLE
Use SDL Relative Mouse Mode

### DIFF
--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -1580,7 +1580,7 @@ bool Panel::ui_mouserelease(const uint8_t button, int32_t x, int32_t y) {
  * panel.
  */
 bool Panel::ui_mousemove(
-   uint8_t const state, int32_t x, int32_t y, int32_t const xdiff, int32_t const ydiff) {
+   uint8_t const state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) {
 	if (!allow_user_input_) {
 		return true;
 	}
@@ -1594,7 +1594,16 @@ bool Panel::ui_mousemove(
 		return false;
 	}
 
-	return p->do_mousemove(state, x, y, xdiff, ydiff);
+	int factor = 1;
+	if (WLApplication::get()->is_mouse_locked()) {
+		if (matches_keymod(SDL_GetModState(), KMOD_CTRL)) {
+			factor = 4;
+		} else if (!matches_keymod(SDL_GetModState(), KMOD_SHIFT)) {
+			factor = 2;
+		}
+	}
+
+	return p->do_mousemove(state, x, y, xdiff * factor, ydiff * factor);
 }
 
 /**

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -1579,8 +1579,7 @@ bool Panel::ui_mouserelease(const uint8_t button, int32_t x, int32_t y) {
  * Input callback function. Pass the mousemove event to the currently modal
  * panel.
  */
-bool Panel::ui_mousemove(
-   uint8_t const state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) {
+bool Panel::ui_mousemove(uint8_t const state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) {
 	if (!allow_user_input_) {
 		return true;
 	}

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1085,8 +1085,6 @@ void WLApplication::warp_mouse(const Vector2i position) {
 			}
 		}
 	}
-
-
 }
 
 /**

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -851,7 +851,7 @@ void WLApplication::run() {
  *
  * \return true if an event was returned inside ev, false otherwise
  */
-bool WLApplication::poll_event(SDL_Event& ev) {
+bool WLApplication::poll_event(SDL_Event& ev) const {
 	if (SDL_PollEvent(&ev) == 0) {
 		return false;
 	}

--- a/src/wlapplication.h
+++ b/src/wlapplication.h
@@ -178,6 +178,9 @@ struct WLApplication {
 
 	/// Lock the mouse cursor into place (e.g., for scrolling the map)
 	void set_mouse_lock(bool locked);
+	bool is_mouse_locked() const {
+		return mouse_locked_;
+	}
 	// @}
 
 	const std::string& get_datadir() const {
@@ -254,10 +257,6 @@ private:
 	/// If true, the mouse cursor will \e not move with a mousemotion event:
 	/// instead, the map will be scrolled
 	bool mouse_locked_;
-
-	/// If the mouse needs to be moved in warp_mouse(), this Vector2i is
-	/// used to cancel the resulting SDL_MouseMotionEvent.
-	Vector2i mouse_compensate_warp_;
 
 	/// Makes it possible to disable the fullscreen and screenshot shortcuts
 	bool handle_key_enabled_;

--- a/src/wlapplication.h
+++ b/src/wlapplication.h
@@ -207,7 +207,7 @@ struct WLApplication {
 private:
 	WLApplication(int argc, char const* const* argv);
 
-	bool poll_event(SDL_Event&);
+	bool poll_event(SDL_Event&) const;
 
 	bool init_settings();
 	void init_language();


### PR DESCRIPTION
Fixes #5410 

Thanks to @attet for the patch. I modified it to make mouse dragging 2× faster (comparable to what it is like in master for those unaffected by the bug). Hold down Ctrl to make dragging faster or Shift to make it slower.

I'm hoping we can have this before the tournament starts ;) 