### PR TITLE
CI system updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,17 +129,17 @@ jobs:
         compiler: [clang-14, clang-13, g++-12, g++-11]
         include:
           # Some compilers need an older ubuntu version to run correctly
-          - compiler: g++-5
-            os: ubuntu-18.04
+          - compiler: g++-7
+            os: ubuntu-20.04
             config: Debug
-          - compiler: g++-5
-            os: ubuntu-18.04
+          - compiler: g++-7
+            os: ubuntu-20.04
             config: Release
-          - compiler: g++-6
-            os: ubuntu-18.04
+          - compiler: g++-8
+            os: ubuntu-20.04
             config: Debug
-          - compiler: g++-6
-            os: ubuntu-18.04
+          - compiler: g++-8
+            os: ubuntu-20.04
             config: Release
           - compiler: clang-6.0
             os: ubuntu-20.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,17 +129,17 @@ jobs:
         compiler: [clang-14, clang-13, g++-12, g++-11]
         include:
           # Some compilers need an older ubuntu version to run correctly
-          - compiler: g++-7
-            os: ubuntu-20.04
+          - compiler: g++-5
+            os: ubuntu-18.04
             config: Debug
-          - compiler: g++-7
-            os: ubuntu-20.04
+          - compiler: g++-5
+            os: ubuntu-18.04
             config: Release
-          - compiler: g++-8
-            os: ubuntu-20.04
+          - compiler: g++-6
+            os: ubuntu-18.04
             config: Debug
-          - compiler: g++-8
-            os: ubuntu-20.04
+          - compiler: g++-6
+            os: ubuntu-18.04
             config: Release
           - compiler: clang-6.0
             os: ubuntu-20.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,9 +374,9 @@ endif()
 if(NOT MSVC)
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     message(STATUS "Compiler warnings will be ignored.")
-  elseif(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") AND (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)))
+  elseif(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") AND 
+         (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)) AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.2))
     # Skip this on g++12.0 and 12.1 because of false-positives from system headers.
-    # TODO(Nordfriese): As soon as a new g++ version fixes the bug, reenable -Werror for the working version.
     message(WARNING "This compiler is known to cause false-positive warnings.")
   else()
     # Turn some warnings into errors.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   # Installed required libs
-  - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER%/install-dependencies.sh msys%BITS% --noconfirm\""
+  - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER:\=/%/install-dependencies.sh msys%BITS% --noconfirm\""
   # Downgrade incompatible packages to working version
   # - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/%MINGWSUFFIX%/mingw-w64-%MINGWSUFFIX%-libtiff-4.3.0-3-any.pkg.tar.zst\""
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,6 @@ shallow_clone: false
 branches:
   only:
     - master
-    - build_system
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   # Installed required libs
-  - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER:\=/%/install-dependencies.sh msys%BITS% --noconfirm\""
+  - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER:\\=/%/install-dependencies.sh msys%BITS% --noconfirm\""
   # Downgrade incompatible packages to working version
   # - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/%MINGWSUFFIX%/mingw-w64-%MINGWSUFFIX%-libtiff-4.3.0-3-any.pkg.tar.zst\""
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 #   Appveyor build configuration  #
 ###################################
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 init:
   - cmd: "IF \"%PLATFORM%\" == \"x86\" (set MINGWPATH=C:\\msys64\\mingw32\\bin& set MINGWSUFFIX=i686& set MINGWINCLUDE=C:\\msys64\\mingw32\\include& set BITS=32) ELSE (set MINGWPATH=C:\\msys64\\mingw64\\bin& set MINGWSUFFIX=x86_64& set MINGWINCLUDE=C:\\msys64\\mingw64\\include& set BITS=64)"
@@ -26,7 +26,7 @@ install:
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   # Installed required libs
-  - cmd: "bash --login -c \"pacman --noconfirm -S mingw-w64-%MINGWSUFFIX%-ninja mingw-w64-%MINGWSUFFIX%-asio mingw-w64-%MINGWSUFFIX%-icu mingw-w64-%MINGWSUFFIX%-SDL2_ttf mingw-w64-%MINGWSUFFIX%-SDL2_mixer mingw-w64-%MINGWSUFFIX%-SDL2_image mingw-w64-%MINGWSUFFIX%-glew\""
+  - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER%/install-dependencies.sh msys%BITS% --noconfirm\""
   # Downgrade incompatible packages to working version
   # - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/%MINGWSUFFIX%/mingw-w64-%MINGWSUFFIX%-libtiff-4.3.0-3-any.pkg.tar.zst\""
 
@@ -35,6 +35,7 @@ shallow_clone: false
 branches:
   only:
     - master
+    - build_system
 
 skip_tags: true
 


### PR DESCRIPTION
- ~~Github will drop the ubuntu-18.04 image with end of support April 2023. To prevent confusions with failed jobs during the deprecation phase, I propose to already drop g++-5 and g++-6 builds, which require this version.~~ → #5541
- gcc-12.2.0 fixed the false positives, so -Werror can work again
- appveyor now also uses the install script and the latest image ([testbuild](https://ci.appveyor.com/project/widelands-dev/widelands/builds/44657122))