### PR TITLE
Fix some more spelling errors, in the comments this time

### DIFF
--- a/src/economy/economy.h
+++ b/src/economy/economy.h
@@ -73,7 +73,7 @@ constexpr Quantity kEconomyTargetInfinity = std::numeric_limits<Quantity>::max()
  * and in particular during game shutdown or when a large network is destroyed
  * in a military operation, cascading economy splits could take a lot of processing time.
  * For this reason, economies do not split immediately when a road is destroyed,
- * but instead keep track of where a potential split occured and evaluate the split lazily.
+ * but instead keep track of where a potential split occurred and evaluate the split lazily.
  *
  * This means that two flags which are connected by the road (and seafaring) network
  * are \b always in the same economy, but two flags in the same economy are not always

--- a/src/logic/save_handler.cc
+++ b/src/logic/save_handler.cc
@@ -236,7 +236,7 @@ std::string SaveHandler::create_file_name(const std::string& dir,
  *
  * Will copy text of errors to error string.
  *
- * Returns true if saved, false in case some error occured.
+ * Returns true if saved, false in case some error occurred.
  */
 bool SaveHandler::save_game(Widelands::Game& game,
                             const std::string& complete_filename,

--- a/src/network/internet_gaming.cc
+++ b/src/network/internet_gaming.cc
@@ -836,7 +836,7 @@ bool InternetGaming::update_for_games() {
 	return temp;
 }
 
-/// \returns the tables in the room, if no error occured, or nullptr in case of error
+/// \returns the tables in the room, if no error occurred, or nullptr in case of error
 const std::vector<InternetGame>* InternetGaming::games() {
 	return error() ? nullptr : &gamelist_;
 }
@@ -849,7 +849,7 @@ bool InternetGaming::update_for_clients() {
 	return temp;
 }
 
-/// \returns the players in the room, if no error occured, or nullptr in case of error
+/// \returns the players in the room, if no error occurred, or nullptr in case of error
 const std::vector<InternetClient>* InternetGaming::clients() {
 	return error() ? nullptr : &clientlist_;
 }


### PR DESCRIPTION
Lintian reported that v1.0 that I'm currently packaging has a spelling error on "occured" -> "occurred", so I fixed in in the package. It turns out that this is now fixed in most locations of the git, but some comments. The current PR fixes the remaining locations.