### PR TITLE
Switch to C++17

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,10 +141,10 @@ jobs:
           - compiler: g++-8
             os: ubuntu-20.04
             config: Release
-          - compiler: clang-6.0
+          - compiler: clang-8
             os: ubuntu-20.04
             config: Debug
-          - compiler: clang-6.0
+          - compiler: clang-8
             os: ubuntu-20.04
             config: Release
           - compiler: clang-7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ else()
   # Assuming GCC 4.8 or higher.
   if(WIN32)
     # This is needed for getenv().
-    wl_add_flag(WL_GENERIC_CXX_FLAGS "-std=gnu++11")
+    wl_add_flag(WL_GENERIC_CXX_FLAGS "-std=gnu++17")
     if (OPTION_BUILD_WINSTATIC)
       set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc -static-libstdc++ ${CMAKE_CXX_STANDARD_LIBRARIES}")
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bstatic")
@@ -397,7 +397,7 @@ if(NOT MSVC)
     endif()
   endif()
 
-  wl_add_flag(WL_GENERIC_CXX_FLAGS "-std=c++11")
+  wl_add_flag(WL_GENERIC_CXX_FLAGS "-std=c++17")
 endif()
 
 # Cross-compile-unit optimization slows linking significantly.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ On how to download Widelands, see https://www.widelands.org/wiki/Download/
 
 ## Compiling
 
-We support compiling Widelands for Linux, Windows under MSys2, and MacOs with GCC >= 5 or Clang/LLVM >= 6, though it might work with other compilers too. We have more detailed documentation available at: https://www.widelands.org/wiki/BuildingWidelands/
+We support compiling Widelands for Linux, Windows under MSys2 and MSVC, and MacOS with GCC >= 7 or Clang/LLVM >= 7, though it might work with other compilers too. We have more detailed documentation available at: https://www.widelands.org/wiki/BuildingWidelands/
 
 
 ### Dependencies

--- a/utils/check_clang_tidy_results.py
+++ b/utils/check_clang_tidy_results.py
@@ -87,7 +87,10 @@ SUPPRESSED_CHECKS = {
     '[readability-const-return-type]',
     '[readability-convert-member-functions-to-static]',
     '[readability-function-size]',
-    '[readability-magic-numbers]'
+    '[readability-magic-numbers]',
+    '[modernize-use-nodiscard]',
+    '[readability-redundant-declaration]',
+    '[modernize-concat-nested-namespaces]'
 }
 
 CHECK_REGEX = re.compile(r'.*\[([A-Za-z0-9.-]+)\]$')


### PR DESCRIPTION
We no longer support Xenial, so we should finally be able unlock those goodies like init statements in `if`, enhanced variadic templates, the `optional` and `any` types, and much more.