### PR TITLE
Cancel battles when players negotiate truce

### DIFF
--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -988,6 +988,12 @@ void Soldier::attack_update(Game& game, State& state) {
 
 	// Count remaining defenders
 	if (enemy != nullptr) {
+		if (!owner().is_hostile(enemy->owner())) {
+			/* The players agreed on a truce. */
+			molog(game.get_gametime(), "[attack] opponent is an ally, cancel attack");
+			return pop_task(game);
+		}
+
 		if (enemy->soldier_control() != nullptr) {
 			defenders = enemy->soldier_control()->present_soldiers().size();
 		}
@@ -1440,6 +1446,11 @@ void Soldier::battle_update(Game& game, State& /* state */) {
 
 	const Map& map = game.map();
 	Soldier& opponent = *battle_->opponent(*this);
+	if (!owner().is_hostile(opponent.owner())) {
+		/* The players agreed on a truce. */
+		molog(game.get_gametime(), "[battle] opponent is an ally, cancel battle");
+		return pop_task(game);
+	}
 	if (opponent.get_position() != get_position()) {
 		const MapObject* mo = map[get_position()].get_immovable();
 		if ((mo != nullptr) && mo->descr().type() >= MapObjectType::BUILDING) {

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -991,6 +991,7 @@ void Soldier::attack_update(Game& game, State& state) {
 		if (!owner().is_hostile(enemy->owner())) {
 			/* The players agreed on a truce. */
 			molog(game.get_gametime(), "[attack] opponent is an ally, cancel attack");
+			combat_walking_ = CD_NONE;
 			return pop_task(game);
 		}
 
@@ -1449,6 +1450,7 @@ void Soldier::battle_update(Game& game, State& /* state */) {
 	if (!owner().is_hostile(opponent.owner())) {
 		/* The players agreed on a truce. */
 		molog(game.get_gametime(), "[battle] opponent is an ally, cancel battle");
+		combat_walking_ = CD_NONE;
 		return pop_task(game);
 	}
 	if (opponent.get_position() != get_position()) {


### PR DESCRIPTION
Fixes a bug observed in the Battle Royale: If two players use diplomacy to become allies while their soldiers are fighting each other, the battles stall because the soldiers neither attack nor retreat. Now soldiers abort both attacks and ongoing battles when a truce comes into effect.

As a side effect, this is the only situation how a battle can end with both participants still alive. So you can use this as a tactic to save a valuable soldier, assuming the other player lets you.