### PR TITLE
Remove outdated info that add-on maps should not be zipped

### DIFF
--- a/doc/sphinx/source/add-ons.rst
+++ b/doc/sphinx/source/add-ons.rst
@@ -162,7 +162,6 @@ Please keep the following guidelines in mind to ensure your add-on is well trans
 - Do not concatenate sentence snippets (use placeholders instead).
 - Always use ``ngettext`` when working with plural forms.
 - Use translation markup wisely. All strings meant to be translated should be fetched with ``_("Translate me")`` or  ``pgettext("context", "Translate me")``. Richtext format characters and other strings not meant to be translated should not be marked for translation.
-- Map files should never be zipped so as to ensure that all translatable strings they contain are picked up by the translations update scripts.
 - When any strings might be unclear (e.g. sentence snippets, placeholders), please add a ``TRANSLATORS`` comment above the string.
 
 The Widelands Development Team may occasionally contact add-on developers to inform them about any questions or feedback from the translators.

--- a/src/map_io/map_players_view_packet.cc
+++ b/src/map_io/map_players_view_packet.cc
@@ -58,8 +58,9 @@ void MapPlayersViewPacket::read(FileSystem& fs, EditorGameBase& egbase) {
 	if (!fr.try_open(fs, "binary/view")) {
 		// TODO(Nordfriese): Savegame compatibility – require this packet after v1.0
 		// and suppress this warning when starting a scenario (where it's a false-positive).
-		verb_log_warn("New-style view packet not found. There may be strange effects regarding unseen "
-		              "areas.\n");
+		verb_log_warn(
+		   "New-style view packet not found. There may be strange effects regarding unseen "
+		   "areas.\n");
 		return;
 	}
 

--- a/src/map_io/map_players_view_packet.cc
+++ b/src/map_io/map_players_view_packet.cc
@@ -57,8 +57,9 @@ void MapPlayersViewPacket::read(FileSystem& fs, EditorGameBase& egbase) {
 	FileRead fr;
 	if (!fr.try_open(fs, "binary/view")) {
 		// TODO(Nordfriese): Savegame compatibility – require this packet after v1.0
-		log_warn("New-style view packet not found. There may be strange effects regarding unseen "
-		         "areas.\n");
+		// and suppress this warning when starting a scenario (where it's a false-positive).
+		verb_log_warn("New-style view packet not found. There may be strange effects regarding unseen "
+		              "areas.\n");
 		return;
 	}
 

--- a/src/ui_fsmenu/addons/packager_box.cc
+++ b/src/ui_fsmenu/addons/packager_box.cc
@@ -367,19 +367,6 @@ void MapsAddOnsPackagerBox::clicked_add_or_delete_map_or_dir(const ModifyAction 
 	case ModifyAction::kAddMap: {
 		const std::string& map = my_maps_.get_selected();
 		std::string filename = FileSystem::fs_filename(map.c_str());
-		if (!g_fs->is_directory(map)) {
-			UI::WLMessageBox mbox(
-			   &main_menu_, UI::WindowStyle::kFsMenu, _("Zipped Map"),
-			   format(_("The map ‘%s’ is not a directory. "
-			            "Please consider disabling the ‘Compress Widelands data files’ option "
-			            "in the options menu and resaving the map in the editor."
-			            "\n\nDo you want to add this map anyway?"),
-			          filename),
-			   UI::WLMessageBox::MBoxType::kOkCancel, UI::Align::kLeft);
-			if (mbox.run<UI::Panel::Returncodes>() != UI::Panel::Returncodes::kOk) {
-				return;
-			}
-		}
 		make_valid_addon_filename(filename, tree->maps);
 		tree->maps[filename] = map;
 		select.push_back(filename);


### PR DESCRIPTION
I just deployed a change to the add-ons server that allows us to parse zipped map files for translatable strings. So providing a zipped map is no longer bad practice and no longer needs to be warned against.