### PR TITLE
Do not delete units during random game loading

### DIFF
--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -330,9 +330,13 @@ void Game::init_newgame(const GameSettings& settings) {
 		maploader = mutable_map()->get_correct_loader(settings.mapfilename);
 		assert(maploader);
 		maploader->preload_map(settings.scenario, &enabled_addons());
+		postload_addons_before_loading();
+	} else {
+		// TODO(matthiakl): Once random games support world Add-Ons, call
+		// postload_addons_before_loading() here as well
+		postload_addons();
+		did_postload_addons_before_loading_ = true;
 	}
-
-	postload_addons_before_loading();
 
 	std::vector<PlayerSettings> shared;
 	std::vector<uint8_t> shared_num;


### PR DESCRIPTION
Fixes #5578 
Reverts a part of #5480 but only for generated maps, so the other saveloading issues should not be affected (please verify). Since map related Add-Ons are disabled for random matches, it should not run into any Add-On description related issues.
I also tried to load the world units again after `postload_addons_before_loading();` (which calls `delete_world_and_tribes()`), but I quickly ran into this issue https://github.com/widelands/widelands/issues/4834#issuecomment-828367446.