### PR TITLE
Don't warp mouse to dropdown if it's already there

### DIFF
--- a/src/ui_basic/dropdown.cc
+++ b/src/ui_basic/dropdown.cc
@@ -446,7 +446,7 @@ void BaseDropdown::set_value() {
 }
 
 void BaseDropdown::toggle() {
-	set_list_visibility(!list_->is_visible());
+	set_list_visibility(!list_->is_visible(), is_mouse_away());
 }
 
 void BaseDropdown::set_list_visibility(bool open, bool move_mouse) {


### PR DESCRIPTION
Fixes #5535 

Although this is a small change I'd feels safer having this for v1.2 in case there are side-effects. Or is this bug annoying enough to warrant risking it?