### PR TITLE
consume every keydown event in editbox

### DIFF
--- a/src/ui_basic/editbox.cc
+++ b/src/ui_basic/editbox.cc
@@ -623,7 +623,7 @@ void EditBox::draw_caret(RenderTarget& dst, const Vector2i& point, const uint16_
 
 	const Image* caret_image =
 	   g_image_cache->get(panel_style_ == PanelStyle::kWui ? "images/ui_basic/caret_wui.png" :
-	                                                         "images/ui_basic/caret_fs.png");
+                                                            "images/ui_basic/caret_fs.png");
 	Vector2i caretpt = Vector2i::zero();
 	caretpt.x = point.x + m_->scrolloffset + caret_x - caret_image->width() + kLineMargin;
 	caretpt.y = point.y + (fontheight - caret_image->height()) / 2;

--- a/src/ui_basic/editbox.cc
+++ b/src/ui_basic/editbox.cc
@@ -473,7 +473,6 @@ bool EditBox::handle_key(bool const down, SDL_Keysym const code) {
 				}
 			}
 			return true;
-			
 		default:
 			break;
 		}

--- a/src/ui_basic/editbox.cc
+++ b/src/ui_basic/editbox.cc
@@ -473,13 +473,14 @@ bool EditBox::handle_key(bool const down, SDL_Keysym const code) {
 				}
 			}
 			return true;
-
+			
 		default:
 			break;
 		}
+		return true;
 	}
 
-	return false;
+	return Panel::handle_key(down, code);
 }
 void EditBox::copy_selected_text() {
 	uint32_t start;
@@ -623,7 +624,7 @@ void EditBox::draw_caret(RenderTarget& dst, const Vector2i& point, const uint16_
 
 	const Image* caret_image =
 	   g_image_cache->get(panel_style_ == PanelStyle::kWui ? "images/ui_basic/caret_wui.png" :
-                                                            "images/ui_basic/caret_fs.png");
+	                                                         "images/ui_basic/caret_fs.png");
 	Vector2i caretpt = Vector2i::zero();
 	caretpt.x = point.x + m_->scrolloffset + caret_x - caret_image->width() + kLineMargin;
 	caretpt.y = point.y + (fontheight - caret_image->height()) / 2;


### PR DESCRIPTION
Fixes #5585 
Consume every keydown event like `multilineeditbox` does.
Alternative approach could be to only add handling of ctrl keystrokes to the switch statement:

```
case SDLK_LCTRL:
case SDLK_RCTRL:
	return true;
```
But that would enable other funny side effects like:

- hit `CTRL` + `S` while textbox is in focus -> shortkey for saving the game is triggered (kind of okay maybe)
- hit `CTRL` + `+` while textbox is in focus -> map is zoomed in while `+` is added to the textbook (iirgh)
- hit `CTRL` + `-` while textbox is in focus -> map is zoomed out while `-` is added to the textbook (iirgh)
- probably other stuff

so I am in favor to consume all keystrokes :)