### PR TITLE
Fix clang-tidy C++17 checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     wl_add_flag(WL_COMPILE_DIAGNOSTICS "-Winconsistent-missing-override")
   endif()
 elseif(MSVC)
+  wl_add_flag(WL_GENERIC_CXX_FLAGS "/std:c++17")
   # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/
   # Disabled warnings that are overly verbose right now or just do not make sense.
   wl_add_flag(WL_COMPILE_DIAGNOSTICS "/wd4244")

--- a/src/ai/ai_help_structs.h
+++ b/src/ai/ai_help_structs.h
@@ -136,12 +136,12 @@ constexpr uint16_t kWhNotReachable = 500;
 struct CheckStepRoadAI {
 	CheckStepRoadAI(Widelands::Player* const pl, uint8_t const mc, bool const oe);
 
-	bool allowed(const Widelands::Map&,
+	[[nodiscard]] bool allowed(const Widelands::Map&,
 	             Widelands::FCoords start,
 	             Widelands::FCoords end,
 	             int32_t dir,
 	             Widelands::CheckStep::StepId) const;
-	bool reachable_dest(const Widelands::Map&, const Widelands::FCoords& dest) const;
+	[[nodiscard]] bool reachable_dest(const Widelands::Map&, const Widelands::FCoords& dest) const;
 
 	Widelands::Player* player;
 	uint8_t movecaps;
@@ -154,12 +154,12 @@ struct CheckStepRoadAI {
 struct CheckStepOwnTerritory {
 	CheckStepOwnTerritory(Widelands::Player* const pl, uint8_t const mc, bool const oe);
 
-	bool allowed(const Widelands::Map&,
+	[[nodiscard]] bool allowed(const Widelands::Map&,
 	             Widelands::FCoords start,
 	             Widelands::FCoords end,
 	             int32_t dir,
 	             Widelands::CheckStep::StepId) const;
-	bool reachable_dest(const Widelands::Map&, const Widelands::FCoords& dest) const;
+	[[nodiscard]] bool reachable_dest(const Widelands::Map&, const Widelands::FCoords& dest) const;
 
 	Widelands::Player* player;
 	uint8_t movecaps;
@@ -171,7 +171,7 @@ struct CheckStepOwnTerritory {
 struct FindNodeEnemy {
 	FindNodeEnemy(Widelands::Player* p, Widelands::Game& g);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Player* player;
 	Widelands::Game& game;
@@ -184,7 +184,7 @@ struct FindNodeEnemy {
 struct FindNodeEnemiesBuilding {
 	FindNodeEnemiesBuilding(Widelands::Player* p, Widelands::Game& g);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Player* player;
 	Widelands::Game& game;
@@ -194,7 +194,7 @@ struct FindNodeEnemiesBuilding {
 struct FindEnemyNodeWalkable {
 	FindEnemyNodeWalkable(Widelands::Player* p, Widelands::Game& g);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Player* player;
 	Widelands::Game& game;
@@ -204,7 +204,7 @@ struct FindEnemyNodeWalkable {
 struct FindNodeAllyOwned {
 	FindNodeAllyOwned(Widelands::Player* p, Widelands::Game& g, Widelands::PlayerNumber n);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Player* player;
 	Widelands::Game& game;
@@ -219,7 +219,7 @@ struct FindNodeUnownedMineable {
 	                        Widelands::Game& g,
 	                        int32_t t = Widelands::INVALID_INDEX);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Player* player;
 	Widelands::Game& game;
@@ -231,7 +231,7 @@ struct FindNodeUnownedMineable {
 struct FindNodeUnownedBuildable {
 	FindNodeUnownedBuildable(Widelands::Player* p, Widelands::Game& g);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Player* player;
 	Widelands::Game& game;
@@ -241,7 +241,7 @@ struct FindNodeUnownedBuildable {
 struct FindNodeUnownedWalkable {
 	FindNodeUnownedWalkable(Widelands::Player* p, Widelands::Game& g);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Player* player;
 	Widelands::Game& game;
@@ -252,7 +252,7 @@ struct FindNodeUnownedWalkable {
 struct FindNodeMineable {
 	FindNodeMineable(Widelands::Game& g, Widelands::DescriptionIndex r);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& fc) const;
 
 	Widelands::Game& game;
 	int32_t res;
@@ -262,7 +262,7 @@ struct FindNodeMineable {
 struct FindNodeWater {
 	explicit FindNodeWater(const Widelands::Descriptions& descriptions);
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& coord) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& coord) const;
 
 private:
 	const Widelands::Descriptions& descriptions_;
@@ -275,16 +275,16 @@ struct FindNodeOpenWater {
 	explicit FindNodeOpenWater(const Widelands::Descriptions& /* descriptions */) {
 	}
 
-	bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& coord) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& coord) const;
 };
 
 struct FindNodeWithFlagOrRoad {
-	bool accept(const Widelands::EditorGameBase&, Widelands::FCoords) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, Widelands::FCoords) const;
 };
 
 // Accepts any field
 struct FindNodeAcceptAll {
-	bool accept(const Widelands::EditorGameBase&, Widelands::FCoords) const {
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, Widelands::FCoords) const {
 		return true;
 	}
 };
@@ -625,7 +625,7 @@ struct EnemySiteObserver {
 struct MineTypesObserver {
 	MineTypesObserver();
 
-	uint16_t total_count() const;
+	[[nodiscard]] uint16_t total_count() const;
 
 	uint16_t in_construction;
 	uint16_t finished;
@@ -760,7 +760,7 @@ struct ManagementData {
 		ai_training_mode_ = true;
 	}
 
-	int16_t get_military_number_at(uint8_t) const;
+	[[nodiscard]] int16_t get_military_number_at(uint8_t) const;
 	void set_military_number_at(uint8_t, int16_t) const;
 	MutatingIntensity do_mutate(bool, int16_t);
 	int8_t shift_weight_value(int8_t, bool = true);
@@ -927,7 +927,7 @@ private:
 		// Saying the road was built and when
 		void set_road_built(const Time&);
 		// Asking if road can be built from this flag (providing current gametime)
-		bool is_road_prohibited(const Time&) const;
+		[[nodiscard]] bool is_road_prohibited(const Time&) const;
 		// get current distance (providing current gametime)
 		uint16_t get(const Time&, uint32_t*) const;
 	};
@@ -942,7 +942,7 @@ public:
 	int16_t get_wh_distance(uint32_t flag_coords, const Time& gametime, uint32_t* nw);
 	void set_road_built(uint32_t coords_hash, const Time& gametime);
 	bool is_road_prohibited(uint32_t coords_hash, const Time& gametime);
-	uint16_t count() const;
+	[[nodiscard]] uint16_t count() const;
 	bool remove_old_flag(const Time& gametime);
 };
 
@@ -965,7 +965,7 @@ struct FlagCandidates {
 		uint16_t possible_road_distance;
 		uint16_t cand_flag_distance_to_wh;
 		// Scoring is considering multiple things
-		int16_t score() const;
+		[[nodiscard]] int16_t score() const;
 		bool is_buildable() {
 			return possible_road_distance > 0;
 		}
@@ -979,10 +979,10 @@ private:
 	uint16_t start_flag_dist_to_wh;
 
 public:
-	const std::vector<Candidate>& flags() const {
+	[[nodiscard]] const std::vector<Candidate>& flags() const {
 		return flags_;
 	}
-	bool has_candidate(uint32_t) const;
+	[[nodiscard]] bool has_candidate(uint32_t) const;
 	void add_flag(uint32_t, bool, uint16_t, uint16_t);
 	bool set_cur_road_distance(uint32_t, uint16_t);
 	bool set_road_possible(uint32_t, uint16_t);

--- a/src/ai/ai_help_structs.h
+++ b/src/ai/ai_help_structs.h
@@ -137,10 +137,10 @@ struct CheckStepRoadAI {
 	CheckStepRoadAI(Widelands::Player* const pl, uint8_t const mc, bool const oe);
 
 	[[nodiscard]] bool allowed(const Widelands::Map&,
-	             Widelands::FCoords start,
-	             Widelands::FCoords end,
-	             int32_t dir,
-	             Widelands::CheckStep::StepId) const;
+	                           Widelands::FCoords start,
+	                           Widelands::FCoords end,
+	                           int32_t dir,
+	                           Widelands::CheckStep::StepId) const;
 	[[nodiscard]] bool reachable_dest(const Widelands::Map&, const Widelands::FCoords& dest) const;
 
 	Widelands::Player* player;
@@ -155,10 +155,10 @@ struct CheckStepOwnTerritory {
 	CheckStepOwnTerritory(Widelands::Player* const pl, uint8_t const mc, bool const oe);
 
 	[[nodiscard]] bool allowed(const Widelands::Map&,
-	             Widelands::FCoords start,
-	             Widelands::FCoords end,
-	             int32_t dir,
-	             Widelands::CheckStep::StepId) const;
+	                           Widelands::FCoords start,
+	                           Widelands::FCoords end,
+	                           int32_t dir,
+	                           Widelands::CheckStep::StepId) const;
 	[[nodiscard]] bool reachable_dest(const Widelands::Map&, const Widelands::FCoords& dest) const;
 
 	Widelands::Player* player;
@@ -262,7 +262,8 @@ struct FindNodeMineable {
 struct FindNodeWater {
 	explicit FindNodeWater(const Widelands::Descriptions& descriptions);
 
-	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& coord) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&,
+	                          const Widelands::FCoords& coord) const;
 
 private:
 	const Widelands::Descriptions& descriptions_;
@@ -275,7 +276,8 @@ struct FindNodeOpenWater {
 	explicit FindNodeOpenWater(const Widelands::Descriptions& /* descriptions */) {
 	}
 
-	[[nodiscard]] bool accept(const Widelands::EditorGameBase&, const Widelands::FCoords& coord) const;
+	[[nodiscard]] bool accept(const Widelands::EditorGameBase&,
+	                          const Widelands::FCoords& coord) const;
 };
 
 struct FindNodeWithFlagOrRoad {

--- a/src/ai/ai_hints.h
+++ b/src/ai/ai_hints.h
@@ -37,52 +37,52 @@ struct BuildingHints {
 	~BuildingHints() {
 	}
 
-	bool needs_water() const {
+	[[nodiscard]] bool needs_water() const {
 		return needs_water_;
 	}
 
-	bool is_space_consumer() const {
+	[[nodiscard]] bool is_space_consumer() const {
 		return space_consumer_;
 	}
-	bool is_expansion_type() const {
+	[[nodiscard]] bool is_expansion_type() const {
 		return expansion_;
 	}
-	bool is_fighting_type() const {
+	[[nodiscard]] bool is_fighting_type() const {
 		return fighting_;
 	}
-	bool is_mountain_conqueror() const {
+	[[nodiscard]] bool is_mountain_conqueror() const {
 		return mountain_conqueror_;
 	}
 
-	bool requires_supporters() const {
+	[[nodiscard]] bool requires_supporters() const {
 		return requires_supporters_;
 	}
 
-	bool is_shipyard() const {
+	[[nodiscard]] bool is_shipyard() const {
 		return shipyard_;
 	}
 
-	bool supports_seafaring() const {
+	[[nodiscard]] bool supports_seafaring() const {
 		return supports_seafaring_;
 	}
 
-	uint32_t get_prohibited_till() const {
+	[[nodiscard]] uint32_t get_prohibited_till() const {
 		return prohibited_till_;
 	}
 
-	uint32_t basic_amount() const {
+	[[nodiscard]] uint32_t basic_amount() const {
 		return basic_amount_;
 	}
 
-	uint32_t get_forced_after() const {
+	[[nodiscard]] uint32_t get_forced_after() const {
 		return forced_after_;
 	}
 
-	int16_t get_ai_limit(AiType) const;
+	[[nodiscard]] int16_t get_ai_limit(AiType) const;
 
 	void set_trainingsites_max_percent(int percent);
 
-	uint8_t trainingsites_max_percent() const;
+	[[nodiscard]] uint8_t trainingsites_max_percent() const;
 
 private:
 	const bool needs_water_;

--- a/src/ai/computer_player.h
+++ b/src/ai/computer_player.h
@@ -51,7 +51,7 @@ struct ComputerPlayer {
 
 	virtual void think() = 0;
 
-	Widelands::Game& game() const {
+	[[nodiscard]] Widelands::Game& game() const {
 		return game_;
 	}
 	Widelands::PlayerNumber player_number() {

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -84,15 +84,6 @@ namespace AI {
 
 // Fix undefined references
 
-
-
-
-
-
-
-
-
-
 DefaultAI::NormalImpl DefaultAI::normal_impl;
 DefaultAI::WeakImpl DefaultAI::weak_impl;
 DefaultAI::VeryWeakImpl DefaultAI::very_weak_impl;

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -83,15 +83,15 @@ constexpr int kMineTypes = 4;
 namespace AI {
 
 // Fix undefined references
-constexpr Duration DefaultAI::kManagementUpdateInterval;
-constexpr Duration DefaultAI::kStatUpdateInterval;
-constexpr Duration DefaultAI::kFlagWarehouseUpdInterval;
-constexpr Duration DefaultAI::kExpeditionMinDuration;
-constexpr Duration DefaultAI::kExpeditionMaxDuration;
-constexpr Duration DefaultAI::kShipCheckInterval;
-constexpr Duration DefaultAI::kCampaignDuration;
-constexpr Duration DefaultAI::kTrainingSitesCheckInterval;
-constexpr Duration DefaultAI::kDiplomacyInterval;
+
+
+
+
+
+
+
+
+
 
 DefaultAI::NormalImpl DefaultAI::normal_impl;
 DefaultAI::WeakImpl DefaultAI::weak_impl;

--- a/src/base/format/tree.h
+++ b/src/base/format/tree.h
@@ -117,7 +117,7 @@ public:
 		return *t;
 	}
 
-	template <typename... Args> std::string format(const bool localize, Args... args) const {
+	template <typename... Args> [[nodiscard]] std::string format(const bool localize, Args... args) const {
 		char* out(buffer_);
 		bool hit_last_arg = false;
 
@@ -142,7 +142,7 @@ public:
 		return buffer_;
 	}
 
-	std::string format(const bool localize, const ArgsVector& args) const {
+	[[nodiscard]] std::string format(const bool localize, const ArgsVector& args) const {
 		if (args.size() != format_nodes_count_) {
 			throw wexception("Wrong number of arguments: expected %u, found %u", format_nodes_count_,
 			                 static_cast<unsigned>(args.size()));
@@ -167,7 +167,7 @@ public:
 		return buffer_;
 	}
 
-	inline unsigned get_nodes_count() const {
+	[[nodiscard]] inline unsigned get_nodes_count() const {
 		return format_nodes_count_;
 	}
 

--- a/src/base/format/tree.h
+++ b/src/base/format/tree.h
@@ -117,7 +117,8 @@ public:
 		return *t;
 	}
 
-	template <typename... Args> [[nodiscard]] std::string format(const bool localize, Args... args) const {
+	template <typename... Args>
+	[[nodiscard]] std::string format(const bool localize, Args... args) const {
 		char* out(buffer_);
 		bool hit_last_arg = false;
 

--- a/src/base/md5.h
+++ b/src/base/md5.h
@@ -42,7 +42,7 @@ struct Md5Ctx {
 struct Md5Checksum {
 	uint8_t data[16];
 
-	std::string str() const;
+	[[nodiscard]] std::string str() const;
 
 	bool operator==(const Md5Checksum& o) const {
 		return memcmp(data, o.data, sizeof(data)) == 0;
@@ -110,7 +110,7 @@ public:
 	/// before this function.
 	///
 	/// \return a pointer to an array of 16 bytes containing the checksum.
-	const Md5Checksum& get_checksum() const {
+	[[nodiscard]] const Md5Checksum& get_checksum() const {
 		assert(!can_handle_data);
 		return sum;
 	}

--- a/src/base/rect.h
+++ b/src/base/rect.h
@@ -35,27 +35,27 @@ template <typename T> struct Rect {
 	}
 
 	/// The Vector2i (x, y).
-	Vector2<T> origin() const {
+	[[nodiscard]] Vector2<T> origin() const {
 		return Vector2<T>(x, y);
 	}
 
 	/// The point (x + w, y + h).
-	Vector2<T> opposite_of_origin() const {
+	[[nodiscard]] Vector2<T> opposite_of_origin() const {
 		return Vector2<T>(x + w, y + h);
 	}
 
 	/// Returns true if this rectangle contains the given point.
 	/// The bottom and right borders of the rectangle are considered to be excluded.
-	template <typename PointType> bool contains(const Vector2<PointType>& pt) const {
+	template <typename PointType> [[nodiscard]] bool contains(const Vector2<PointType>& pt) const {
 		return T(pt.x) >= x && T(pt.x) < x + w && T(pt.y) >= y && T(pt.y) < y + h;
 	}
 
 	// The center point of 'r'.
-	Vector2f center() const {
+	[[nodiscard]] Vector2f center() const {
 		return Vector2f(x + w / 2.f, y + h / 2.f);
 	}
 
-	template <typename Type> Rect<Type> cast() const {
+	template <typename Type> [[nodiscard]] [[nodiscard]] Rect<Type> cast() const {
 		return Rect<Type>(Type(x), Type(y), Type(w), Type(h));
 	}
 

--- a/src/base/times.h
+++ b/src/base/times.h
@@ -99,7 +99,7 @@ struct Duration {
 		return Duration(get() / d);
 	}
 
-	uint32_t get() const {
+	[[nodiscard]] uint32_t get() const {
 		return value_.load();
 	}
 
@@ -123,10 +123,10 @@ struct Duration {
 	}
 
 	// Special values
-	inline bool is_invalid() const {
+	[[nodiscard]] inline bool is_invalid() const {
 		return *this == Duration();
 	}
-	inline bool is_valid() const {
+	[[nodiscard]] inline bool is_valid() const {
 		return !is_invalid();
 	}
 
@@ -181,7 +181,7 @@ struct Time {
 		return Duration(get() - t.get());
 	}
 
-	uint32_t get() const {
+	[[nodiscard]] uint32_t get() const {
 		return value_;
 	}
 
@@ -212,10 +212,10 @@ struct Time {
 	}
 
 	// Special values
-	inline bool is_invalid() const {
+	[[nodiscard]] inline bool is_invalid() const {
 		return *this == Time();
 	}
-	inline bool is_valid() const {
+	[[nodiscard]] inline bool is_valid() const {
 		return !is_invalid();
 	}
 

--- a/src/base/vector.h
+++ b/src/base/vector.h
@@ -75,7 +75,7 @@ template <typename T> struct Vector2 {
 		return *this;
 	}
 
-	template <typename Type> Vector2<Type> cast() const {
+	template <typename Type> [[nodiscard]] Vector2<Type> cast() const {
 		return Vector2<Type>(Type(x), Type(y));
 	}
 
@@ -110,7 +110,7 @@ struct Vector3f {
 	}
 
 	// inner product
-	float dot(const Vector3f& other) const {
+	[[nodiscard]] float dot(const Vector3f& other) const {
 		return x * other.x + y * other.y + z * other.z;
 	}
 

--- a/src/base/warning.h
+++ b/src/base/warning.h
@@ -39,8 +39,8 @@ struct WLWarning : public std::exception {
 
 	/// The target of the returned pointer remains valid during the lifetime of
 	/// the warning object.
-	virtual const char* title() const;
-	const char* what() const noexcept override;
+	[[nodiscard]] virtual const char* title() const;
+	[[nodiscard]] const char* what() const noexcept override;
 
 protected:
 	WLWarning() {

--- a/src/base/wexception.h
+++ b/src/base/wexception.h
@@ -45,7 +45,7 @@ public:
 	 * The target of the returned pointer remains valid during the lifetime of
 	 * the WException object.
 	 */
-	const char* what() const noexcept override;
+	[[nodiscard]] const char* what() const noexcept override;
 
 protected:
 	WException() {

--- a/src/chat/chat.h
+++ b/src/chat/chat.h
@@ -72,7 +72,7 @@ struct ChatProvider {
 	// This list need not be stable or monotonic. In other words,
 	// subsequent calls to this functions may return a smaller or
 	// greater number of chat messages.
-	virtual const std::vector<ChatMessage>& get_messages() const = 0;
+	[[nodiscard]] virtual const std::vector<ChatMessage>& get_messages() const = 0;
 
 	// reimplemented e.g. in internet_gaming to silence the chat if in game.
 	// TODO(sirver): this does not belong here. The receiver of the
@@ -82,7 +82,7 @@ struct ChatProvider {
 	}
 
 	// The specific chat provider subclass might not have been set, e.g. due to an exception.
-	virtual bool has_been_set() const {
+	[[nodiscard]] virtual bool has_been_set() const {
 		return false;
 	}
 

--- a/src/economy/cmd_call_economy_balance.h
+++ b/src/economy/cmd_call_economy_balance.h
@@ -33,7 +33,7 @@ struct CmdCallEconomyBalance : public GameLogicCommand {
 
 	void execute(Game&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kCallEconomyBalance;
 	}
 

--- a/src/economy/economy.h
+++ b/src/economy/economy.h
@@ -112,15 +112,15 @@ public:
 	explicit Economy(Player&, Serial serial, WareWorker);  // For saveloading
 	~Economy();
 
-	Serial serial() const {
+	[[nodiscard]] Serial serial() const {
 		return serial_;
 	}
 
-	Player& owner() const {
+	[[nodiscard]] Player& owner() const {
 		return owner_;
 	}
 
-	WareWorker type() const {
+	[[nodiscard]] WareWorker type() const {
 		return type_;
 	}
 
@@ -135,7 +135,7 @@ public:
 	                                  uint32_t cost_cutoff = 0,
 	                                  const WarehouseAcceptFn& acceptfn = WarehouseAcceptFn());
 
-	std::vector<Flag*>::size_type get_nrflags() const {
+	[[nodiscard]] std::vector<Flag*>::size_type get_nrflags() const {
 		return flags_.size();
 	}
 	void add_flag(Flag&);
@@ -153,7 +153,7 @@ public:
 
 	void add_warehouse(Warehouse&);
 	void remove_warehouse(Warehouse&);
-	const std::vector<Warehouse*>& warehouses() const {
+	[[nodiscard]] const std::vector<Warehouse*>& warehouses() const {
 		return warehouses_;
 	}
 
@@ -171,28 +171,28 @@ public:
 	/// Whether the economy needs more of this ware/worker type.
 	/// Productionsites may ask this before they produce, to avoid depleting a
 	/// ware type by overproducing another from it.
-	bool needs_ware_or_worker(DescriptionIndex) const;
+	[[nodiscard]] bool needs_ware_or_worker(DescriptionIndex) const;
 
-	const TargetQuantity& target_quantity(DescriptionIndex const i) const {
+	[[nodiscard]] const TargetQuantity& target_quantity(DescriptionIndex const i) const {
 		return target_quantities_[i];
 	}
 	TargetQuantity& target_quantity(DescriptionIndex const i) {
 		return target_quantities_[i];
 	}
 
-	void* get_options_window() const {
+	[[nodiscard]] void* get_options_window() const {
 		return options_window_;
 	}
 	void set_options_window(void* window) {
 		options_window_ = window;
 	}
 
-	const WareList& get_wares_or_workers() const {
+	[[nodiscard]] const WareList& get_wares_or_workers() const {
 		return wares_or_workers_;
 	}
 
 	// Checks whether this economy contains a building of the specified type
-	bool has_building(DescriptionIndex) const;
+	[[nodiscard]] bool has_building(DescriptionIndex) const;
 	/**
 	 * Of all occupied ProductionSites of the specified type in this economy,
 	 * find the one that is closest to the specified flag and return it.

--- a/src/economy/expedition_bootstrap.h
+++ b/src/economy/expedition_bootstrap.h
@@ -68,15 +68,15 @@ public:
 	void set_economy(Economy* economy, WareWorker);
 
 	// Returns the wares and workers currently waiting for the expedition.
-	std::vector<InputQueue*> queues(bool all) const;
+	[[nodiscard]] std::vector<InputQueue*> queues(bool all) const;
 
 	// Returns the matching input queue for the given index and type.
-	InputQueue& inputqueue(DescriptionIndex index, WareWorker type, bool) const;
-	InputQueue* inputqueue(size_t additional_index) const;
-	InputQueue& inputqueue(const Request&) const;
+	[[nodiscard]] InputQueue& inputqueue(DescriptionIndex index, WareWorker type, bool) const;
+	[[nodiscard]] InputQueue* inputqueue(size_t additional_index) const;
+	[[nodiscard]] InputQueue& inputqueue(const Request&) const;
 
 	void demand_additional_item(Game&, WareWorker, DescriptionIndex, bool);
-	size_t count_additional_queues() const;
+	[[nodiscard]] size_t count_additional_queues() const;
 
 	// Tests if all wares for the expedition have arrived. If so, informs the portdock.
 	void check_is_ready(Game& game);

--- a/src/economy/ferry_fleet.cc
+++ b/src/economy/ferry_fleet.cc
@@ -99,7 +99,7 @@ struct StepEvalFindFerryFleet {
 	int32_t estimate(Map& /* map */, FCoords /* pos */) const {
 		return 0;
 	}
-	int32_t stepcost(
+	[[nodiscard]] int32_t stepcost(
 	   const Map& map, FCoords from, int32_t /* fromcost */, WalkingDir dir, FCoords to) const {
 		return checkstep_->allowed(map, from, to, dir, CheckStep::StepId::stepNormal) ? 1 : -1;
 	}

--- a/src/economy/idleworkersupply.h
+++ b/src/economy/idleworkersupply.h
@@ -31,13 +31,13 @@ struct IdleWorkerSupply : public Supply {
 	void set_economy(Economy*);
 	PlayerImmovable* get_position(Game&) override;
 
-	bool is_active() const override;
+	[[nodiscard]] bool is_active() const override;
 	SupplyProviders provider_type(Game*) const override;
-	bool has_storage() const override;
+	[[nodiscard]] bool has_storage() const override;
 	void get_ware_type(WareWorker& type, DescriptionIndex& ware) const override;
 	void send_to_storage(Game&, Warehouse* wh) override;
 
-	uint32_t nr_supplies(const Game&, const Request&) const override;
+	[[nodiscard]] uint32_t nr_supplies(const Game&, const Request&) const override;
 	WareInstance& launch_ware(Game&, const Request&) override;
 	Worker& launch_worker(Game&, const Request&) override;
 

--- a/src/economy/input_queue.h
+++ b/src/economy/input_queue.h
@@ -61,7 +61,7 @@ public:
 	 * Returns the index of the ware or worker which is handled by the queue.
 	 * @return The DescriptionIndex of whatever is stored here.
 	 */
-	DescriptionIndex get_index() const {
+	[[nodiscard]] DescriptionIndex get_index() const {
 		return index_;
 	}
 
@@ -70,7 +70,7 @@ public:
 	 * This is a value which can be influenced by the player with the provided buttons.
 	 * @return The maximum number of wares or workers which should be here.
 	 */
-	Quantity get_max_fill() const {
+	[[nodiscard]] Quantity get_max_fill() const {
 		return max_fill_;
 	}
 
@@ -78,7 +78,7 @@ public:
 	 * Whether wares or workers are stored in this queue.
 	 * @return Whether wares or workers are stored in this queue.
 	 */
-	WareWorker get_type() const {
+	[[nodiscard]] WareWorker get_type() const {
 		return type_;
 	}
 
@@ -86,7 +86,7 @@ public:
 	 * The maximum size of the queue as defined by the building.
 	 * @return The maximum size.
 	 */
-	Quantity get_max_size() const {
+	[[nodiscard]] Quantity get_max_size() const {
 		return max_size_;
 	}
 
@@ -96,7 +96,7 @@ public:
 	 * be smaller than get_max_size().
 	 * @return The amount at this moment.
 	 */
-	virtual Quantity get_filled() const = 0;
+	[[nodiscard]] virtual Quantity get_filled() const = 0;
 
 	/**
 	 * The amount of missing wares or workers which have been requested
@@ -104,7 +104,7 @@ public:
 	 * This will never be larger than (get_max_fill()-get_filled()).
 	 * @return The amount at this moment.
 	 */
-	uint32_t get_missing() const;
+	[[nodiscard]] uint32_t get_missing() const;
 
 	/**
 	 * Clear the queue appropriately.
@@ -172,11 +172,11 @@ public:
 	 * Returns the player owning the building containing this queue.
 	 * @return A reference to the owning player.
 	 */
-	const Player& owner() const {
+	[[nodiscard]] const Player& owner() const {
 		return owner_.owner();
 	}
 
-	bool matches(const Request& r) const {
+	[[nodiscard]] bool matches(const Request& r) const {
 		return request_.get() == &r;
 	}
 
@@ -210,7 +210,7 @@ protected:
 	 * Returns the mutable player owning the building containing this queue.
 	 * @return A pointer to the owning player.
 	 */
-	Player* get_owner() const {
+	[[nodiscard]] Player* get_owner() const {
 		return owner_.get_owner();
 	}
 

--- a/src/economy/itransport_cost_calculator.h
+++ b/src/economy/itransport_cost_calculator.h
@@ -37,7 +37,7 @@ public:
 	virtual ~ITransportCostCalculator() {
 	}
 
-	virtual int32_t calc_cost_estimate(const Coords&, const Coords&) const = 0;
+	[[nodiscard]] virtual int32_t calc_cost_estimate(const Coords&, const Coords&) const = 0;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(ITransportCostCalculator);

--- a/src/economy/request.h
+++ b/src/economy/request.h
@@ -62,44 +62,44 @@ public:
 	Request(PlayerImmovable& target, DescriptionIndex, CallbackFn, WareWorker);
 	~Request() override;
 
-	PlayerImmovable& target() const {
+	[[nodiscard]] PlayerImmovable& target() const {
 		return target_;
 	}
-	DescriptionIndex get_index() const {
+	[[nodiscard]] DescriptionIndex get_index() const {
 		return index_;
 	}
-	WareWorker get_type() const {
+	[[nodiscard]] WareWorker get_type() const {
 		return type_;
 	}
-	Quantity get_count() const {
+	[[nodiscard]] Quantity get_count() const {
 		return count_;
 	}
-	uint32_t get_open_count() const {
+	[[nodiscard]] uint32_t get_open_count() const {
 		return count_ - transfers_.size();
 	}
-	bool get_exact_match() const {
+	[[nodiscard]] bool get_exact_match() const {
 		return exact_match_;
 	}
-	bool is_open() const {
+	[[nodiscard]] bool is_open() const {
 		return transfers_.size() < count_;
 	}
-	Economy* get_economy() const {
+	[[nodiscard]] Economy* get_economy() const {
 		return economy_;
 	}
-	Time get_required_time() const;
-	const Time& get_last_request_time() const {
+	[[nodiscard]] Time get_required_time() const;
+	[[nodiscard]] const Time& get_last_request_time() const {
 		return last_request_time_;
 	}
-	uint32_t get_priority(int32_t cost) const;
-	uint32_t get_normalized_transfer_priority() const;
-	uint32_t get_num_transfers() const {
+	[[nodiscard]] uint32_t get_priority(int32_t cost) const;
+	[[nodiscard]] uint32_t get_normalized_transfer_priority() const;
+	[[nodiscard]] uint32_t get_num_transfers() const {
 		return transfers_.size();
 	}
-	const TransferList& get_transfers() const {
+	[[nodiscard]] const TransferList& get_transfers() const {
 		return transfers_;
 	}
 
-	Flag& target_flag() const;
+	[[nodiscard]] Flag& target_flag() const;
 
 	void set_economy(Economy*);
 	void set_count(Quantity);
@@ -125,12 +125,12 @@ public:
 	void set_requirements(const Requirements& r) {
 		requirements_ = r;
 	}
-	const Requirements& get_requirements() const {
+	[[nodiscard]] const Requirements& get_requirements() const {
 		return requirements_;
 	}
 
 private:
-	Time get_base_required_time(const EditorGameBase&, uint32_t nr) const;
+	[[nodiscard]] Time get_base_required_time(const EditorGameBase&, uint32_t nr) const;
 	void remove_transfer(uint32_t idx);
 	uint32_t find_transfer(Transfer&);
 

--- a/src/economy/route.h
+++ b/src/economy/route.h
@@ -45,10 +45,10 @@ struct Route : public IRoute {
 
 	void init(int32_t) override;
 
-	int32_t get_totalcost() const {
+	[[nodiscard]] int32_t get_totalcost() const {
 		return totalcost_;
 	}
-	int32_t get_nrsteps() const {
+	[[nodiscard]] int32_t get_nrsteps() const {
 		return route_.size() - 1;
 	}
 	Flag& get_flag(EditorGameBase&, std::vector<Flag*>::size_type) const;

--- a/src/economy/routing_node.h
+++ b/src/economy/routing_node.h
@@ -34,10 +34,10 @@ struct RoutingNode;
 struct RoutingNodeNeighbour {
 	RoutingNodeNeighbour(RoutingNode* const f, int32_t const cost) : nb_(f), cost_(cost) {
 	}
-	RoutingNode* get_neighbour() const {
+	[[nodiscard]] RoutingNode* get_neighbour() const {
 		return nb_;
 	}
-	int32_t get_cost() const {
+	[[nodiscard]] int32_t get_cost() const {
 		return cost_;
 	}
 
@@ -99,7 +99,7 @@ public:
 		}
 	}
 
-	int32_t cost(WareWorker which) const {
+	[[nodiscard]] int32_t cost(WareWorker which) const {
 		return (which == wwWARE) ? mpf_realcost_ware + mpf_estimate_ware :
                                  mpf_realcost_worker + mpf_estimate_worker;
 	}
@@ -109,7 +109,7 @@ public:
 
 	virtual Flag& base_flag() = 0;
 	virtual void get_neighbours(WareWorker type, RoutingNodeNeighbours&) = 0;
-	virtual const Coords& get_position() const = 0;
+	[[nodiscard]] virtual const Coords& get_position() const = 0;
 };
 }  // namespace Widelands
 

--- a/src/economy/ship_fleet.cc
+++ b/src/economy/ship_fleet.cc
@@ -460,7 +460,7 @@ struct StepEvalFindPorts {
 		return std::max(0, est - 5 * map.calc_cost(0));
 	}
 
-	int32_t stepcost(
+	[[nodiscard]] int32_t stepcost(
 	   const Map& map, FCoords from, int32_t /* fromcost */, WalkingDir dir, FCoords to) const {
 		if ((to.field->nodecaps() & MOVECAPS_SWIM) == 0) {
 			return -1;

--- a/src/economy/shipping_schedule.h
+++ b/src/economy/shipping_schedule.h
@@ -92,9 +92,9 @@ public:
 	 * We may have ships and/or ports but no plans to carry anything.
 	 * @return true when no plans for any ship exist
 	 */
-	bool empty() const;
+	[[nodiscard]] bool empty() const;
 
-	bool is_busy(const Ship&) const;
+	[[nodiscard]] bool is_busy(const Ship&) const;
 
 	void log_general_info(const EditorGameBase&) const;
 

--- a/src/economy/supply.h
+++ b/src/economy/supply.h
@@ -55,7 +55,7 @@ struct Supply : public Trackable {
 	 * Indicates whether this supply is active as explained above (out
 	 * on the road network).
 	 */
-	virtual bool is_active() const = 0;
+	[[nodiscard]] virtual bool is_active() const = 0;
 
 	/**
 	 * Return the type of player im/movable where the ware is now (warehouse,
@@ -69,7 +69,7 @@ struct Supply : public Trackable {
 	 *
 	 * If this is \c false, somebody needs to find this supply a warehouse.
 	 */
-	virtual bool has_storage() const = 0;
+	[[nodiscard]] virtual bool has_storage() const = 0;
 
 	/**
 	 * Gets the ware type of this supply.
@@ -90,7 +90,7 @@ struct Supply : public Trackable {
 	 * \return the number of wares or workers that can be launched right
 	 * now for the thing requested by the given request
 	 */
-	virtual uint32_t nr_supplies(const Game&, const Request&) const = 0;
+	[[nodiscard]] virtual uint32_t nr_supplies(const Game&, const Request&) const = 0;
 
 	/**
 	 * Prepare an ware to satisfy the given request. Note that the caller

--- a/src/economy/supply_list.h
+++ b/src/economy/supply_list.h
@@ -35,7 +35,7 @@ struct SupplyList {
 	void add_supply(Supply&);
 	void remove_supply(Supply&);
 
-	size_t get_nrsupplies() const {
+	[[nodiscard]] size_t get_nrsupplies() const {
 		return supplies_.size();
 	}
 	const Supply& operator[](size_t const idx) const {

--- a/src/economy/test/test_routing.cc
+++ b/src/economy/test/test_routing.cc
@@ -92,7 +92,7 @@ bool TestingRoutingNode::all_members_zeroed() const {
 }
 
 class TestingTransportCostCalculator : public Widelands::ITransportCostCalculator {
-	int32_t calc_cost_estimate(const Widelands::Coords& c1,
+	[[nodiscard]] int32_t calc_cost_estimate(const Widelands::Coords& c1,
 	                           const Widelands::Coords& c2) const override {
 		// We use an euclidian metric here. It is much easier for
 		// test cases
@@ -112,7 +112,7 @@ public:
 		nodes.insert(nodes.begin(), node);
 	}
 
-	int32_t get_length() const {
+	[[nodiscard]] int32_t get_length() const {
 		return nodes.size();
 	}
 

--- a/src/economy/test/test_routing.cc
+++ b/src/economy/test/test_routing.cc
@@ -93,7 +93,7 @@ bool TestingRoutingNode::all_members_zeroed() const {
 
 class TestingTransportCostCalculator : public Widelands::ITransportCostCalculator {
 	[[nodiscard]] int32_t calc_cost_estimate(const Widelands::Coords& c1,
-	                           const Widelands::Coords& c2) const override {
+	                                         const Widelands::Coords& c2) const override {
 		// We use an euclidian metric here. It is much easier for
 		// test cases
 		double xd = (c1.x - c2.x);

--- a/src/economy/transfer.h
+++ b/src/economy/transfer.h
@@ -49,13 +49,13 @@ struct Transfer {
 	Transfer(Game&, Worker&);
 	~Transfer();
 
-	Request* get_request() const {
+	[[nodiscard]] Request* get_request() const {
 		return request_;
 	}
 	void set_request(Request* req);
 	void set_destination(PlayerImmovable& imm);
 	PlayerImmovable* get_destination(Game& g);
-	uint32_t get_steps_left() const {
+	[[nodiscard]] uint32_t get_steps_left() const {
 		return route_.get_nrsteps();
 	}
 
@@ -64,10 +64,10 @@ struct Transfer {
 	void has_finished();
 	void has_failed();
 
-	WareInstance* get_ware() const {
+	[[nodiscard]] WareInstance* get_ware() const {
 		return ware_;
 	}
-	Worker* get_worker() const {
+	[[nodiscard]] Worker* get_worker() const {
 		return worker_;
 	}
 

--- a/src/economy/ware_instance.cc
+++ b/src/economy/ware_instance.cc
@@ -53,13 +53,13 @@ struct IdleWareSupply : public Supply {
 
 	//  implementation of Supply
 	PlayerImmovable* get_position(Game& /*game*/) override;
-	bool is_active() const override;
+	[[nodiscard]] bool is_active() const override;
 	SupplyProviders provider_type(Game* /*game*/) const override;
-	bool has_storage() const override;
+	[[nodiscard]] bool has_storage() const override;
 	void get_ware_type(WareWorker& type, DescriptionIndex& ware) const override;
 	void send_to_storage(Game& /*game*/, Warehouse* wh) override;
 
-	uint32_t nr_supplies(const Game& /* game */, const Request& /* req */) const override;
+	[[nodiscard]] uint32_t nr_supplies(const Game& /* game */, const Request& /* req */) const override;
 	WareInstance& launch_ware(Game& /* game */, const Request& /* req */) override;
 	Worker& launch_worker(Game& /* game */, const Request& /* req */) override;
 

--- a/src/economy/ware_instance.cc
+++ b/src/economy/ware_instance.cc
@@ -59,7 +59,8 @@ struct IdleWareSupply : public Supply {
 	void get_ware_type(WareWorker& type, DescriptionIndex& ware) const override;
 	void send_to_storage(Game& /*game*/, Warehouse* wh) override;
 
-	[[nodiscard]] uint32_t nr_supplies(const Game& /* game */, const Request& /* req */) const override;
+	[[nodiscard]] uint32_t nr_supplies(const Game& /* game */,
+	                                   const Request& /* req */) const override;
 	WareInstance& launch_ware(Game& /* game */, const Request& /* req */) override;
 	Worker& launch_worker(Game& /* game */, const Request& /* req */) override;
 

--- a/src/economy/ware_priority.h
+++ b/src/economy/ware_priority.h
@@ -35,7 +35,7 @@ public:
 	~WarePriority() {
 	}
 
-	uint32_t to_weighting_factor() const {
+	[[nodiscard]] uint32_t to_weighting_factor() const {
 		return value_;
 	}
 

--- a/src/economy/warehousesupply.h
+++ b/src/economy/warehousesupply.h
@@ -40,16 +40,16 @@ struct WarehouseSupply : public Supply {
 	void set_nrworkers(DescriptionIndex);
 	void set_nrwares(DescriptionIndex);
 
-	const WareList& get_wares() const {
+	[[nodiscard]] const WareList& get_wares() const {
 		return wares_;
 	}
-	const WareList& get_workers() const {
+	[[nodiscard]] const WareList& get_workers() const {
 		return workers_;
 	}
-	Quantity stock_wares(DescriptionIndex const i) const {
+	[[nodiscard]] Quantity stock_wares(DescriptionIndex const i) const {
 		return wares_.stock(i);
 	}
-	Quantity stock_workers(DescriptionIndex const i) const {
+	[[nodiscard]] Quantity stock_workers(DescriptionIndex const i) const {
 		return workers_.stock(i);
 	}
 	void add_wares(DescriptionIndex, Quantity count);
@@ -59,13 +59,13 @@ struct WarehouseSupply : public Supply {
 
 	// Supply implementation
 	PlayerImmovable* get_position(Game&) override;
-	bool is_active() const override;
+	[[nodiscard]] bool is_active() const override;
 	SupplyProviders provider_type(Game*) const override;
-	bool has_storage() const override;
+	[[nodiscard]] bool has_storage() const override;
 	void get_ware_type(WareWorker& type, DescriptionIndex& ware) const override;
 
 	void send_to_storage(Game&, Warehouse* wh) override;
-	uint32_t nr_supplies(const Game&, const Request&) const override;
+	[[nodiscard]] uint32_t nr_supplies(const Game&, const Request&) const override;
 	WareInstance& launch_ware(Game&, const Request&) override;
 	Worker& launch_worker(Game&, const Request&) override;
 

--- a/src/economy/wares_queue.h
+++ b/src/economy/wares_queue.h
@@ -37,7 +37,7 @@ public:
 	}
 #endif
 
-	Quantity get_filled() const override {
+	[[nodiscard]] Quantity get_filled() const override {
 		return filled_;
 	}
 

--- a/src/economy/workers_queue.h
+++ b/src/economy/workers_queue.h
@@ -37,7 +37,7 @@ public:
 	}
 #endif
 
-	Quantity get_filled() const override {
+	[[nodiscard]] Quantity get_filled() const override {
 		return workers_.size();
 	}
 

--- a/src/editor/editor_category.h
+++ b/src/editor/editor_category.h
@@ -38,18 +38,18 @@ public:
 	                        Widelands::Descriptions& descriptions);
 
 	/// Internal name.
-	const std::string& name() const;
+	[[nodiscard]] const std::string& name() const;
 
 	/// User facing (translated) name.
-	const std::string& descname() const;
+	[[nodiscard]] const std::string& descname() const;
 
 	/// The menu image for the category.
-	const Image* picture() const;
+	[[nodiscard]] const Image* picture() const;
 
 	/// The number of items displayed in each row.
-	int items_per_row() const;
+	[[nodiscard]] int items_per_row() const;
 
-	const std::vector<Widelands::DescriptionIndex>& items() const;
+	[[nodiscard]] const std::vector<Widelands::DescriptionIndex>& items() const;
 
 private:
 	const std::string name_;

--- a/src/editor/editorinteractive.h
+++ b/src/editor/editorinteractive.h
@@ -76,7 +76,7 @@ public:
 		     resize(parent, map.get_width(), map.get_height()),
 		     tool_history(parent) {
 		}
-		EditorTool& current() const {
+		[[nodiscard]] EditorTool& current() const {
 			return *current_pointer;
 		}
 		using ToolVector = std::vector<EditorTool*>;

--- a/src/editor/tools/decrease_height_tool.h
+++ b/src/editor/tools/decrease_height_tool.h
@@ -37,11 +37,11 @@ struct EditorDecreaseHeightTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor//fsel_editor_decrease_height.png");
 	}
 
-	int32_t get_change_by() const {
+	[[nodiscard]] int32_t get_change_by() const {
 		return change_by_;
 	}
 	void set_change_by(const int32_t n) {

--- a/src/editor/tools/decrease_resources_tool.h
+++ b/src/editor/tools/decrease_resources_tool.h
@@ -38,7 +38,7 @@ struct EditorDecreaseResourcesTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_decrease_resources.png");
 	}
 
@@ -47,13 +47,13 @@ struct EditorDecreaseResourcesTool : public EditorTool {
 		return resource_tools_nodecaps(fcoords, egbase, cur_res_);
 	}
 
-	int32_t get_change_by() const {
+	[[nodiscard]] int32_t get_change_by() const {
 		return change_by_;
 	}
 	void set_change_by(const int32_t n) {
 		change_by_ = n;
 	}
-	Widelands::DescriptionIndex get_cur_res() const {
+	[[nodiscard]] Widelands::DescriptionIndex get_cur_res() const {
 		return cur_res_;
 	}
 	void set_cur_res(Widelands::DescriptionIndex const res) {

--- a/src/editor/tools/delete_critter_tool.h
+++ b/src/editor/tools/delete_critter_tool.h
@@ -36,7 +36,7 @@ struct EditorDeleteCritterTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_delete.png");
 	}
 };

--- a/src/editor/tools/delete_immovable_tool.h
+++ b/src/editor/tools/delete_immovable_tool.h
@@ -36,7 +36,7 @@ struct EditorDeleteImmovableTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_delete.png");
 	}
 };

--- a/src/editor/tools/draw_tool.h
+++ b/src/editor/tools/draw_tool.h
@@ -38,7 +38,7 @@ struct EditorDrawTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/novalue.png");
 	}
 

--- a/src/editor/tools/increase_height_tool.h
+++ b/src/editor/tools/increase_height_tool.h
@@ -43,21 +43,21 @@ struct EditorIncreaseHeightTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_increase_height.png");
 	}
 
-	int32_t get_change_by() const {
+	[[nodiscard]] int32_t get_change_by() const {
 		return change_by_;
 	}
 	void set_change_by(const int32_t n) {
 		change_by_ = n;
 	}
 
-	EditorDecreaseHeightTool& decrease_tool() const {
+	[[nodiscard]] EditorDecreaseHeightTool& decrease_tool() const {
 		return decrease_tool_;
 	}
-	EditorSetHeightTool& set_tool() const {
+	[[nodiscard]] EditorSetHeightTool& set_tool() const {
 		return set_tool_;
 	}
 

--- a/src/editor/tools/increase_resources_tool.h
+++ b/src/editor/tools/increase_resources_tool.h
@@ -49,7 +49,7 @@ struct EditorIncreaseResourcesTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_increase_resources.png");
 	}
 
@@ -58,23 +58,23 @@ struct EditorIncreaseResourcesTool : public EditorTool {
 		return resource_tools_nodecaps(fcoords, egbase, cur_res_);
 	}
 
-	int32_t get_change_by() const {
+	[[nodiscard]] int32_t get_change_by() const {
 		return change_by_;
 	}
 	void set_change_by(const int32_t n) {
 		change_by_ = n;
 	}
-	Widelands::DescriptionIndex get_cur_res() const {
+	[[nodiscard]] Widelands::DescriptionIndex get_cur_res() const {
 		return cur_res_;
 	}
 	void set_cur_res(Widelands::DescriptionIndex const res) {
 		cur_res_ = res;
 	}
 
-	EditorDecreaseResourcesTool& decrease_tool() const {
+	[[nodiscard]] EditorDecreaseResourcesTool& decrease_tool() const {
 		return decrease_tool_;
 	}
-	EditorSetResourcesTool& set_tool() const {
+	[[nodiscard]] EditorSetResourcesTool& set_tool() const {
 		return set_tool_;
 	}
 

--- a/src/editor/tools/info_tool.h
+++ b/src/editor/tools/info_tool.h
@@ -33,11 +33,11 @@ struct EditorInfoTool : public EditorTool {
 	                          EditorActionArgs* args,
 	                          Widelands::Map* map) override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_info.png");
 	}
 
-	bool has_size_one() const override {
+	[[nodiscard]] bool has_size_one() const override {
 		return true;
 	}
 

--- a/src/editor/tools/multi_select.h
+++ b/src/editor/tools/multi_select.h
@@ -43,15 +43,15 @@ struct MultiSelect {
 		}
 	}
 
-	bool is_enabled(int32_t n) const {
+	[[nodiscard]] bool is_enabled(int32_t n) const {
 		return enabled_.find(n) != enabled_.end();
 	}
 
-	int32_t get_nr_enabled() const {
+	[[nodiscard]] int32_t get_nr_enabled() const {
 		return enabled_.size();
 	}
 
-	int32_t get_random_enabled() const {
+	[[nodiscard]] int32_t get_random_enabled() const {
 		int32_t rand_value =
 		   static_cast<int32_t>(static_cast<double>(get_nr_enabled()) * rand() / (RAND_MAX + 1.0));
 
@@ -69,11 +69,11 @@ struct MultiSelect {
 		enabled_.clear();
 	}
 
-	int32_t count() const {
+	[[nodiscard]] int32_t count() const {
 		return enabled_.size();
 	}
 
-	const std::set<int32_t>& get_enabled() const {
+	[[nodiscard]] const std::set<int32_t>& get_enabled() const {
 		return enabled_;
 	}
 

--- a/src/editor/tools/noise_height_tool.h
+++ b/src/editor/tools/noise_height_tool.h
@@ -42,18 +42,18 @@ struct EditorNoiseHeightTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_noise_height.png");
 	}
 
-	Widelands::HeightInterval get_interval() const {
+	[[nodiscard]] Widelands::HeightInterval get_interval() const {
 		return interval_;
 	}
 	void set_interval(const Widelands::HeightInterval& i) {
 		interval_ = i;
 	}
 
-	EditorSetHeightTool& set_tool() const {
+	[[nodiscard]] EditorSetHeightTool& set_tool() const {
 		return set_tool_;
 	}
 

--- a/src/editor/tools/place_critter_tool.h
+++ b/src/editor/tools/place_critter_tool.h
@@ -38,7 +38,7 @@ struct EditorPlaceCritterTool : public EditorTool, public MultiSelect {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_place_critter.png");
 	}
 

--- a/src/editor/tools/place_immovable_tool.h
+++ b/src/editor/tools/place_immovable_tool.h
@@ -40,7 +40,7 @@ struct EditorPlaceImmovableTool : public EditorTool, public MultiSelect {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_place_immovable.png");
 	}
 

--- a/src/editor/tools/resize_tool.h
+++ b/src/editor/tools/resize_tool.h
@@ -40,11 +40,11 @@ struct EditorResizeTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_resize.png");
 	}
 
-	bool has_size_one() const override {
+	[[nodiscard]] bool has_size_one() const override {
 		return true;
 	}
 

--- a/src/editor/tools/set_height_tool.h
+++ b/src/editor/tools/set_height_tool.h
@@ -39,11 +39,11 @@ struct EditorSetHeightTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_set_height.png");
 	}
 
-	Widelands::HeightInterval get_interval() const {
+	[[nodiscard]] Widelands::HeightInterval get_interval() const {
 		return interval_;
 	}
 	void set_interval(const Widelands::HeightInterval& i) {

--- a/src/editor/tools/set_origin_tool.h
+++ b/src/editor/tools/set_origin_tool.h
@@ -36,11 +36,11 @@ struct EditorSetOriginTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/ui_basic/fsel.png");
 	}
 
-	bool has_size_one() const override {
+	[[nodiscard]] bool has_size_one() const override {
 		return true;
 	}
 };

--- a/src/editor/tools/set_port_space_tool.h
+++ b/src/editor/tools/set_port_space_tool.h
@@ -37,7 +37,7 @@ public:
 	                         EditorActionArgs* args,
 	                         Widelands::Map* map) override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get(FSEL_EUPS_FILENAME);
 	}
 	Widelands::NodeCaps nodecaps_for_buildhelp(const Widelands::FCoords& fcoords,
@@ -57,7 +57,7 @@ public:
 	                         EditorActionArgs* args,
 	                         Widelands::Map* map) override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get(FSEL_ESPS_FILENAME);
 	}
 	Widelands::NodeCaps nodecaps_for_buildhelp(const Widelands::FCoords& fcoords,

--- a/src/editor/tools/set_resources_tool.h
+++ b/src/editor/tools/set_resources_tool.h
@@ -44,7 +44,7 @@ struct EditorSetResourcesTool : public EditorTool {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_set_resources.png");
 	}
 
@@ -53,13 +53,13 @@ struct EditorSetResourcesTool : public EditorTool {
 		return resource_tools_nodecaps(fcoords, egbase, cur_res_);
 	}
 
-	Widelands::ResourceAmount get_set_to() const {
+	[[nodiscard]] Widelands::ResourceAmount get_set_to() const {
 		return set_to_;
 	}
 	void set_set_to(Widelands::ResourceAmount const n) {
 		set_to_ = n;
 	}
-	Widelands::DescriptionIndex get_cur_res() const {
+	[[nodiscard]] Widelands::DescriptionIndex get_cur_res() const {
 		return cur_res_;
 	}
 	void set_cur_res(Widelands::DescriptionIndex const res) {

--- a/src/editor/tools/set_starting_pos_tool.h
+++ b/src/editor/tools/set_starting_pos_tool.h
@@ -28,13 +28,13 @@ struct EditorSetStartingPosTool : public EditorTool {
 	int32_t handle_click_impl(const Widelands::NodeAndTriangle<>&,
 	                          EditorActionArgs*,
 	                          Widelands::Map*) override;
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return playercolor_image(get_current_player() - 1, "images/players/player_position_menu.png");
 	}
 
-	Widelands::PlayerNumber get_current_player() const;
+	[[nodiscard]] Widelands::PlayerNumber get_current_player() const;
 	void set_current_player(int32_t);
-	bool has_size_one() const override {
+	[[nodiscard]] bool has_size_one() const override {
 		return true;
 	}
 	Widelands::NodeCaps nodecaps_for_buildhelp(const Widelands::FCoords& fcoords,

--- a/src/editor/tools/set_terrain_tool.h
+++ b/src/editor/tools/set_terrain_tool.h
@@ -36,10 +36,10 @@ struct EditorSetTerrainTool : public EditorTool, public MultiSelect {
 
 	EditorActionArgs format_args_impl() override;
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/ui_basic/fsel.png");
 	}
-	bool operates_on_triangles() const override {
+	[[nodiscard]] bool operates_on_triangles() const override {
 		return true;
 	}
 

--- a/src/editor/tools/tool.h
+++ b/src/editor/tools/tool.h
@@ -86,7 +86,7 @@ public:
 	bool is_undoable() {
 		return undoable_;
 	}
-	virtual bool has_size_one() const {
+	[[nodiscard]] virtual bool has_size_one() const {
 		return false;
 	}
 	virtual EditorActionArgs format_args_impl() {
@@ -104,7 +104,7 @@ public:
 	handle_undo_impl(const Widelands::NodeAndTriangle<>&, EditorActionArgs*, Widelands::Map*) {
 		return 0;
 	}  // non unduable tools don't need to implement this.
-	virtual const Image* get_sel_impl() const = 0;
+	[[nodiscard]] virtual const Image* get_sel_impl() const = 0;
 
 	// Gives the tool the chance to modify the nodecaps to change what will be
 	// displayed as build help.
@@ -120,7 +120,7 @@ public:
 		return fcoords.field->maxcaps();
 	}
 
-	virtual bool operates_on_triangles() const {
+	[[nodiscard]] virtual bool operates_on_triangles() const {
 		return false;
 	}
 

--- a/src/editor/tools/tool_conf.h
+++ b/src/editor/tools/tool_conf.h
@@ -33,7 +33,7 @@ struct ToolConf {
 	ToolConf& operator=(const ToolConf&) = default;
 
 	/// Returns a description of the conf's content in non-locale-dependent form.
-	std::string to_key() const;
+	[[nodiscard]] std::string to_key() const;
 
 	EditorTool* primary;
 

--- a/src/editor/tools/toolhistory_tool.h
+++ b/src/editor/tools/toolhistory_tool.h
@@ -46,7 +46,7 @@ struct EditorHistoryTool : public EditorTool {
 
 	bool add_configuration(const ToolConf& conf);
 
-	const Image* get_sel_impl() const override {
+	[[nodiscard]] const Image* get_sel_impl() const override {
 		return g_image_cache->get("images/wui/editor/fsel_editor_info.png");
 	}
 

--- a/src/game_io/game_preload_packet.h
+++ b/src/game_io/game_preload_packet.h
@@ -37,43 +37,43 @@ struct GamePreloadPacket : public GameDataPacket {
 	void read(FileSystem&, Game&, MapObjectLoader* = nullptr) override;
 	void write(FileSystem&, Game&, MapObjectSaver* = nullptr) override;
 
-	char const* get_mapname() const {
+	[[nodiscard]] char const* get_mapname() const {
 		return mapname_.c_str();
 	}
-	std::string get_background() const {
+	[[nodiscard]] std::string get_background() const {
 		return background_;
 	}
-	std::string get_background_theme() const {
+	[[nodiscard]] std::string get_background_theme() const {
 		return background_theme_;
 	}
-	std::string get_win_condition() const {
+	[[nodiscard]] std::string get_win_condition() const {
 		return win_condition_;
 	}
-	std::string get_localized_win_condition() const;
-	int32_t get_win_condition_duration() const {
+	[[nodiscard]] std::string get_localized_win_condition() const;
+	[[nodiscard]] int32_t get_win_condition_duration() const {
 		return win_condition_duration_;
 	}
-	const Time& get_gametime() const {
+	[[nodiscard]] const Time& get_gametime() const {
 		return gametime_;
 	}
-	uint8_t get_player_nr() const {
+	[[nodiscard]] uint8_t get_player_nr() const {
 		return player_nr_;
 	}
-	std::string get_version() const {
+	[[nodiscard]] std::string get_version() const {
 		return version_;
 	}
 
-	uint8_t get_number_of_players() const {
+	[[nodiscard]] uint8_t get_number_of_players() const {
 		return number_of_players_;
 	}
-	std::string get_minimap_path() const {
+	[[nodiscard]] std::string get_minimap_path() const {
 		return minimap_path_;
 	}
 
-	time_t get_savetimestamp() const {
+	[[nodiscard]] time_t get_savetimestamp() const {
 		return savetimestamp_;
 	}
-	GameController::GameType get_gametype() const {
+	[[nodiscard]] GameController::GameType get_gametype() const {
 		return gametype_;
 	}
 
@@ -90,7 +90,7 @@ struct GamePreloadPacket : public GameDataPacket {
 	 * and players can not influence the world of existing maps.
 	 * Tribes add-ons however are selected when starting a new game.
 	 */
-	const AddOns::AddOnRequirements& required_addons() const {
+	[[nodiscard]] const AddOns::AddOnRequirements& required_addons() const {
 		return required_addons_;
 	}
 

--- a/src/graphic/animation/animation.h
+++ b/src/graphic/animation/animation.h
@@ -105,8 +105,8 @@ public:
 	/// We need to expose these for the packed animation,
 	/// so that the create_spritesheet utility can use them.
 	/// Do not use otherwise.
-	[[nodiscard]] std::vector<std::unique_ptr<const Texture>> frame_textures(float scale,
-	                                                           bool return_playercolor_masks) const;
+	[[nodiscard]] std::vector<std::unique_ptr<const Texture>>
+	frame_textures(float scale, bool return_playercolor_masks) const;
 
 	/// The scales for which this animation has exact images.
 	[[nodiscard]] std::set<float> available_scales() const;

--- a/src/graphic/animation/animation.h
+++ b/src/graphic/animation/animation.h
@@ -56,31 +56,31 @@ public:
 	virtual ~Animation() = default;
 
 	/// The height of this animation.
-	int height() const;
+	[[nodiscard]] int height() const;
 	/// The width of this animation.
-	int width() const;
+	[[nodiscard]] int width() const;
 	/// The hotspot of this animation for aligning it on the map.
-	const Vector2i& hotspot() const;
+	[[nodiscard]] const Vector2i& hotspot() const;
 
 	/// The frame to be blitted for the given 'time'
-	uint32_t current_frame(uint32_t time) const;
+	[[nodiscard]] uint32_t current_frame(uint32_t time) const;
 
 	/// The size of the animation source images in pixels. Use 'percent_from_bottom' to crop the
 	/// animation.
-	Rectf source_rectangle(int percent_from_bottom, float scale) const;
+	[[nodiscard]] Rectf source_rectangle(int percent_from_bottom, float scale) const;
 
 	/// Calculates the destination rectangle for blitting the animation in pixels.
 	/// 'position' is where the top left corner of the animation will end up,
 	/// 'source_rect' is the rectangle calculated by source_rectangle,
 	/// 'scale' is the zoom scale.
-	Rectf
+	[[nodiscard]] Rectf
 	destination_rectangle(const Vector2f& position, const Rectf& source_rect, float scale) const;
 
 	/// The number of animation frames of this animation. Returns a positive integer.
-	uint16_t nr_frames() const;
+	[[nodiscard]] uint16_t nr_frames() const;
 
 	/// The number of milliseconds each frame will be displayed. Returns a positive integer.
-	uint32_t frametime() const;
+	[[nodiscard]] uint32_t frametime() const;
 
 	/// An image of the first frame, blended with the given player color.
 	/// The 'clr' is the player color used for blending - the parameter can be
@@ -105,17 +105,17 @@ public:
 	/// We need to expose these for the packed animation,
 	/// so that the create_spritesheet utility can use them.
 	/// Do not use otherwise.
-	std::vector<std::unique_ptr<const Texture>> frame_textures(float scale,
+	[[nodiscard]] std::vector<std::unique_ptr<const Texture>> frame_textures(float scale,
 	                                                           bool return_playercolor_masks) const;
 
 	/// The scales for which this animation has exact images.
-	std::set<float> available_scales() const;
+	[[nodiscard]] std::set<float> available_scales() const;
 
 	/// Load animation images into memory for default scale.
 	void load_default_scale_and_sounds() const;
 
 	/// The frame to be shown in menus etc.
-	int representative_frame() const;
+	[[nodiscard]] int representative_frame() const;
 
 protected:
 	/// Animation data for a particular scale
@@ -140,11 +140,11 @@ protected:
 		                  float opacity) const = 0;
 
 		/// The width of this mipmap entry's textures
-		virtual int width() const = 0;
+		[[nodiscard]] virtual int width() const = 0;
 		/// The height of this mipmap entry's textures
-		virtual int height() const = 0;
+		[[nodiscard]] virtual int height() const = 0;
 
-		virtual std::vector<std::unique_ptr<const Texture>>
+		[[nodiscard]] virtual std::vector<std::unique_ptr<const Texture>>
 		frame_textures(bool return_playercolor_masks) const = 0;
 
 		/// Whether this texture set has player color masks provided
@@ -161,7 +161,7 @@ protected:
 	void trigger_sound(uint32_t time, const Widelands::Coords& coords) const;
 
 	/// Ensures that the graphics are loaded before returning the entry
-	const Animation::MipMapEntry& mipmap_entry(float scale) const;
+	[[nodiscard]] const Animation::MipMapEntry& mipmap_entry(float scale) const;
 
 	/// The number of textures this animation will play
 	uint16_t nr_frames_;
@@ -186,7 +186,7 @@ private:
 	                                        const std::string& scale_as_string) = 0;
 
 	/// Find the best scale for blitting at the given zoom 'scale'
-	float find_best_scale(float scale) const;
+	[[nodiscard]] float find_best_scale(float scale) const;
 
 	/// The frame to show in menus, in the in-game help etc.
 	int representative_frame_;

--- a/src/graphic/animation/animation_manager.h
+++ b/src/graphic/animation/animation_manager.h
@@ -52,7 +52,7 @@ public:
 
 	/// Returns the animation with the given ID or throws an exception if it is
 	/// unknown.
-	const Animation& get_animation(uint32_t id) const;
+	[[nodiscard]] const Animation& get_animation(uint32_t id) const;
 
 	/// Returns the representative image for the animation with the given 'id', using the given
 	/// player color. If this image has already been generated, it is pulled from the cache using the

--- a/src/graphic/animation/diranimations.h
+++ b/src/graphic/animation/diranimations.h
@@ -30,7 +30,7 @@ struct DirAnimations {
 	              uint32_t dir5 = 0,
 	              uint32_t dir6 = 0);
 
-	uint32_t get_animation(Widelands::Direction const dir) const {
+	[[nodiscard]] uint32_t get_animation(Widelands::Direction const dir) const {
 		return animations_[dir - 1];
 	}
 	void set_animation(const Widelands::Direction dir, const uint32_t anim) {

--- a/src/graphic/animation/nonpacked_animation.h
+++ b/src/graphic/animation/nonpacked_animation.h
@@ -61,10 +61,10 @@ private:
 		          Surface* target,
 		          float opacity) const override;
 
-		int width() const override;
-		int height() const override;
+		[[nodiscard]] int width() const override;
+		[[nodiscard]] int height() const override;
 
-		std::vector<std::unique_ptr<const Texture>>
+		[[nodiscard]] std::vector<std::unique_ptr<const Texture>>
 		frame_textures(bool return_playercolor_masks) const override;
 
 		/// Image files on disk

--- a/src/graphic/animation/spritesheet_animation.h
+++ b/src/graphic/animation/spritesheet_animation.h
@@ -59,8 +59,8 @@ private:
 		          Surface* target,
 		          float opacity) const override;
 
-		int width() const override;
-		int height() const override;
+		[[nodiscard]] int width() const override;
+		[[nodiscard]] int height() const override;
 
 		/// Loaded sprite sheet for all frames
 		const Image* sheet;
@@ -77,7 +77,7 @@ private:
 		/// Texture height
 		int h;
 
-		std::vector<std::unique_ptr<const Texture>>
+		[[nodiscard]] std::vector<std::unique_ptr<const Texture>>
 		frame_textures(bool return_playercolor_masks) const override;
 
 	private:

--- a/src/graphic/color.h
+++ b/src/graphic/color.h
@@ -32,10 +32,10 @@ struct RGBColor {
 	RGBColor();
 
 	// Returns this color in hex format.
-	std::string hex_value() const;
+	[[nodiscard]] std::string hex_value() const;
 
 	// Map this color to the given 'fmt'
-	uint32_t map(const SDL_PixelFormat& fmt) const;
+	[[nodiscard]] uint32_t map(const SDL_PixelFormat& fmt) const;
 
 	// Set it to the given 'clr' which is interpretes through 'fmt'.
 	void set(SDL_PixelFormat* fmt, uint32_t clr);
@@ -59,10 +59,10 @@ struct RGBAColor {
 	RGBAColor(const RGBColor& c);
 
 	// Returns this color in hex format.
-	std::string hex_value() const;
+	[[nodiscard]] std::string hex_value() const;
 
 	// Map this color to the given 'fmt'
-	uint32_t map(const SDL_PixelFormat& fmt) const;
+	[[nodiscard]] uint32_t map(const SDL_PixelFormat& fmt) const;
 
 	// Set it to the given 'clr' which is interpretes through 'fmt'.
 	void set(const SDL_PixelFormat& fmt, uint32_t clr);

--- a/src/graphic/font_handler.cc
+++ b/src/graphic/font_handler.cc
@@ -101,7 +101,7 @@ public:
 		return rendered_text;
 	}
 
-	UI::FontSet const* fontset() const override {
+	[[nodiscard]] UI::FontSet const* fontset() const override {
 		return fontset_;
 	}
 

--- a/src/graphic/font_handler.h
+++ b/src/graphic/font_handler.h
@@ -44,7 +44,7 @@ public:
 	                                                       uint16_t w = 0) = 0;
 
 	/// Returns the font handler's current FontSet
-	virtual UI::FontSet const* fontset() const = 0;
+	[[nodiscard]] virtual UI::FontSet const* fontset() const = 0;
 
 	/// Loads the FontSet for the currently active locale into the
 	/// font handler. This needs to be called after the language of the

--- a/src/graphic/gl/fields_to_draw.h
+++ b/src/graphic/gl/fields_to_draw.h
@@ -64,7 +64,7 @@ public:
 		int bln_index;
 		int brn_index;
 
-		inline bool all_neighbors_valid() const {
+		[[nodiscard]] inline bool all_neighbors_valid() const {
 			return ln_index != kInvalidIndex && rn_index != kInvalidIndex &&
 			       trn_index != kInvalidIndex && bln_index != kInvalidIndex &&
 			       brn_index != kInvalidIndex;
@@ -78,12 +78,12 @@ public:
 	           RenderTarget* dst);
 
 	// The number of fields to draw.
-	inline size_t size() const {
+	[[nodiscard]] inline size_t size() const {
 		return fields_.size();
 	}
 
 	// Get the field at 'index' which must be in bound.
-	inline const Field& at(const int index) const {
+	[[nodiscard]] inline const Field& at(const int index) const {
 		return fields_.at(index);
 	}
 
@@ -95,7 +95,7 @@ public:
 	// Calculates the index of the given field with ('fx', 'fy') being geometric
 	// coordinates in the map. Returns INVALID_INDEX if this field is not in the
 	// fields_to_draw.
-	inline int calculate_index(int fx, int fy) const {
+	[[nodiscard]] inline int calculate_index(int fx, int fy) const {
 		if (fx < min_fx_ || fx > max_fx_ || fy < min_fy_ || fy > max_fy_) {
 			return kInvalidIndex;
 		}

--- a/src/graphic/gl/utils.cc
+++ b/src/graphic/gl/utils.cc
@@ -81,7 +81,7 @@ public:
 	explicit Shader(GLenum type);
 	~Shader();
 
-	GLuint object() const {
+	[[nodiscard]] GLuint object() const {
 		return shader_object_;
 	}
 

--- a/src/graphic/gl/utils.h
+++ b/src/graphic/gl/utils.h
@@ -41,7 +41,7 @@ public:
 	Program();
 	~Program();
 
-	GLuint object() const {
+	[[nodiscard]] GLuint object() const {
 		return program_object_;
 	}
 

--- a/src/graphic/graphic.h
+++ b/src/graphic/graphic.h
@@ -63,25 +63,25 @@ public:
 	// Use 'resize_window = true' to resize the window to the new resolution.
 	// Use 'resize_window = false' if the window has already been resized.
 	void change_resolution(int w, int h, bool resize_window);
-	int get_xres() const;
-	int get_yres() const;
-	int get_window_mode_xres() const;
-	int get_window_mode_yres() const;
+	[[nodiscard]] int get_xres() const;
+	[[nodiscard]] int get_yres() const;
+	[[nodiscard]] int get_window_mode_xres() const;
+	[[nodiscard]] int get_window_mode_yres() const;
 
-	bool maximized() const;
+	[[nodiscard]] bool maximized() const;
 	void set_maximized(bool);
 
 	// Changes the window to be fullscreen or not.
-	bool fullscreen() const;
+	[[nodiscard]] bool fullscreen() const;
 	void set_fullscreen(bool);
 
 	RenderTarget* get_render_target();
 	void refresh();
-	SDL_Window* get_sdlwindow() const {
+	[[nodiscard]] SDL_Window* get_sdlwindow() const {
 		return sdl_window_;
 	}
 
-	int max_texture_size_for_font_rendering() const;
+	[[nodiscard]] int max_texture_size_for_font_rendering() const;
 
 	// Requests a screenshot being taken on the next frame.
 	void screenshot(const std::string& fname);

--- a/src/graphic/hyperlink.h
+++ b/src/graphic/hyperlink.h
@@ -34,8 +34,8 @@ struct NoteHyperlink {
 
 struct TextClickTarget {
 	virtual ~TextClickTarget() = default;
-	virtual bool handle_mousepress(int32_t x, int32_t y) const = 0;
-	virtual const std::string* get_tooltip(int32_t x, int32_t y) const = 0;
+	[[nodiscard]] virtual bool handle_mousepress(int32_t x, int32_t y) const = 0;
+	[[nodiscard]] virtual const std::string* get_tooltip(int32_t x, int32_t y) const = 0;
 };
 
 #endif  // end of include guard: WL_GRAPHIC_HYPERLINK_H

--- a/src/graphic/image.h
+++ b/src/graphic/image.h
@@ -33,13 +33,13 @@ public:
 	}
 
 	// Dimensions of this Image in pixels.
-	virtual int width() const = 0;
-	virtual int height() const = 0;
+	[[nodiscard]] virtual int width() const = 0;
+	[[nodiscard]] virtual int height() const = 0;
 
 	// OpenGL texture and texture coordinates backing this Image. This can
 	// change at any time, so do not hold one to this value for more than one
 	// frame.
-	virtual const BlitData& blit_data() const = 0;
+	[[nodiscard]] virtual const BlitData& blit_data() const = 0;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(Image);

--- a/src/graphic/image_cache.h
+++ b/src/graphic/image_cache.h
@@ -47,7 +47,7 @@ public:
 	const Image* get(const std::string& hash);
 
 	// Returns true if the 'hash' is stored in the cache.
-	bool has(const std::string& hash) const;
+	[[nodiscard]] bool has(const std::string& hash) const;
 
 	// Fills the image cache with the hash -> Texture map 'textures_in_atlas'
 	// and take ownership of 'texture_atlases' so that the textures stay valid.

--- a/src/graphic/mouse_cursor.h
+++ b/src/graphic/mouse_cursor.h
@@ -44,14 +44,14 @@ public:
 
 	// Enable/disable SDL mode
 	void set_use_sdl(bool init_use_sdl);
-	bool is_using_sdl() const;
+	[[nodiscard]] bool is_using_sdl() const;
 
 	// Switch between "normal" and "pressed" cursors
 	void change_cursor(bool is_pressed);
 
 	// Hide/show the cursor
 	void set_visible(bool visible);
-	bool is_visible() const;
+	[[nodiscard]] bool is_visible() const;
 
 	// Render the cursor (does nothing in SDL mode)
 	void draw(RenderTarget& rt, Vector2i position);

--- a/src/graphic/rendertarget.h
+++ b/src/graphic/rendertarget.h
@@ -54,8 +54,8 @@ public:
 	void set_window(const Recti& rc, const Vector2i& ofs);
 	bool enter_window(const Recti& rc, Recti* previous, Vector2i* prevofs);
 
-	int32_t width() const;
-	int32_t height() const;
+	[[nodiscard]] int32_t width() const;
+	[[nodiscard]] int32_t height() const;
 
 	void draw_line_strip(const std::vector<Vector2f>& points, const RGBColor& color, float width);
 	void draw_rect(const Recti&, const RGBColor&);
@@ -119,13 +119,13 @@ public:
 
 	void reset();
 
-	const Surface& get_surface() const {
+	[[nodiscard]] const Surface& get_surface() const {
 		return *surface_;
 	}
-	const Recti& get_rect() const {
+	[[nodiscard]] const Recti& get_rect() const {
 		return rect_;
 	}
-	const Vector2i& get_offset() const {
+	[[nodiscard]] const Vector2i& get_offset() const {
 		return offset_;
 	}
 

--- a/src/graphic/screen.h
+++ b/src/graphic/screen.h
@@ -34,13 +34,13 @@ public:
 	}
 
 	// Implements Surface.
-	int width() const override;
-	int height() const override;
+	[[nodiscard]] int width() const override;
+	[[nodiscard]] int height() const override;
 
 	// Reads out the current pixels in the framebuffer and returns
 	// them as a texture for screenshots. This is a very slow process,
 	// so use with care.
-	std::unique_ptr<Texture> to_texture() const;
+	[[nodiscard]] std::unique_ptr<Texture> to_texture() const;
 
 private:
 	void do_blit(const Rectf& dst_rect,

--- a/src/graphic/style_manager.h
+++ b/src/graphic/style_manager.h
@@ -48,30 +48,30 @@ public:
 	StyleManager();
 	~StyleManager() = default;
 
-	const UI::BuildingStatisticsStyleInfo& building_statistics_style() const;
-	const UI::ButtonStyleInfo& button_style(UI::ButtonStyle) const;
-	const UI::TextPanelStyleInfo& slider_style(UI::SliderStyle) const;
-	const UI::PanelStyleInfo* tabpanel_style(UI::TabPanelStyle) const;
-	const UI::TextPanelStyleInfo& editbox_style(UI::PanelStyle) const;
-	const UI::PanelStyleInfo* dropdown_style(UI::PanelStyle) const;
-	const UI::PanelStyleInfo* scrollbar_style(UI::PanelStyle) const;
-	const UI::ProgressbarStyleInfo& progressbar_style(UI::PanelStyle) const;
-	const UI::StatisticsPlotStyleInfo& statistics_plot_style() const;
-	const UI::TableStyleInfo& table_style(UI::PanelStyle) const;
-	const UI::WareInfoStyleInfo& ware_info_style(UI::WareInfoStyle) const;
-	const UI::WindowStyleInfo& window_style(UI::WindowStyle) const;
-	const UI::FontStyleInfo& font_style(UI::FontStyle style) const;
+	[[nodiscard]] const UI::BuildingStatisticsStyleInfo& building_statistics_style() const;
+	[[nodiscard]] const UI::ButtonStyleInfo& button_style(UI::ButtonStyle) const;
+	[[nodiscard]] const UI::TextPanelStyleInfo& slider_style(UI::SliderStyle) const;
+	[[nodiscard]] const UI::PanelStyleInfo* tabpanel_style(UI::TabPanelStyle) const;
+	[[nodiscard]] const UI::TextPanelStyleInfo& editbox_style(UI::PanelStyle) const;
+	[[nodiscard]] const UI::PanelStyleInfo* dropdown_style(UI::PanelStyle) const;
+	[[nodiscard]] const UI::PanelStyleInfo* scrollbar_style(UI::PanelStyle) const;
+	[[nodiscard]] const UI::ProgressbarStyleInfo& progressbar_style(UI::PanelStyle) const;
+	[[nodiscard]] const UI::StatisticsPlotStyleInfo& statistics_plot_style() const;
+	[[nodiscard]] const UI::TableStyleInfo& table_style(UI::PanelStyle) const;
+	[[nodiscard]] const UI::WareInfoStyleInfo& ware_info_style(UI::WareInfoStyle) const;
+	[[nodiscard]] const UI::WindowStyleInfo& window_style(UI::WindowStyle) const;
+	[[nodiscard]] const UI::FontStyleInfo& font_style(UI::FontStyle style) const;
 
 	// Special elements
-	int minimum_font_size() const;
-	const RGBColor& minimap_icon_frame() const;
-	const RGBAColor& focused_color() const {
+	[[nodiscard]] int minimum_font_size() const;
+	[[nodiscard]] const RGBColor& minimap_icon_frame() const;
+	[[nodiscard]] const RGBAColor& focused_color() const {
 		return focused_color_;
 	}
-	const RGBAColor& semi_focused_color() const {
+	[[nodiscard]] const RGBAColor& semi_focused_color() const {
 		return semi_focused_color_;
 	}
-	int focus_border_thickness() const {
+	[[nodiscard]] int focus_border_thickness() const {
 		return focus_border_thickness_;
 	}
 	static std::string color_tag(const std::string& text, const RGBColor& color);

--- a/src/graphic/styles/building_statistics_style.h
+++ b/src/graphic/styles/building_statistics_style.h
@@ -55,44 +55,44 @@ struct BuildingStatisticsStyleInfo {
 	     alternative_high_color_(init_alt_high_color) {
 	}
 
-	const UI::FontStyleInfo& building_statistics_button_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& building_statistics_button_font() const {
 		return *building_statistics_button_font_.get();
 	}
-	const UI::FontStyleInfo& building_statistics_details_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& building_statistics_details_font() const {
 		return *building_statistics_details_font_.get();
 	}
-	int editbox_margin() const {
+	[[nodiscard]] int editbox_margin() const {
 		return editbox_margin_;
 	}
 
-	const UI::FontStyleInfo& census_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& census_font() const {
 		return *census_font_.get();
 	}
-	const UI::FontStyleInfo& statistics_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& statistics_font() const {
 		return *statistics_font_.get();
 	}
-	const RGBColor& construction_color() const {
+	[[nodiscard]] const RGBColor& construction_color() const {
 		return construction_color_;
 	}
-	const RGBColor& neutral_color() const {
+	[[nodiscard]] const RGBColor& neutral_color() const {
 		return neutral_color_;
 	}
-	const RGBColor& low_color() const {
+	[[nodiscard]] const RGBColor& low_color() const {
 		return low_color_;
 	}
-	const RGBColor& medium_color() const {
+	[[nodiscard]] const RGBColor& medium_color() const {
 		return medium_color_;
 	}
-	const RGBColor& high_color() const {
+	[[nodiscard]] const RGBColor& high_color() const {
 		return high_color_;
 	}
-	const RGBColor& alternative_low_color() const {
+	[[nodiscard]] const RGBColor& alternative_low_color() const {
 		return alternative_low_color_;
 	}
-	const RGBColor& alternative_medium_color() const {
+	[[nodiscard]] const RGBColor& alternative_medium_color() const {
 		return alternative_medium_color_;
 	}
-	const RGBColor& alternative_high_color() const {
+	[[nodiscard]] const RGBColor& alternative_high_color() const {
 		return alternative_high_color_;
 	}
 

--- a/src/graphic/styles/button_style.h
+++ b/src/graphic/styles/button_style.h
@@ -48,10 +48,10 @@ struct ButtonStyleInfo {
 	     disabled_(new UI::TextPanelStyleInfo(other.disabled())) {
 	}
 
-	const UI::TextPanelStyleInfo& enabled() const {
+	[[nodiscard]] const UI::TextPanelStyleInfo& enabled() const {
 		return *enabled_.get();
 	}
-	const UI::TextPanelStyleInfo& disabled() const {
+	[[nodiscard]] const UI::TextPanelStyleInfo& disabled() const {
 		return *disabled_.get();
 	}
 

--- a/src/graphic/styles/font_style.h
+++ b/src/graphic/styles/font_style.h
@@ -71,25 +71,25 @@ struct FontStyleInfo {
 	                       bool init_shadow);
 	explicit FontStyleInfo(const FontStyleInfo& other);
 
-	std::string as_font_tag(const std::string& text) const;
+	[[nodiscard]] std::string as_font_tag(const std::string& text) const;
 
-	Face face() const;
+	[[nodiscard]] Face face() const;
 	void make_condensed();
 
-	const RGBColor& color() const;
+	[[nodiscard]] const RGBColor& color() const;
 	void set_color(const RGBColor& new_color);
 
-	int size() const;
+	[[nodiscard]] int size() const;
 	void set_size(int new_size);
 
-	bool bold() const;
-	bool italic() const;
-	bool underline() const;
-	bool shadow() const;
+	[[nodiscard]] bool bold() const;
+	[[nodiscard]] bool italic() const;
+	[[nodiscard]] bool underline() const;
+	[[nodiscard]] bool shadow() const;
 
 private:
 	static Face string_to_face(const std::string& init_face);
-	const std::string face_to_string() const;
+	[[nodiscard]] const std::string face_to_string() const;
 
 	Face face_;
 	RGBColor color_;

--- a/src/graphic/styles/panel_styles.h
+++ b/src/graphic/styles/panel_styles.h
@@ -36,14 +36,14 @@ struct PanelStyleInfo {
 	   : margin_(other.margin()), image_(other.image()), color_(other.color()) {
 	}
 
-	const RGBAColor& color() const {
+	[[nodiscard]] const RGBAColor& color() const {
 		return color_;
 	}
-	const Image* image() const {
+	[[nodiscard]] const Image* image() const {
 		return image_;
 	}
 
-	int margin() const {
+	[[nodiscard]] int margin() const {
 		return margin_;
 	}
 

--- a/src/graphic/styles/progress_bar_style.h
+++ b/src/graphic/styles/progress_bar_style.h
@@ -43,16 +43,16 @@ struct ProgressbarStyleInfo {
 	     high_color_(other.high_color()) {
 	}
 
-	const UI::FontStyleInfo& font() const {
+	[[nodiscard]] const UI::FontStyleInfo& font() const {
 		return *font_.get();
 	}
-	const RGBColor& low_color() const {
+	[[nodiscard]] const RGBColor& low_color() const {
 		return low_color_;
 	}
-	const RGBColor& medium_color() const {
+	[[nodiscard]] const RGBColor& medium_color() const {
 		return medium_color_;
 	}
-	const RGBColor& high_color() const {
+	[[nodiscard]] const RGBColor& high_color() const {
 		return high_color_;
 	}
 

--- a/src/graphic/styles/statistics_plot_style.h
+++ b/src/graphic/styles/statistics_plot_style.h
@@ -39,19 +39,19 @@ struct StatisticsPlotStyleInfo {
 	     zero_line_color_(init_zero_line_color) {
 	}
 
-	const UI::FontStyleInfo& x_tick_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& x_tick_font() const {
 		return *x_tick_font_.get();
 	}
-	const UI::FontStyleInfo& y_min_value_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& y_min_value_font() const {
 		return *y_min_value_font_.get();
 	}
-	const UI::FontStyleInfo& y_max_value_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& y_max_value_font() const {
 		return *y_max_value_font_.get();
 	}
-	const RGBColor& axis_line_color() const {
+	[[nodiscard]] const RGBColor& axis_line_color() const {
 		return axis_line_color_;
 	}
-	const RGBColor& zero_line_color() const {
+	[[nodiscard]] const RGBColor& zero_line_color() const {
 		return zero_line_color_;
 	}
 

--- a/src/graphic/styles/table_style.h
+++ b/src/graphic/styles/table_style.h
@@ -32,13 +32,13 @@ struct TableStyleInfo {
 	   : enabled_(init_enabled), disabled_(init_disabled), hotkey_(init_hotkey) {
 	}
 
-	const UI::FontStyleInfo& enabled() const {
+	[[nodiscard]] const UI::FontStyleInfo& enabled() const {
 		return *enabled_.get();
 	}
-	const UI::FontStyleInfo& disabled() const {
+	[[nodiscard]] const UI::FontStyleInfo& disabled() const {
 		return *disabled_.get();
 	}
-	const UI::FontStyleInfo& hotkey() const {
+	[[nodiscard]] const UI::FontStyleInfo& hotkey() const {
 		return *hotkey_.get();
 	}
 

--- a/src/graphic/styles/text_panel_style.h
+++ b/src/graphic/styles/text_panel_style.h
@@ -38,14 +38,14 @@ struct TextPanelStyleInfo {
 	     font_(new UI::FontStyleInfo(other.font())) {
 	}
 
-	const UI::FontStyleInfo& font() const {
+	[[nodiscard]] const UI::FontStyleInfo& font() const {
 		return *font_.get();
 	}
 	void set_font(const UI::FontStyleInfo& new_font) {
 		font_.reset(new UI::FontStyleInfo(new_font));
 	}
 
-	const UI::PanelStyleInfo& background() const {
+	[[nodiscard]] const UI::PanelStyleInfo& background() const {
 		return *background_.get();
 	}
 

--- a/src/graphic/styles/ware_info_style.h
+++ b/src/graphic/styles/ware_info_style.h
@@ -44,22 +44,22 @@ struct WareInfoStyleInfo {
 	     info_background_(init_info_background) {
 	}
 
-	const UI::FontStyleInfo& header_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& header_font() const {
 		return *header_font_.get();
 	}
-	const UI::FontStyleInfo& info_font() const {
+	[[nodiscard]] const UI::FontStyleInfo& info_font() const {
 		return *info_font_.get();
 	}
-	const Image* icon_background_image() const {
+	[[nodiscard]] const Image* icon_background_image() const {
 		return icon_background_image_;
 	}
-	const RGBColor& icon_frame() const {
+	[[nodiscard]] const RGBColor& icon_frame() const {
 		return icon_frame_;
 	}
-	const RGBColor& icon_background() const {
+	[[nodiscard]] const RGBColor& icon_background() const {
 		return icon_background_;
 	}
-	const RGBColor& info_background() const {
+	[[nodiscard]] const RGBColor& info_background() const {
 		return info_background_;
 	}
 

--- a/src/graphic/styles/window_style.h
+++ b/src/graphic/styles/window_style.h
@@ -54,42 +54,42 @@ struct WindowStyleInfo {
 	}
 	WindowStyleInfo(const WindowStyleInfo&) = default;
 
-	const RGBAColor& window_border_focused() const {
+	[[nodiscard]] const RGBAColor& window_border_focused() const {
 		return window_border_focused_;
 	}
-	const RGBAColor& window_border_unfocused() const {
+	[[nodiscard]] const RGBAColor& window_border_unfocused() const {
 		return window_border_unfocused_;
 	}
 
-	const Image* background() const {
+	[[nodiscard]] const Image* background() const {
 		return background_;
 	}
-	const Image* border_top() const {
+	[[nodiscard]] const Image* border_top() const {
 		return border_top_;
 	}
-	const Image* border_right() const {
+	[[nodiscard]] const Image* border_right() const {
 		return border_right_;
 	}
-	const Image* border_left() const {
+	[[nodiscard]] const Image* border_left() const {
 		return border_left_;
 	}
-	const Image* border_bottom() const {
+	[[nodiscard]] const Image* border_bottom() const {
 		return border_bottom_;
 	}
 
-	const std::string& button_close() const {
+	[[nodiscard]] const std::string& button_close() const {
 		return button_close_;
 	}
-	const std::string& button_pin() const {
+	[[nodiscard]] const std::string& button_pin() const {
 		return button_pin_;
 	}
-	const std::string& button_unpin() const {
+	[[nodiscard]] const std::string& button_unpin() const {
 		return button_unpin_;
 	}
-	const std::string& button_unminimize() const {
+	[[nodiscard]] const std::string& button_unminimize() const {
 		return button_unminimize_;
 	}
-	const std::string& button_minimize() const {
+	[[nodiscard]] const std::string& button_minimize() const {
 		return button_minimize_;
 	}
 

--- a/src/graphic/surface.h
+++ b/src/graphic/surface.h
@@ -35,8 +35,8 @@ public:
 	}
 
 	/// Dimensions.
-	virtual int width() const = 0;
-	virtual int height() const = 0;
+	[[nodiscard]] virtual int width() const = 0;
+	[[nodiscard]] virtual int height() const = 0;
 
 	/// This draws a part of 'texture'.
 	void blit(const Rectf& dst,

--- a/src/graphic/text/font_set.h
+++ b/src/graphic/text/font_set.h
@@ -36,27 +36,27 @@ struct FontSet {
 	explicit FontSet(const std::string& fontset_name);
 
 	// The fontset's name
-	const std::string& name() const;
+	[[nodiscard]] const std::string& name() const;
 
 	/// All functions below return the path of the font file used for the given
 	/// style.
-	const std::string& serif() const;
-	const std::string& serif_bold() const;
-	const std::string& serif_italic() const;
-	const std::string& serif_bold_italic() const;
-	const std::string& sans() const;
-	const std::string& sans_bold() const;
-	const std::string& sans_italic() const;
-	const std::string& sans_bold_italic() const;
-	const std::string& condensed() const;
-	const std::string& condensed_bold() const;
-	const std::string& condensed_italic() const;
-	const std::string& condensed_bold_italic() const;
-	const std::string& representative_character() const;
+	[[nodiscard]] const std::string& serif() const;
+	[[nodiscard]] const std::string& serif_bold() const;
+	[[nodiscard]] const std::string& serif_italic() const;
+	[[nodiscard]] const std::string& serif_bold_italic() const;
+	[[nodiscard]] const std::string& sans() const;
+	[[nodiscard]] const std::string& sans_bold() const;
+	[[nodiscard]] const std::string& sans_italic() const;
+	[[nodiscard]] const std::string& sans_bold_italic() const;
+	[[nodiscard]] const std::string& condensed() const;
+	[[nodiscard]] const std::string& condensed_bold() const;
+	[[nodiscard]] const std::string& condensed_italic() const;
+	[[nodiscard]] const std::string& condensed_bold_italic() const;
+	[[nodiscard]] const std::string& representative_character() const;
 	// Some scripts need more vertical space than the default font, e.g. Arabic
-	uint16_t size_offset() const;
+	[[nodiscard]] uint16_t size_offset() const;
 	// Returns true iff the fontset's script is written from right to left.
-	bool is_rtl() const;
+	[[nodiscard]] bool is_rtl() const;
 
 private:
 	/// Parses font information for the given fontset name from Lua.
@@ -101,9 +101,9 @@ struct FontSets {
 	FontSets();
 
 	/// Get the fontset corresponding to the given selector.
-	const FontSet* get_fontset(UI::FontSets::Selector selector) const;
+	[[nodiscard]] const FontSet* get_fontset(UI::FontSets::Selector selector) const;
 	/// Get the fontset used by the given locale ISO code.
-	const FontSet* get_fontset(const std::string& locale) const;
+	[[nodiscard]] const FontSet* get_fontset(const std::string& locale) const;
 
 private:
 	// Maps locale ISO codes to fontset selectors.

--- a/src/graphic/text/rendered_text.h
+++ b/src/graphic/text/rendered_text.h
@@ -79,17 +79,17 @@ public:
 	explicit RenderedRect(const Image* init_image, const TextClickTarget* click_target);
 
 	/// An image to be blitted. Can be nullptr.
-	const Image* image() const;
+	[[nodiscard]] const Image* image() const;
 
-	const Recti& rect() const;
+	[[nodiscard]] const Recti& rect() const;
 	/// The x position of the rectangle
-	int x() const;
+	[[nodiscard]] int x() const;
 	/// The y position of the rectangle
-	int y() const;
+	[[nodiscard]] int y() const;
 	/// The width of the rectangle
-	int width() const;
+	[[nodiscard]] int width() const;
 	/// The height of the rectangle
-	int height() const;
+	[[nodiscard]] int height() const;
 
 	/// Change x and y position of the rectangle.
 	void set_origin(const Vector2i& new_origin);
@@ -98,18 +98,18 @@ public:
 	/// for correct positioning.
 	void set_visited();
 	/// Whether this rectangle was already visited by the font renderer
-	bool was_visited() const;
+	[[nodiscard]] bool was_visited() const;
 
 	/// Whether this rectangle contains a background color
-	bool has_background_color() const;
+	[[nodiscard]] bool has_background_color() const;
 	/// This rectangle's background color
-	const RGBColor& background_color() const;
+	[[nodiscard]] const RGBColor& background_color() const;
 
 	/// Whether the RenderedRect's image should be blitted once or tiled
-	DrawMode mode() const;
+	[[nodiscard]] DrawMode mode() const;
 
-	bool handle_mousepress(int32_t x, int32_t y) const;
-	const std::string* get_tooltip(int32_t x, int32_t y) const;
+	[[nodiscard]] bool handle_mousepress(int32_t x, int32_t y) const;
+	[[nodiscard]] const std::string* get_tooltip(int32_t x, int32_t y) const;
 
 private:
 	Recti rect_;
@@ -134,12 +134,12 @@ struct RenderedText {
 	void set_memory_tree_root(TextClickTarget* t);
 
 	/// The width occupied  by all rects in pixels.
-	int width() const;
+	[[nodiscard]] int width() const;
 	/// The height occupied  by all rects in pixels.
-	int height() const;
+	[[nodiscard]] int height() const;
 
-	bool handle_mousepress(int32_t x, int32_t y) const;
-	const std::string* get_tooltip(int32_t x, int32_t y) const;
+	[[nodiscard]] bool handle_mousepress(int32_t x, int32_t y) const;
+	[[nodiscard]] const std::string* get_tooltip(int32_t x, int32_t y) const;
 
 	enum class CropMode {
 		// The RenderTarget will handle all cropping. Use this for scrollable elements or when you

--- a/src/graphic/text/rt_errors.h
+++ b/src/graphic/text/rt_errors.h
@@ -29,7 +29,7 @@ class Exception : public std::exception {
 public:
 	explicit Exception(const std::string& msg) : std::exception(), msg_(msg) {
 	}
-	const char* what() const noexcept override {
+	[[nodiscard]] const char* what() const noexcept override {
 		return msg_.c_str();
 	}
 

--- a/src/graphic/text/rt_parse.h
+++ b/src/graphic/text/rt_parse.h
@@ -37,11 +37,11 @@ class Attr {
 public:
 	Attr(const std::string& gname, const std::string& value);
 
-	const std::string& name() const;
-	int64_t get_int(int64_t max_value) const;
-	bool get_bool() const;
-	std::string get_string() const;
-	RGBColor get_color() const;
+	[[nodiscard]] const std::string& name() const;
+	[[nodiscard]] int64_t get_int(int64_t max_value) const;
+	[[nodiscard]] bool get_bool() const;
+	[[nodiscard]] std::string get_string() const;
+	[[nodiscard]] RGBColor get_color() const;
 
 private:
 	const std::string name_, value_;
@@ -57,7 +57,7 @@ public:
 	const Attr& operator[](const std::string& s) const;
 
 	// Returns true if 'name' is a known attribute.
-	bool has(const std::string& s) const;
+	[[nodiscard]] bool has(const std::string& s) const;
 
 private:
 	std::map<std::string, std::unique_ptr<Attr>> attrs_;
@@ -78,9 +78,9 @@ public:
 
 	~Tag();
 
-	const std::string& name() const;
-	const AttrMap& attrs() const;
-	const ChildList& children() const;
+	[[nodiscard]] const std::string& name() const;
+	[[nodiscard]] const AttrMap& attrs() const;
+	[[nodiscard]] const ChildList& children() const;
 	void parse(TextStream& ts, TagConstraints& tcs, const TagSet&);
 
 private:

--- a/src/graphic/text/rt_render.cc
+++ b/src/graphic/text/rt_render.cc
@@ -229,20 +229,20 @@ public:
 	}
 	virtual ~RenderNode() = default;
 
-	virtual uint16_t width() const = 0;
-	virtual uint16_t height() const = 0;
-	virtual uint16_t hotspot_y() const = 0;
+	[[nodiscard]] virtual uint16_t width() const = 0;
+	[[nodiscard]] virtual uint16_t height() const = 0;
+	[[nodiscard]] virtual uint16_t hotspot_y() const = 0;
 	virtual std::shared_ptr<UI::RenderedText> render(TextureCache* texture_cache) = 0;
 
 	// TODO(GunChleoc): Remove this function once conversion is finished and well tested.
-	virtual std::string debug_info() const = 0;
+	[[nodiscard]] virtual std::string debug_info() const = 0;
 
 	// If a node is a non-mandatory space, it can be removed as a leading/trailing space
 	// by the positioning algorithm.
-	virtual bool is_non_mandatory_space() const {
+	[[nodiscard]] virtual bool is_non_mandatory_space() const {
 		return false;
 	}
-	virtual bool is_expanding() const {
+	[[nodiscard]] virtual bool is_expanding() const {
 		return false;
 	}
 	virtual void set_w(uint16_t /* w */) {
@@ -252,16 +252,16 @@ public:
 		return std::vector<Reference>();
 	}
 
-	Floating get_floating() const {
+	[[nodiscard]] Floating get_floating() const {
 		return floating_;
 	}
 	void set_floating(Floating f) {
 		floating_ = f;
 	}
-	UI::Align halign() const {
+	[[nodiscard]] UI::Align halign() const {
 		return halign_;
 	}
-	UI::Align valign() const {
+	[[nodiscard]] UI::Align valign() const {
 		return valign_;
 	}
 	void set_valign(UI::Align gvalign) {
@@ -270,7 +270,7 @@ public:
 
 	// True for nodes that need to stay aligned to the text baseline.
 	// False for the rest.
-	virtual bool align_to_baseline() const {
+	[[nodiscard]] virtual bool align_to_baseline() const {
 		return false;
 	}
 
@@ -280,10 +280,10 @@ public:
 	void set_y(int32_t ny) {
 		y_ = ny;
 	}
-	int32_t x() const {
+	[[nodiscard]] int32_t x() const {
 		return x_;
 	}
-	int32_t y() const {
+	[[nodiscard]] int32_t y() const {
 		return y_;
 	}
 
@@ -323,7 +323,7 @@ public:
 	}
 	virtual ~Layout() = default;
 
-	uint16_t height() const {
+	[[nodiscard]] uint16_t height() const {
 		return h_;
 	}
 	uint16_t fit_nodes(std::vector<RenderNode*>* rv, uint16_t w, Borders p, bool trim_spaces);
@@ -621,20 +621,20 @@ public:
 	TextNode(TextClickTarget* c, FontCache& font, NodeStyle& /*ns*/, const std::string& txt);
 	~TextNode() override = default;
 
-	std::string debug_info() const override {
+	[[nodiscard]] std::string debug_info() const override {
 		return "'" + txt_ + "'";
 	}
 
-	uint16_t width() const override {
+	[[nodiscard]] uint16_t width() const override {
 		return w_;
 	}
-	uint16_t height() const override {
+	[[nodiscard]] uint16_t height() const override {
 		return h_ + nodestyle_.spacing;
 	}
-	bool align_to_baseline() const override {
+	[[nodiscard]] bool align_to_baseline() const override {
 		return true;
 	}
-	uint16_t hotspot_y() const override;
+	[[nodiscard]] uint16_t hotspot_y() const override;
 	const std::vector<Reference> get_references() override {
 		std::vector<Reference> rv;
 		if (!nodestyle_.reference.empty()) {
@@ -714,13 +714,13 @@ public:
 	}
 	~FillingTextNode() override = default;
 
-	std::string debug_info() const override {
+	[[nodiscard]] std::string debug_info() const override {
 		return "ft";
 	}
 
 	std::shared_ptr<UI::RenderedText> render(TextureCache* /*texture_cache*/) override;
 
-	bool is_expanding() const override {
+	[[nodiscard]] bool is_expanding() const override {
 		return is_expanding_;
 	}
 	void set_w(uint16_t w) override {
@@ -766,7 +766,7 @@ public:
 		show_spaces_ = t;
 	}
 
-	std::string debug_info() const override {
+	[[nodiscard]] std::string debug_info() const override {
 		return "wsp";
 	}
 
@@ -787,7 +787,7 @@ public:
 		}
 		return TextNode::render(texture_cache);
 	}
-	bool is_non_mandatory_space() const override {
+	[[nodiscard]] bool is_non_mandatory_space() const override {
 		return true;
 	}
 
@@ -805,23 +805,23 @@ public:
 	explicit NewlineNode(TextClickTarget* c, NodeStyle& ns) : RenderNode(c, ns) {
 	}
 
-	std::string debug_info() const override {
+	[[nodiscard]] std::string debug_info() const override {
 		return "nl";
 	}
 
-	uint16_t height() const override {
+	[[nodiscard]] uint16_t height() const override {
 		return 0;
 	}
-	uint16_t width() const override {
+	[[nodiscard]] uint16_t width() const override {
 		return INFINITE_WIDTH;
 	}
-	uint16_t hotspot_y() const override {
+	[[nodiscard]] uint16_t hotspot_y() const override {
 		return 0;
 	}
 	std::shared_ptr<UI::RenderedText> render(TextureCache* /* texture_cache */) override {
 		return std::make_shared<UI::RenderedText>();
 	}
-	bool is_non_mandatory_space() const override {
+	[[nodiscard]] bool is_non_mandatory_space() const override {
 		return true;
 	}
 };
@@ -836,17 +836,17 @@ public:
 		check_size();
 	}
 
-	std::string debug_info() const override {
+	[[nodiscard]] std::string debug_info() const override {
 		return "sp";
 	}
 
-	uint16_t height() const override {
+	[[nodiscard]] uint16_t height() const override {
 		return h_;
 	}
-	uint16_t width() const override {
+	[[nodiscard]] uint16_t width() const override {
 		return w_;
 	}
-	uint16_t hotspot_y() const override {
+	[[nodiscard]] uint16_t hotspot_y() const override {
 		return h_;
 	}
 	std::shared_ptr<UI::RenderedText> render(TextureCache* texture_cache) override {
@@ -879,7 +879,7 @@ public:
 		return rendered_text;
 	}
 
-	bool is_expanding() const override {
+	[[nodiscard]] bool is_expanding() const override {
 		return is_expanding_;
 	}
 	void set_w(uint16_t w) override {
@@ -916,21 +916,21 @@ public:
 		nodes_to_render_.clear();
 	}
 
-	std::string debug_info() const override {
+	[[nodiscard]] std::string debug_info() const override {
 		return "div";
 	}
 
-	uint16_t width() const override {
+	[[nodiscard]] uint16_t width() const override {
 		return w_ + margin_.left + margin_.right;
 	}
-	uint16_t height() const override {
+	[[nodiscard]] uint16_t height() const override {
 		return h_ + margin_.top + margin_.bottom;
 	}
-	uint16_t hotspot_y() const override {
+	[[nodiscard]] uint16_t hotspot_y() const override {
 		return height();
 	}
 
-	DesiredWidth desired_width() const {
+	[[nodiscard]] DesiredWidth desired_width() const {
 		return desired_width_;
 	}
 
@@ -1041,17 +1041,17 @@ public:
 		check_size();
 	}
 
-	std::string debug_info() const override {
+	[[nodiscard]] std::string debug_info() const override {
 		return "img";
 	}
 
-	uint16_t width() const override {
+	[[nodiscard]] uint16_t width() const override {
 		return scale_ * image_->width();
 	}
-	uint16_t height() const override {
+	[[nodiscard]] uint16_t height() const override {
 		return scale_ * image_->height();
 	}
-	uint16_t hotspot_y() const override {
+	[[nodiscard]] uint16_t hotspot_y() const override {
 		return scale_ * image_->height();
 	}
 	std::shared_ptr<UI::RenderedText> render(TextureCache* texture_cache) override;
@@ -1123,10 +1123,10 @@ public:
 	}
 	virtual void emit_nodes(std::vector<RenderNode*>& /*nodes*/);
 
-	bool handle_mousepress(int32_t x, int32_t y) const override {
+	[[nodiscard]] bool handle_mousepress(int32_t x, int32_t y) const override {
 		return parent_ != nullptr && parent_->handle_mousepress(x, y);
 	}
-	const std::string* get_tooltip(int32_t x, int32_t y) const override {
+	[[nodiscard]] const std::string* get_tooltip(int32_t x, int32_t y) const override {
 		return parent_ == nullptr ? nullptr : parent_->get_tooltip(x, y);
 	}
 
@@ -1404,7 +1404,7 @@ public:
 		}
 	}
 
-	bool handle_mousepress(int32_t /* x */, int32_t /* y */) const override {
+	[[nodiscard]] bool handle_mousepress(int32_t /* x */, int32_t /* y */) const override {
 		switch (type_) {
 		case Type::kUI:
 			Notifications::publish(NoteHyperlink(target_, action_));
@@ -1420,7 +1420,7 @@ public:
 		NEVER_HERE();
 	}
 
-	const std::string* get_tooltip(int32_t /* x */, int32_t /* y */) const override {
+	[[nodiscard]] const std::string* get_tooltip(int32_t /* x */, int32_t /* y */) const override {
 #if !CAN_OPEN_HYPERLINK
 		if (type_ == Type::kURL) {
 			static std::string cant_open_link;

--- a/src/graphic/text/sdl_ttf_font.h
+++ b/src/graphic/text/sdl_ttf_font.h
@@ -52,8 +52,8 @@ public:
 	virtual std::shared_ptr<const Image>
 	render(const std::string&, const RGBColor& clr, int, TextureCache*) = 0;
 
-	virtual uint16_t ascent(int) const = 0;
-	virtual TTF_Font* get_ttf_font() const = 0;
+	[[nodiscard]] virtual uint16_t ascent(int) const = 0;
+	[[nodiscard]] virtual TTF_Font* get_ttf_font() const = 0;
 };
 
 // Implementation of a Font object using SDL_ttf.
@@ -65,8 +65,8 @@ public:
 	void dimensions(const std::string&, int, uint16_t* w, uint16_t* h) override;
 	std::shared_ptr<const Image>
 	render(const std::string&, const RGBColor& clr, int, TextureCache*) override;
-	uint16_t ascent(int) const override;
-	TTF_Font* get_ttf_font() const override {
+	[[nodiscard]] uint16_t ascent(int) const override;
+	[[nodiscard]] TTF_Font* get_ttf_font() const override {
 		return font_;
 	}
 

--- a/src/graphic/text/textstream.h
+++ b/src/graphic/text/textstream.h
@@ -29,17 +29,17 @@ public:
 	   : text_(text), line_(1), col_(0), pos_(0), end_(text.size()) {
 	}
 
-	size_t line() const {
+	[[nodiscard]] size_t line() const {
 		return line_;
 	}
-	size_t col() const {
+	[[nodiscard]] size_t col() const {
 		return col_;
 	}
-	size_t pos() const {
+	[[nodiscard]] size_t pos() const {
 		return pos_;
 	}
 
-	std::string peek(size_t, size_t = -1) const;
+	[[nodiscard]] std::string peek(size_t, size_t = -1) const;
 	void expect(std::string, bool = true);
 
 	std::string till_any(std::string);

--- a/src/graphic/texture.cc
+++ b/src/graphic/texture.cc
@@ -73,7 +73,7 @@ public:
 		glDeleteFramebuffers(1, &gl_framebuffer_id_);
 	}
 
-	GLuint id() const {
+	[[nodiscard]] GLuint id() const {
 		return gl_framebuffer_id_;
 	}
 

--- a/src/graphic/texture.h
+++ b/src/graphic/texture.h
@@ -43,11 +43,11 @@ public:
 	~Texture() override;
 
 	// Implements Surface
-	int width() const override;
-	int height() const override;
+	[[nodiscard]] int width() const override;
+	[[nodiscard]] int height() const override;
 
 	// Implements Image.
-	const BlitData& blit_data() const override;
+	[[nodiscard]] const BlitData& blit_data() const override;
 
 	enum UnlockMode {
 		/**

--- a/src/graphic/wordwrap.h
+++ b/src/graphic/wordwrap.h
@@ -42,12 +42,12 @@ struct WordWrap {
 
 	void set_wrapwidth(uint32_t wrapwidth);
 
-	uint32_t wrapwidth() const;
+	[[nodiscard]] uint32_t wrapwidth() const;
 
 	void wrap(const std::string& text);
 
-	uint32_t width() const;
-	uint32_t height() const;
+	[[nodiscard]] uint32_t width() const;
+	[[nodiscard]] uint32_t height() const;
 	void set_draw_caret(bool draw_it) {
 		draw_caret_ = draw_it;
 	}
@@ -63,12 +63,12 @@ struct WordWrap {
 	          const std::string& caret_image_path = std::string());
 
 	void calc_wrapped_pos(uint32_t caret, uint32_t& line, uint32_t& pos) const;
-	uint32_t nrlines() const {
+	[[nodiscard]] uint32_t nrlines() const {
 		return lines_.size();
 	}
-	uint32_t line_offset(uint32_t line) const;
-	uint32_t offset_of_line_at(int32_t y) const;
-	std::string text_of_line_at(int32_t y) const;
+	[[nodiscard]] uint32_t line_offset(uint32_t line) const;
+	[[nodiscard]] uint32_t offset_of_line_at(int32_t y) const;
+	[[nodiscard]] std::string text_of_line_at(int32_t y) const;
 	int text_width_of(std::string& text) const;
 
 	void focus();
@@ -89,10 +89,10 @@ private:
 	                         std::string::size_type& next_line_start,
 	                         uint32_t safety_margin);
 
-	bool line_fits(const std::string& text, uint32_t safety_margin) const;
+	[[nodiscard]] bool line_fits(const std::string& text, uint32_t safety_margin) const;
 
-	uint32_t quick_width(const UChar& c) const;
-	uint32_t quick_width(const std::string& text) const;
+	[[nodiscard]] uint32_t quick_width(const UChar& c) const;
+	[[nodiscard]] uint32_t quick_width(const std::string& text) const;
 
 	uint32_t wrapwidth_;
 	bool draw_caret_;
@@ -114,7 +114,7 @@ private:
 	                         const int fontheight,
 	                         uint32_t line,
 	                         const Vector2i& point) const;
-	uint32_t line_index(int32_t y) const;
+	[[nodiscard]] uint32_t line_index(int32_t y) const;
 	ScopedTimer caret_timer_;
 	uint32_t caret_ms_;
 	ScopedTimer cursor_movement_timer_;

--- a/src/io/fileread.h
+++ b/src/io/fileread.h
@@ -41,7 +41,7 @@ public:
 			return std::numeric_limits<size_t>::max();
 		}
 
-		bool is_null() const {
+		[[nodiscard]] bool is_null() const {
 			return *this == null();
 		}
 		operator size_t() const {
@@ -71,7 +71,7 @@ public:
 
 	// See base class.
 	size_t data(void* dst, size_t bufsize) override;
-	bool end_of_file() const override;
+	[[nodiscard]] bool end_of_file() const override;
 	char const* c_string() override;
 
 	/// Loads a file into memory. Reserves one additional byte which is zeroed,
@@ -90,7 +90,7 @@ public:
 	void close();
 
 	// Returns the size of the file in bytes;
-	size_t get_size() const;
+	[[nodiscard]] size_t get_size() const;
 
 	/// Set the file pointer to the given location.
 	/// \throws File_Boundary_Exceeded if the pointer is out of bound.
@@ -98,7 +98,7 @@ public:
 
 	/// Get the position that will be read from in the next read operation that
 	/// does not specify a position.
-	Pos get_pos() const;
+	[[nodiscard]] Pos get_pos() const;
 
 	// Returns the next 'bytes' starting at 'pos' in the file. Can throw
 	// File_Boundary_Exceeded.

--- a/src/io/filesystem/disk_filesystem.cc
+++ b/src/io/filesystem/disk_filesystem.cc
@@ -500,7 +500,7 @@ struct RealFSStreamRead : public StreamRead {
 		return fread(read_data, 1, bufsize, file_);
 	}
 
-	bool end_of_file() const override {
+	[[nodiscard]] bool end_of_file() const override {
 		return feof(file_) != 0;
 	}
 

--- a/src/io/filesystem/disk_filesystem.h
+++ b/src/io/filesystem/disk_filesystem.h
@@ -26,11 +26,11 @@ class RealFSImpl : public FileSystem {
 public:
 	explicit RealFSImpl(const std::string& Directory);
 
-	FilenameSet list_directory(const std::string& path) const override;
+	[[nodiscard]] FilenameSet list_directory(const std::string& path) const override;
 
-	bool is_writable() const override;
-	bool file_exists(const std::string& path) const override;
-	bool is_directory(const std::string& path) const override;
+	[[nodiscard]] bool is_writable() const override;
+	[[nodiscard]] bool file_exists(const std::string& path) const override;
+	[[nodiscard]] bool is_directory(const std::string& path) const override;
 	void ensure_directory_exists(const std::string& fs_dirname) override;
 	void make_directory(const std::string& fs_dirname) override;
 

--- a/src/io/filesystem/filesystem.h
+++ b/src/io/filesystem/filesystem.h
@@ -131,7 +131,8 @@ public:
 	/// Return the files in the given 'directory' that match the condition in 'test', i.e. 'test'
 	/// returned 'true' for their filenames.
 	template <class UnaryPredicate>
-	[[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] FilenameSet filter_directory(const std::string& directory, UnaryPredicate test) const {
+	[[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] FilenameSet
+	filter_directory(const std::string& directory, UnaryPredicate test) const {
 		FilenameSet result = list_directory(directory);
 		for (auto it = result.begin(); it != result.end();) {
 			if (!test(*it)) {
@@ -146,8 +147,8 @@ public:
 	/// Returns all files in the given 'directory' that match 'basename' followed by 1-3 numbers,
 	/// followed by '.', followed by 'extension'
 	[[nodiscard]] std::vector<std::string> get_sequential_files(const std::string& directory,
-	                                              const std::string& basename,
-	                                              const std::string& extension) const;
+	                                                            const std::string& basename,
+	                                                            const std::string& extension) const;
 
 	virtual unsigned long long disk_space() = 0;  // NOLINT
 

--- a/src/io/filesystem/filesystem.h
+++ b/src/io/filesystem/filesystem.h
@@ -46,7 +46,7 @@ public:
 
 	[[nodiscard]] virtual bool is_writable() const = 0;
 	[[nodiscard]] virtual bool is_directory(const std::string& path) const = 0;
-	[[nodiscard]] virtual bool file_exists(const std::string& path) const = 0;
+	virtual bool file_exists(const std::string& path) const = 0;  // NOLINT not nodicard
 
 	virtual void* load(const std::string& fname, size_t& length) = 0;
 

--- a/src/io/filesystem/filesystem.h
+++ b/src/io/filesystem/filesystem.h
@@ -42,11 +42,11 @@ public:
 	}
 
 	// Returns all files and directories (full path) in the given directory 'directory'.
-	virtual FilenameSet list_directory(const std::string& directory) const = 0;
+	[[nodiscard]] virtual FilenameSet list_directory(const std::string& directory) const = 0;
 
-	virtual bool is_writable() const = 0;
-	virtual bool is_directory(const std::string& path) const = 0;
-	virtual bool file_exists(const std::string& path) const = 0;
+	[[nodiscard]] virtual bool is_writable() const = 0;
+	[[nodiscard]] virtual bool is_directory(const std::string& path) const = 0;
+	[[nodiscard]] virtual bool file_exists(const std::string& path) const = 0;
 
 	virtual void* load(const std::string& fname, size_t& length) = 0;
 
@@ -96,9 +96,9 @@ public:
 	virtual std::string get_basename() = 0;
 
 	// basic path/filename manipulation
-	std::string fix_cross_file(const std::string&) const;
-	std::string canonicalize_name(const std::string& path) const;
-	bool is_path_absolute(const std::string& path) const;
+	[[nodiscard]] std::string fix_cross_file(const std::string&) const;
+	[[nodiscard]] std::string canonicalize_name(const std::string& path) const;
+	[[nodiscard]] bool is_path_absolute(const std::string& path) const;
 
 	// Returns the path separator, i.e. \ on windows and / everywhere else.
 	static char file_separator();
@@ -131,7 +131,7 @@ public:
 	/// Return the files in the given 'directory' that match the condition in 'test', i.e. 'test'
 	/// returned 'true' for their filenames.
 	template <class UnaryPredicate>
-	FilenameSet filter_directory(const std::string& directory, UnaryPredicate test) const {
+	[[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] FilenameSet filter_directory(const std::string& directory, UnaryPredicate test) const {
 		FilenameSet result = list_directory(directory);
 		for (auto it = result.begin(); it != result.end();) {
 			if (!test(*it)) {
@@ -145,7 +145,7 @@ public:
 
 	/// Returns all files in the given 'directory' that match 'basename' followed by 1-3 numbers,
 	/// followed by '.', followed by 'extension'
-	std::vector<std::string> get_sequential_files(const std::string& directory,
+	[[nodiscard]] std::vector<std::string> get_sequential_files(const std::string& directory,
 	                                              const std::string& basename,
 	                                              const std::string& extension) const;
 

--- a/src/io/filesystem/layered_filesystem.h
+++ b/src/io/filesystem/layered_filesystem.h
@@ -55,11 +55,11 @@ public:
 	// files). Take ownership of the given filesystem.
 	void set_home_file_system(FileSystem*);
 
-	FilenameSet list_directory(const std::string& path) const override;
+	[[nodiscard]] FilenameSet list_directory(const std::string& path) const override;
 
-	bool is_writable() const override;
-	bool file_exists(const std::string& path) const override;
-	bool is_directory(const std::string& path) const override;
+	[[nodiscard]] bool is_writable() const override;
+	[[nodiscard]] bool file_exists(const std::string& path) const override;
+	[[nodiscard]] bool is_directory(const std::string& path) const override;
 	void ensure_directory_exists(const std::string& fs_dirname) override;
 	void make_directory(const std::string& fs_dirname) override;
 
@@ -82,7 +82,7 @@ public:
 
 private:
 	/// This is used to assemble an error message for exceptions that includes all file paths
-	std::string paths_error_message(const std::string& filename) const;
+	[[nodiscard]] std::string paths_error_message(const std::string& filename) const;
 
 	std::vector<std::unique_ptr<FileSystem>> filesystems_;
 	std::unique_ptr<FileSystem> home_;

--- a/src/io/filesystem/zip_filesystem.h
+++ b/src/io/filesystem/zip_filesystem.h
@@ -38,7 +38,7 @@ public:
 	[[nodiscard]] FilenameSet list_directory(const std::string& path) const override;
 
 	[[nodiscard]] bool is_directory(const std::string& path) const override;
-	[[nodiscard]] bool file_exists(const std::string& path) const override;
+	bool file_exists(const std::string& path) const override;  // NOLINT not nodicard
 
 	void* load(const std::string& fname, size_t& length) override;
 

--- a/src/io/filesystem/zip_filesystem.h
+++ b/src/io/filesystem/zip_filesystem.h
@@ -33,12 +33,12 @@ public:
 	explicit ZipFilesystem(const std::string&);
 	~ZipFilesystem() override = default;
 
-	bool is_writable() const override;
+	[[nodiscard]] bool is_writable() const override;
 
-	FilenameSet list_directory(const std::string& path) const override;
+	[[nodiscard]] FilenameSet list_directory(const std::string& path) const override;
 
-	bool is_directory(const std::string& path) const override;
-	bool file_exists(const std::string& path) const override;
+	[[nodiscard]] bool is_directory(const std::string& path) const override;
+	[[nodiscard]] bool file_exists(const std::string& path) const override;
 
 	void* load(const std::string& fname, size_t& length) override;
 
@@ -79,7 +79,7 @@ private:
 		std::string strip_basename(const std::string& filename);
 
 		// Full path to the zip file.
-		const std::string& path() const;
+		[[nodiscard]] const std::string& path() const;
 
 		// Closes the file if it is open, reopens it for writing, and
 		// returns the minizip handle.
@@ -121,7 +121,7 @@ private:
 		explicit ZipStreamRead(const std::shared_ptr<ZipFile>& shared_data);
 		~ZipStreamRead() override = default;
 		size_t data(void* data, size_t bufsize) override;
-		bool end_of_file() const override;
+		[[nodiscard]] bool end_of_file() const override;
 
 	private:
 		std::shared_ptr<ZipFile> zip_file_;

--- a/src/io/filewrite.h
+++ b/src/io/filewrite.h
@@ -38,7 +38,7 @@ public:
 			return std::numeric_limits<size_t>::max();
 		}
 
-		bool is_null() const {
+		[[nodiscard]] bool is_null() const {
 			return *this == null();
 		}
 		operator size_t() const {
@@ -74,7 +74,7 @@ public:
 
 	/// Get the position that will be written to in the next write operation that
 	/// does not specify a position.
-	Pos get_pos() const;
+	[[nodiscard]] Pos get_pos() const;
 
 	/// Set the file pointer to a new location. The position can be beyond the
 	/// current end of file.
@@ -87,7 +87,7 @@ public:
 	void data(void const* src, size_t size) override;
 
 	/// Returns the current buffer. Use this for in_memory operations.
-	std::string get_data() const;
+	[[nodiscard]] std::string get_data() const;
 
 private:
 	char* data_;

--- a/src/io/profile.h
+++ b/src/io/profile.h
@@ -63,21 +63,21 @@ public:
 		Value& operator=(Value) noexcept;
 		Value& operator=(Value&& other) noexcept;
 
-		char const* get_name() const {
+		[[nodiscard]] char const* get_name() const {
 			return name_.c_str();
 		}
 
-		bool is_used() const;
+		[[nodiscard]] bool is_used() const;
 		void mark_used();
 
-		int32_t get_int() const;
-		uint32_t get_natural() const;
-		uint32_t get_positive() const;
-		bool get_bool() const;
-		char const* get_string() const;
-		Vector2i get_point() const;
+		[[nodiscard]] int32_t get_int() const;
+		[[nodiscard]] uint32_t get_natural() const;
+		[[nodiscard]] uint32_t get_positive() const;
+		[[nodiscard]] bool get_bool() const;
+		[[nodiscard]] char const* get_string() const;
+		[[nodiscard]] Vector2i get_point() const;
 
-		char const* get_untranslated_string() const {
+		[[nodiscard]] char const* get_untranslated_string() const {
 			return value_.get();
 		}
 		char* get_untranslated_string() {
@@ -86,7 +86,7 @@ public:
 
 		void set_string(char const*);
 
-		bool get_translate() const {
+		[[nodiscard]] bool get_translate() const {
 			return translate_;
 		}
 		void set_translate(const bool t) {
@@ -125,14 +125,14 @@ public:
 
 	Value* get_val(char const* name);
 	Value* get_next_val(char const* name = nullptr);
-	uint32_t get_num_values() const {
+	[[nodiscard]] uint32_t get_num_values() const {
 		return values_.size();
 	}
 
-	char const* get_name() const;
+	[[nodiscard]] char const* get_name() const;
 	void set_name(const std::string&);
 
-	bool is_used() const;
+	[[nodiscard]] bool is_used() const;
 	void mark_used();
 
 	void check_used() const;

--- a/src/io/streamread.h
+++ b/src/io/streamread.h
@@ -52,7 +52,7 @@ public:
 	/**
 	 * \return \c true if the end of file / end of stream has been reached.
 	 */
-	virtual bool end_of_file() const = 0;
+	[[nodiscard]] virtual bool end_of_file() const = 0;
 
 	void data_complete(void* data, size_t size);
 

--- a/src/logic/addons.h
+++ b/src/logic/addons.h
@@ -123,10 +123,10 @@ struct AddOnInfo {
 	uint32_t votes[kMaxRating] = {0};  ///< Total number of votes for each of the ratings 1-10.
 	std::map<size_t, AddOnComment> user_comments;
 
-	bool matches_widelands_version() const;
-	uint32_t number_of_votes() const;
-	double average_rating() const;
-	bool requires_texture_atlas_rebuild() const;
+	[[nodiscard]] bool matches_widelands_version() const;
+	[[nodiscard]] uint32_t number_of_votes() const;
+	[[nodiscard]] double average_rating() const;
+	[[nodiscard]] bool requires_texture_atlas_rebuild() const;
 };
 
 using AddOnsList = std::vector<std::shared_ptr<AddOns::AddOnInfo>>;

--- a/src/logic/cmd_calculate_statistics.h
+++ b/src/logic/cmd_calculate_statistics.h
@@ -33,7 +33,7 @@ struct CmdCalculateStatistics : public GameLogicCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kCalculateStatistics;
 	}
 	void execute(Game&) override;

--- a/src/logic/cmd_delete_message.h
+++ b/src/logic/cmd_delete_message.h
@@ -39,7 +39,7 @@ struct CmdDeleteMessage : public Command {
 	}
 
 	void execute(Game& game) override;
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kDeleteMessage;
 	}
 

--- a/src/logic/cmd_incorporate.h
+++ b/src/logic/cmd_incorporate.h
@@ -37,7 +37,7 @@ struct CmdIncorporate : public GameLogicCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kIncorporate;
 	}
 

--- a/src/logic/cmd_luacoroutine.h
+++ b/src/logic/cmd_luacoroutine.h
@@ -39,7 +39,7 @@ struct CmdLuaCoroutine : public GameLogicCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kLuaCoroutine;
 	}
 

--- a/src/logic/cmd_luascript.h
+++ b/src/logic/cmd_luascript.h
@@ -36,7 +36,7 @@ struct CmdLuaScript : public GameLogicCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kLuaScript;
 	}
 

--- a/src/logic/cmd_queue.h
+++ b/src/logic/cmd_queue.h
@@ -67,9 +67,9 @@ struct Command {
 	virtual ~Command() = default;
 
 	virtual void execute(Game&) = 0;
-	virtual QueueCommandTypes id() const = 0;
+	[[nodiscard]] virtual QueueCommandTypes id() const = 0;
 
-	const Time& duetime() const {
+	[[nodiscard]] const Time& duetime() const {
 		return duetime_;
 	}
 	void set_duetime(const Time& t) {

--- a/src/logic/cookie_priority_queue.h
+++ b/src/logic/cookie_priority_queue.h
@@ -41,7 +41,7 @@ template <typename CT> struct CookiePriorityQueueBase {
 		}
 
 		/** Returns \c true if the cookie is currently managed by a queue */
-		bool is_active() const {
+		[[nodiscard]] bool is_active() const {
 			return pos != bad_pos();
 		}
 
@@ -96,16 +96,16 @@ struct CookiePriorityQueue : CookiePriorityQueueBase<CPQType> {
 	                             const CookieAccessor& accessor = CookieAccessor());
 	~CookiePriorityQueue();
 
-	CookieSizeType size() const;
-	bool empty() const;
-	CookieType* top() const;
+	[[nodiscard]] CookieSizeType size() const;
+	[[nodiscard]] bool empty() const;
+	[[nodiscard]] CookieType* top() const;
 
 	void push(CookieType* elt);
 	void pop(CookieType* elt);
 	void decrease_key(CookieType* elt);
 	void increase_key(CookieType* elt);
 
-	Widelands::WareWorker type() const {
+	[[nodiscard]] Widelands::WareWorker type() const {
 		return type_;
 	}
 

--- a/src/logic/field.h
+++ b/src/logic/field.h
@@ -110,28 +110,28 @@ public:
 		return *this;
 	}
 
-	Height get_height() const {
+	[[nodiscard]] Height get_height() const {
 		return height;
 	}
-	NodeCaps nodecaps() const {
+	[[nodiscard]] NodeCaps nodecaps() const {
 		return static_cast<NodeCaps>(caps);
 	}
-	NodeCaps maxcaps() const {
+	[[nodiscard]] NodeCaps maxcaps() const {
 		return static_cast<NodeCaps>(max_caps);
 	}
-	uint16_t get_caps() const {
+	[[nodiscard]] uint16_t get_caps() const {
 		return caps;
 	}
 
-	Terrains get_terrains() const {
+	[[nodiscard]] Terrains get_terrains() const {
 		return terrains;
 	}
 	// The terrain on the downward triangle
-	DescriptionIndex terrain_d() const {
+	[[nodiscard]] DescriptionIndex terrain_d() const {
 		return terrains.d;
 	}
 	// The terrain on the triangle to the right
-	DescriptionIndex terrain_r() const {
+	[[nodiscard]] DescriptionIndex terrain_r() const {
 		return terrains.r;
 	}
 	void set_terrains(const Terrains& i) {
@@ -152,10 +152,10 @@ public:
 		terrains.r = i;
 	}
 
-	Bob* get_first_bob() const {
+	[[nodiscard]] Bob* get_first_bob() const {
 		return bobs;
 	}
-	const BaseImmovable* get_immovable() const {
+	[[nodiscard]] const BaseImmovable* get_immovable() const {
 		return immovable;
 	}
 	BaseImmovable* get_immovable() {
@@ -163,7 +163,7 @@ public:
 	}
 
 	void set_brightness(int32_t l, int32_t r, int32_t tl, int32_t tr, int32_t bl, int32_t br);
-	int8_t get_brightness() const {
+	[[nodiscard]] int8_t get_brightness() const {
 		return brightness;
 	}
 
@@ -176,11 +176,11 @@ public:
 		owner_info_and_selections = n | (owner_info_and_selections & ~Player_Number_Bitmask);
 	}
 
-	PlayerNumber get_owned_by() const {
+	[[nodiscard]] PlayerNumber get_owned_by() const {
 		assert((owner_info_and_selections & Player_Number_Bitmask) <= kMaxPlayers);
 		return owner_info_and_selections & Player_Number_Bitmask;
 	}
-	bool is_border() const {
+	[[nodiscard]] bool is_border() const {
 		return owner_info_and_selections & Border_Bitmask;
 	}
 
@@ -191,7 +191,7 @@ public:
 	///
 	/// player_number must be in the range 1 .. Player_Number_Bitmask or the
 	/// behaviour is undefined.
-	bool is_interior(const PlayerNumber player_number) const {
+	[[nodiscard]] bool is_interior(const PlayerNumber player_number) const {
 		assert(0 < player_number);
 		assert(player_number <= Player_Number_Bitmask);
 		return player_number == (owner_info_and_selections & Owner_Info_Bitmask);
@@ -201,7 +201,7 @@ public:
 		owner_info_and_selections = (owner_info_and_selections & ~Border_Bitmask) | (b << Border_Bit);
 	}
 
-	RoadSegment get_road(uint8_t dir) const {
+	[[nodiscard]] RoadSegment get_road(uint8_t dir) const {
 		switch (dir) {
 		case WalkingDir::WALK_E:
 			return road_east;
@@ -231,14 +231,14 @@ public:
 
 	// Resources can be set through Map::set_resources()
 	// TODO(unknown): This should return DescriptionIndex
-	DescriptionIndex get_resources() const {
+	[[nodiscard]] DescriptionIndex get_resources() const {
 		return resources;
 	}
-	ResourceAmount get_resources_amount() const {
+	[[nodiscard]] ResourceAmount get_resources_amount() const {
 		return res_amount;
 	}
 	// TODO(unknown): This should return uint8_t
-	ResourceAmount get_initial_res_amount() const {
+	[[nodiscard]] ResourceAmount get_initial_res_amount() const {
 		return initial_res_amount;
 	}
 

--- a/src/logic/game_data_error.h
+++ b/src/logic/game_data_error.h
@@ -28,7 +28,7 @@ namespace Widelands {
 struct GameDataError : public WException {
 	explicit GameDataError(char const* fmt, ...) PRINTF_FORMAT(2, 3);
 
-	char const* what() const noexcept override {
+	[[nodiscard]] char const* what() const noexcept override {
 		return what_.c_str();
 	}
 
@@ -53,7 +53,7 @@ struct UnhandledVersionError : public GameDataError {
 	                               int32_t packet_version,
 	                               int32_t current_packet_version);
 
-	char const* what() const noexcept override {
+	[[nodiscard]] char const* what() const noexcept override {
 		return what_.c_str();
 	}
 

--- a/src/logic/game_settings.h
+++ b/src/logic/game_settings.h
@@ -152,17 +152,17 @@ struct GameSettings {
 	}
 
 	/// Returns the basic preload info for a tribe.
-	Widelands::TribeBasicInfo get_tribeinfo(const std::string& tribename) const;
+	[[nodiscard]] Widelands::TribeBasicInfo get_tribeinfo(const std::string& tribename) const;
 
 	/// Find a player number that the slot could share in. Does not guarantee that a viable slot was
 	/// actually found.
-	Widelands::PlayerNumber find_shared(PlayerSlot slot) const;
+	[[nodiscard]] Widelands::PlayerNumber find_shared(PlayerSlot slot) const;
 	/// Check if the player number returned by find_shared is usable
-	bool is_shared_usable(PlayerSlot slot, Widelands::PlayerNumber shared) const;
+	[[nodiscard]] bool is_shared_usable(PlayerSlot slot, Widelands::PlayerNumber shared) const;
 	/// Savegame slots and certain scenario slots can't be closed
-	bool uncloseable(PlayerSlot slot) const;
+	[[nodiscard]] bool uncloseable(PlayerSlot slot) const;
 	/// AIs cannot be changed in scenarios
-	bool allows_ais(PlayerSlot slot) const;
+	[[nodiscard]] bool allows_ais(PlayerSlot slot) const;
 
 	/// Number of player position of the host player
 	int16_t playernum;

--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -255,7 +255,7 @@ public:
 	 * Counts the valuable fields that are owned by each player. Only players that currently own a
 	 * field are added. Returns a map of <player number, number of owned fields>.
 	 */
-	std::map<PlayerNumber, size_t>
+	[[nodiscard]] std::map<PlayerNumber, size_t>
 	count_owned_valuable_fields(const std::string& immovable_attribute) const;
 
 	/***
@@ -275,7 +275,7 @@ public:
 	void set_nrplayers(PlayerNumber);
 
 	void set_starting_pos(PlayerNumber, const Coords&);
-	Coords get_starting_pos(PlayerNumber const p) const {
+	[[nodiscard]] Coords get_starting_pos(PlayerNumber const p) const {
 		assert(1 <= p && p <= get_nrplayers());
 		return starting_pos_[p - 1];
 	}
@@ -296,93 +296,93 @@ public:
 
 	// Allows access to the filesystem of the map to access auxiliary files.
 	// This can be nullptr if this file is new.
-	FileSystem* filesystem() const;
+	[[nodiscard]] FileSystem* filesystem() const;
 	// swap the filesystem after load / save
 	void swap_filesystem(std::unique_ptr<FileSystem>& fs);
 	void reset_filesystem();
 
 	// informational functions
-	const std::string& get_filename() const {
+	[[nodiscard]] const std::string& get_filename() const {
 		return filename_;
 	}
-	const std::string& get_author() const {
+	[[nodiscard]] const std::string& get_author() const {
 		return author_;
 	}
-	bool get_localize_author() const {
+	[[nodiscard]] bool get_localize_author() const {
 		return localize_author_;
 	}
-	const std::string& get_name() const {
+	[[nodiscard]] const std::string& get_name() const {
 		return name_;
 	}
-	const std::string& get_description() const {
+	[[nodiscard]] const std::string& get_description() const {
 		return description_;
 	}
-	const std::string& get_hint() const {
+	[[nodiscard]] const std::string& get_hint() const {
 		return hint_;
 	}
-	const std::string& get_background() const {
+	[[nodiscard]] const std::string& get_background() const {
 		return background_;
 	}
-	const std::string& get_background_theme() const {
+	[[nodiscard]] const std::string& get_background_theme() const {
 		return background_theme_;
 	}
 
-	const MapVersion& version() const {
+	[[nodiscard]] const MapVersion& version() const {
 		return map_version_;
 	}
 
 	using Tags = std::set<std::string>;
-	const Tags& get_tags() const {
+	[[nodiscard]] const Tags& get_tags() const {
 		return tags_;
 	}
 	void clear_tags() {
 		tags_.clear();
 	}
-	bool has_tag(const std::string& s) const {
+	[[nodiscard]] bool has_tag(const std::string& s) const {
 		return tags_.count(s);
 	}
 
-	const std::vector<SuggestedTeamLineup>& get_suggested_teams() const {
+	[[nodiscard]] const std::vector<SuggestedTeamLineup>& get_suggested_teams() const {
 		return suggested_teams_;
 	}
 	std::vector<SuggestedTeamLineup>& get_suggested_teams() {
 		return suggested_teams_;
 	}
 
-	PlayerNumber get_nrplayers() const {
+	[[nodiscard]] PlayerNumber get_nrplayers() const {
 		return nrplayers_;
 	}
-	ScenarioTypes scenario_types() const {
+	[[nodiscard]] ScenarioTypes scenario_types() const {
 		return scenario_types_;
 	}
-	Extent extent() const {
+	[[nodiscard]] Extent extent() const {
 		return Extent(width_, height_);
 	}
-	int16_t get_width() const {
+	[[nodiscard]] int16_t get_width() const {
 		return width_;
 	}
-	int16_t get_height() const {
+	[[nodiscard]] int16_t get_height() const {
 		return height_;
 	}
 
 	// Map compatibility information for the website
-	const std::string& minimum_required_widelands_version() const;
+	[[nodiscard]] const std::string& minimum_required_widelands_version() const;
 
 	//  The next few functions are only valid when the map is loaded as a
 	//  scenario.
-	const std::string& get_scenario_player_tribe(PlayerNumber) const;
-	const std::string& get_scenario_player_name(PlayerNumber) const;
-	const std::string& get_scenario_player_ai(PlayerNumber) const;
-	bool get_scenario_player_closeable(PlayerNumber) const;
+	[[nodiscard]] const std::string& get_scenario_player_tribe(PlayerNumber) const;
+	[[nodiscard]] const std::string& get_scenario_player_name(PlayerNumber) const;
+	[[nodiscard]] const std::string& get_scenario_player_ai(PlayerNumber) const;
+	[[nodiscard]] bool get_scenario_player_closeable(PlayerNumber) const;
 	void set_scenario_player_tribe(PlayerNumber, const std::string&);
 	void set_scenario_player_name(PlayerNumber, const std::string&);
 	void set_scenario_player_ai(PlayerNumber, const std::string&);
 	void set_scenario_player_closeable(PlayerNumber, bool);
 
 	/// \returns the maximum theoretical possible nodecaps (no blocking bobs, immovables etc.)
-	NodeCaps get_max_nodecaps(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] NodeCaps get_max_nodecaps(const EditorGameBase&, const FCoords&) const;
 
-	BaseImmovable* get_immovable(const Coords&) const;
+	[[nodiscard]] BaseImmovable* get_immovable(const Coords&) const;
 	uint32_t find_bobs(const EditorGameBase&,
 	                   const Area<FCoords>,
 	                   std::vector<Bob*>* list,
@@ -419,58 +419,58 @@ public:
 
 	// Field logic
 	static MapIndex get_index(const Coords&, int16_t width);
-	MapIndex get_index(const Coords&) const;
-	MapIndex max_index() const {
+	[[nodiscard]] MapIndex get_index(const Coords&) const;
+	[[nodiscard]] MapIndex max_index() const {
 		return width_ * height_;
 	}
 	Field& operator[](MapIndex) const;
 	Field& operator[](const Coords&) const;
-	FCoords get_fcoords(const Coords&) const;
+	[[nodiscard]] FCoords get_fcoords(const Coords&) const;
 	static void normalize_coords(Coords&, int16_t, int16_t);
 	void normalize_coords(Coords&) const;
 	FCoords get_fcoords(Field&) const;
 	void get_coords(Field& f, Coords& c) const;
 
-	uint32_t calc_distance(const Coords&, const Coords&) const;
+	[[nodiscard]] uint32_t calc_distance(const Coords&, const Coords&) const;
 
-	int32_t calc_cost_estimate(const Coords&, const Coords&) const override;
-	int32_t calc_cost_lowerbound(const Coords&, const Coords&) const;
-	int32_t calc_cost(int32_t slope) const;
-	int32_t calc_cost(const Coords&, int32_t dir) const;
-	int32_t calc_bidi_cost(const Coords&, int32_t dir) const;
+	[[nodiscard]] int32_t calc_cost_estimate(const Coords&, const Coords&) const override;
+	[[nodiscard]] int32_t calc_cost_lowerbound(const Coords&, const Coords&) const;
+	[[nodiscard]] int32_t calc_cost(int32_t slope) const;
+	[[nodiscard]] int32_t calc_cost(const Coords&, int32_t dir) const;
+	[[nodiscard]] int32_t calc_bidi_cost(const Coords&, int32_t dir) const;
 	void calc_cost(const Path&, int32_t* forward, int32_t* backward) const;
 
 	void get_ln(const Coords&, Coords*) const;
 	void get_ln(const FCoords&, FCoords*) const;
-	Coords l_n(const Coords&) const;
-	FCoords l_n(const FCoords&) const;
+	[[nodiscard]] Coords l_n(const Coords&) const;
+	[[nodiscard]] FCoords l_n(const FCoords&) const;
 	void get_rn(const Coords&, Coords*) const;
 	void get_rn(const FCoords&, FCoords*) const;
-	Coords r_n(const Coords&) const;
-	FCoords r_n(const FCoords&) const;
+	[[nodiscard]] Coords r_n(const Coords&) const;
+	[[nodiscard]] FCoords r_n(const FCoords&) const;
 	void get_tln(const Coords&, Coords*) const;
 	void get_tln(const FCoords&, FCoords*) const;
-	Coords tl_n(const Coords&) const;
-	FCoords tl_n(const FCoords&) const;
+	[[nodiscard]] Coords tl_n(const Coords&) const;
+	[[nodiscard]] FCoords tl_n(const FCoords&) const;
 	void get_trn(const Coords&, Coords*) const;
 	void get_trn(const FCoords&, FCoords*) const;
-	Coords tr_n(const Coords&) const;
-	FCoords tr_n(const FCoords&) const;
+	[[nodiscard]] Coords tr_n(const Coords&) const;
+	[[nodiscard]] FCoords tr_n(const FCoords&) const;
 	void get_bln(const Coords&, Coords*) const;
 	void get_bln(const FCoords&, FCoords*) const;
-	Coords bl_n(const Coords&) const;
-	FCoords bl_n(const FCoords&) const;
+	[[nodiscard]] Coords bl_n(const Coords&) const;
+	[[nodiscard]] FCoords bl_n(const FCoords&) const;
 	void get_brn(const Coords&, Coords*) const;
 	void get_brn(const FCoords&, FCoords*) const;
-	Coords br_n(const Coords&) const;
-	FCoords br_n(const FCoords&) const;
+	[[nodiscard]] Coords br_n(const Coords&) const;
+	[[nodiscard]] FCoords br_n(const FCoords&) const;
 
 	void get_neighbour(const Coords&, Direction dir, Coords*) const;
 	void get_neighbour(const FCoords&, Direction dir, FCoords*) const;
-	FCoords get_neighbour(const FCoords&, Direction dir) const;
+	[[nodiscard]] FCoords get_neighbour(const FCoords&, Direction dir) const;
 
-	std::set<Coords> to_set(Area<Coords> area) const;
-	std::set<TCoords<Coords>> triangles_in_region(std::set<Coords> area) const;
+	[[nodiscard]] std::set<Coords> to_set(Area<Coords> area) const;
+	[[nodiscard]] std::set<TCoords<Coords>> triangles_in_region(std::set<Coords> area) const;
 
 	// Pathfinding
 	int32_t findpath(Coords instart,
@@ -486,7 +486,7 @@ public:
 	 * We can reach a field by water either if it has MOVECAPS_SWIM or if it has
 	 * MOVECAPS_WALK and at least one of the neighbours has MOVECAPS_SWIM
 	 */
-	bool can_reach_by_water(const Coords&) const;
+	[[nodiscard]] bool can_reach_by_water(const Coords&) const;
 
 	/// Sets the height to a value. Recalculates brightness. Changes the
 	/// surrounding nodes if necessary. Returns the radius that covers all
@@ -545,12 +545,12 @@ public:
 	 *
 	 * To qualify as valid, resources need to be surrounded by at least two matching terrains.
 	 */
-	bool is_resource_valid(const Widelands::Descriptions& descriptions,
+	[[nodiscard]] bool is_resource_valid(const Widelands::Descriptions& descriptions,
 	                       const Widelands::FCoords& c,
 	                       DescriptionIndex curres) const;
 
 	// The objectives that are defined in this map if it is a scenario.
-	const Objectives& objectives() const {
+	[[nodiscard]] const Objectives& objectives() const {
 		return objectives_;
 	}
 	Objectives* mutable_objectives() {
@@ -562,7 +562,7 @@ public:
 	}
 
 	/// Returns the military influence on a location from an area.
-	MilitaryInfluence calc_influence(Coords, Area<>) const;
+	[[nodiscard]] MilitaryInfluence calc_influence(Coords, Area<>) const;
 
 	/// Translate the whole map so that the given point becomes the new origin.
 	void set_origin(const Coords&);
@@ -571,8 +571,8 @@ public:
 
 	/// Checks whether the maximum theoretical possible NodeCap of the field is big,
 	/// and there is room for a port space
-	bool is_port_space_allowed(const EditorGameBase&, const FCoords& fc) const;
-	bool is_port_space(const Coords& c) const;
+	[[nodiscard]] bool is_port_space_allowed(const EditorGameBase&, const FCoords& fc) const;
+	[[nodiscard]] bool is_port_space(const Coords& c) const;
 
 	/// If 'set', set the space at 'c' as port space, otherwise unset.
 	/// 'force' sets the port space even if it isn't viable, and is to be used for map loading only.
@@ -582,13 +582,13 @@ public:
 	                    bool set,
 	                    bool force = false,
 	                    bool recalculate_seafaring = false);
-	const PortSpacesSet& get_port_spaces() const {
+	[[nodiscard]] const PortSpacesSet& get_port_spaces() const {
 		return port_spaces_;
 	}
-	std::vector<Coords> find_portdock(const Widelands::Coords& c, bool force) const;
+	[[nodiscard]] std::vector<Coords> find_portdock(const Widelands::Coords& c, bool force) const;
 
 	/// Return true if there are at least 2 port spaces that can be reached from each other by water
-	bool allows_seafaring() const;
+	[[nodiscard]] bool allows_seafaring() const;
 	/// Calculate whether there are at least 2 port spaces that can be reached from each other by
 	/// water and set the allows_seafaring property
 	void recalculate_allows_seafaring();
@@ -610,12 +610,12 @@ public:
 	// Creates a ResizeHistory that can be passed to set_to() later.
 	// This has to save the entire map's state because resize operations
 	// may affect all fields when resolving height differences etc.
-	ResizeHistory dump_state(const EditorGameBase&) const;
+	[[nodiscard]] ResizeHistory dump_state(const EditorGameBase&) const;
 
-	uint32_t get_waterway_max_length() const;
+	[[nodiscard]] uint32_t get_waterway_max_length() const;
 	void set_waterway_max_length(uint32_t max_length);
 
-	const AddOns::AddOnRequirements& required_addons() const {
+	[[nodiscard]] const AddOns::AddOnRequirements& required_addons() const {
 		return required_addons_;
 	}
 
@@ -630,9 +630,9 @@ private:
 	void recalc_brightness(const FCoords&) const;
 	void recalc_nodecaps_pass1(const EditorGameBase&, const FCoords&);
 	void recalc_nodecaps_pass2(const EditorGameBase&, const FCoords& f);
-	NodeCaps
+	[[nodiscard]] NodeCaps
 	calc_nodecaps_pass1(const EditorGameBase&, const FCoords&, bool consider_mobs = true) const;
-	NodeCaps calc_nodecaps_pass2(const EditorGameBase&,
+	[[nodiscard]] NodeCaps calc_nodecaps_pass2(const EditorGameBase&,
 	                             const FCoords&,
 	                             bool consider_mobs = true,
 	                             NodeCaps initcaps = CAPS_NONE) const;
@@ -643,7 +643,7 @@ private:
 	                   bool* ismine = nullptr,
 	                   bool consider_mobs = true,
 	                   NodeCaps initcaps = CAPS_NONE) const;
-	bool is_cycle_connected(const FCoords& start, const std::vector<WalkingDir>&) const;
+	[[nodiscard]] bool is_cycle_connected(const FCoords& start, const std::vector<WalkingDir>&) const;
 	template <typename functorT>
 	void
 	find_reachable(const EditorGameBase&, const Area<FCoords>&, const CheckStep&, functorT&) const;

--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -546,8 +546,8 @@ public:
 	 * To qualify as valid, resources need to be surrounded by at least two matching terrains.
 	 */
 	[[nodiscard]] bool is_resource_valid(const Widelands::Descriptions& descriptions,
-	                       const Widelands::FCoords& c,
-	                       DescriptionIndex curres) const;
+	                                     const Widelands::FCoords& c,
+	                                     DescriptionIndex curres) const;
 
 	// The objectives that are defined in this map if it is a scenario.
 	[[nodiscard]] const Objectives& objectives() const {
@@ -633,9 +633,9 @@ private:
 	[[nodiscard]] NodeCaps
 	calc_nodecaps_pass1(const EditorGameBase&, const FCoords&, bool consider_mobs = true) const;
 	[[nodiscard]] NodeCaps calc_nodecaps_pass2(const EditorGameBase&,
-	                             const FCoords&,
-	                             bool consider_mobs = true,
-	                             NodeCaps initcaps = CAPS_NONE) const;
+	                                           const FCoords&,
+	                                           bool consider_mobs = true,
+	                                           NodeCaps initcaps = CAPS_NONE) const;
 	void check_neighbour_heights(FCoords, uint32_t& area);
 	int calc_buildsize(const EditorGameBase&,
 	                   const FCoords& f,
@@ -643,7 +643,8 @@ private:
 	                   bool* ismine = nullptr,
 	                   bool consider_mobs = true,
 	                   NodeCaps initcaps = CAPS_NONE) const;
-	[[nodiscard]] bool is_cycle_connected(const FCoords& start, const std::vector<WalkingDir>&) const;
+	[[nodiscard]] bool is_cycle_connected(const FCoords& start,
+	                                      const std::vector<WalkingDir>&) const;
 	template <typename functorT>
 	void
 	find_reachable(const EditorGameBase&, const Area<FCoords>&, const CheckStep&, functorT&) const;

--- a/src/logic/map_objects/bob.cc
+++ b/src/logic/map_objects/bob.cc
@@ -507,10 +507,10 @@ struct CheckStepBlocked {
 	}
 
 	[[nodiscard]] bool allowed(const Map& /* map */,
-	             FCoords /* start */,
-	             FCoords end,
-	             int32_t /* dir */,
-	             CheckStep::StepId /* id */) const {
+	                           FCoords /* start */,
+	                           FCoords end,
+	                           int32_t /* dir */,
+	                           CheckStep::StepId /* id */) const {
 		if (end == tracker_.finaldest_) {
 			return true;
 		}

--- a/src/logic/map_objects/bob.cc
+++ b/src/logic/map_objects/bob.cc
@@ -506,7 +506,7 @@ struct CheckStepBlocked {
 	explicit CheckStepBlocked(BlockedTracker& tracker) : tracker_(tracker) {
 	}
 
-	bool allowed(const Map& /* map */,
+	[[nodiscard]] bool allowed(const Map& /* map */,
 	             FCoords /* start */,
 	             FCoords end,
 	             int32_t /* dir */,
@@ -516,7 +516,7 @@ struct CheckStepBlocked {
 		}
 		return !tracker_.is_blocked(end);
 	}
-	bool reachable_dest(const Map& /* map */, FCoords /* pos */) const {
+	[[nodiscard]] bool reachable_dest(const Map& /* map */, FCoords /* pos */) const {
 		return true;
 	}
 

--- a/src/logic/map_objects/bob.h
+++ b/src/logic/map_objects/bob.h
@@ -55,17 +55,17 @@ public:
 
 	Bob& create(EditorGameBase&, Player* owner, const Coords&) const;
 
-	MapObjectDescr::OwnerType get_owner_type() const {
+	[[nodiscard]] MapObjectDescr::OwnerType get_owner_type() const {
 		return owner_type_;
 	}
 
-	virtual uint32_t movecaps() const {
+	[[nodiscard]] virtual uint32_t movecaps() const {
 		return 0;
 	}
-	uint32_t vision_range() const;
+	[[nodiscard]] uint32_t vision_range() const;
 
 protected:
-	virtual Bob& create_object() const = 0;
+	[[nodiscard]] virtual Bob& create_object() const = 0;
 
 private:
 	const MapObjectDescr::OwnerType owner_type_;

--- a/src/logic/map_objects/buildcost.h
+++ b/src/logic/map_objects/buildcost.h
@@ -37,7 +37,7 @@ struct Buildcost : std::map<DescriptionIndex, uint8_t> {
 	Buildcost() = default;
 	Buildcost(std::unique_ptr<LuaTable> table, Widelands::Descriptions& descriptions);
 
-	Quantity total() const;
+	[[nodiscard]] Quantity total() const;
 
 	void save(FileWrite& fw, const TribeDescr& tribe) const;
 	void load(FileRead& fr, const TribeDescr& tribe);

--- a/src/logic/map_objects/checkstep.cc
+++ b/src/logic/map_objects/checkstep.cc
@@ -37,10 +37,10 @@ CheckStep::CheckStep() : capsule(always_false().capsule) {
 
 struct CheckStepAlwaysFalse {
 	[[nodiscard]] bool allowed(const Map& /* map */,
-	             const FCoords& /* start */,
-	             const FCoords& /* end */,
-	             int32_t /* dir */,
-	             CheckStep::StepId /* id */) const {
+	                           const FCoords& /* start */,
+	                           const FCoords& /* end */,
+	                           int32_t /* dir */,
+	                           CheckStep::StepId /* id */) const {
 		return false;
 	}
 	[[nodiscard]] bool reachable_dest(const Map& /* map */, const FCoords& /* dest */) const {

--- a/src/logic/map_objects/checkstep.cc
+++ b/src/logic/map_objects/checkstep.cc
@@ -36,14 +36,14 @@ CheckStep::CheckStep() : capsule(always_false().capsule) {
 }
 
 struct CheckStepAlwaysFalse {
-	bool allowed(const Map& /* map */,
+	[[nodiscard]] bool allowed(const Map& /* map */,
 	             const FCoords& /* start */,
 	             const FCoords& /* end */,
 	             int32_t /* dir */,
 	             CheckStep::StepId /* id */) const {
 		return false;
 	}
-	bool reachable_dest(const Map& /* map */, const FCoords& /* dest */) const {
+	[[nodiscard]] bool reachable_dest(const Map& /* map */, const FCoords& /* dest */) const {
 		return false;
 	}
 };

--- a/src/logic/map_objects/checkstep.h
+++ b/src/logic/map_objects/checkstep.h
@@ -42,22 +42,22 @@ private:
 	struct BaseCapsule {
 		virtual ~BaseCapsule() {
 		}
-		virtual bool allowed(
+		[[nodiscard]] virtual bool allowed(
 		   const Map&, const FCoords& start, const FCoords& end, int32_t dir, StepId id) const = 0;
-		virtual bool reachable_dest(const Map&, const FCoords& dest) const = 0;
+		[[nodiscard]] virtual bool reachable_dest(const Map&, const FCoords& dest) const = 0;
 	};
 	template <typename T> struct Capsule : public BaseCapsule {
 		Capsule(const T& init_op) : op(init_op) {
 		}
 
-		bool allowed(const Map& map,
+		[[nodiscard]] bool allowed(const Map& map,
 		             const FCoords& start,
 		             const FCoords& end,
 		             int32_t const dir,
 		             StepId const id) const override {
 			return op.allowed(map, start, end, dir, id);
 		}
-		bool reachable_dest(const Map& map, const FCoords& dest) const override {
+		[[nodiscard]] bool reachable_dest(const Map& map, const FCoords& dest) const override {
 			return op.reachable_dest(map, dest);
 		}
 
@@ -78,7 +78,7 @@ public:
 	 * \return \c true true if moving from start to end (single step in the given
 	 * direction) is allowed.
 	 */
-	bool allowed(const Map& map,
+	[[nodiscard]] bool allowed(const Map& map,
 	             const FCoords& start,
 	             const FCoords& end,
 	             int32_t const dir,
@@ -90,7 +90,7 @@ public:
 	 * \return \c true if the destination field can be reached at all
 	 * (e.g. return false for land-based bobs when dest is in water).
 	 */
-	bool reachable_dest(const Map& map, const FCoords& dest) const {
+	[[nodiscard]] bool reachable_dest(const Map& map, const FCoords& dest) const {
 		return capsule->reachable_dest(map, dest);
 	}
 };
@@ -102,12 +102,12 @@ public:
 struct CheckStepAnd {
 	void add(const CheckStep& sub);
 
-	bool allowed(const Map&,
+	[[nodiscard]] bool allowed(const Map&,
 	             const FCoords& start,
 	             const FCoords& end,
 	             int32_t dir,
 	             CheckStep::StepId id) const;
-	bool reachable_dest(const Map&, const FCoords& dest) const;
+	[[nodiscard]] bool reachable_dest(const Map&, const FCoords& dest) const;
 
 private:
 	std::vector<CheckStep> subs;
@@ -124,9 +124,9 @@ struct CheckStepDefault {
 	explicit CheckStepDefault(uint8_t const movecaps) : movecaps_(movecaps) {
 	}
 
-	bool allowed(
+	[[nodiscard]] bool allowed(
 	   const Map&, const FCoords& start, const FCoords& end, int32_t dir, CheckStep::StepId) const;
-	bool reachable_dest(const Map&, const FCoords& dest) const;
+	[[nodiscard]] bool reachable_dest(const Map&, const FCoords& dest) const;
 
 private:
 	uint8_t movecaps_;
@@ -141,9 +141,9 @@ struct CheckStepFerry {
 	explicit CheckStepFerry(const EditorGameBase& egbase) : egbase_(egbase) {
 	}
 
-	bool allowed(
+	[[nodiscard]] bool allowed(
 	   const Map&, const FCoords& from, const FCoords& to, int32_t dir, CheckStep::StepId) const;
-	bool reachable_dest(const Map&, const FCoords& dest) const;
+	[[nodiscard]] bool reachable_dest(const Map&, const FCoords& dest) const;
 
 private:
 	const EditorGameBase& egbase_;
@@ -159,9 +159,9 @@ struct CheckStepWalkOn {
 	   : movecaps_(movecaps), onlyend_(onlyend) {
 	}
 
-	bool allowed(
+	[[nodiscard]] bool allowed(
 	   const Map&, const FCoords& start, const FCoords& end, int32_t dir, CheckStep::StepId) const;
-	bool reachable_dest(const Map&, FCoords dest) const;
+	[[nodiscard]] bool reachable_dest(const Map&, FCoords dest) const;
 
 private:
 	uint8_t movecaps_;
@@ -180,9 +180,9 @@ struct CheckStepRoad {
 	   : player_(player), movecaps_(movecaps) {
 	}
 
-	bool allowed(
+	[[nodiscard]] bool allowed(
 	   const Map&, const FCoords& start, const FCoords& end, int32_t dir, CheckStep::StepId) const;
-	bool reachable_dest(const Map&, const FCoords& dest) const;
+	[[nodiscard]] bool reachable_dest(const Map&, const FCoords& dest) const;
 
 private:
 	const Player& player_;
@@ -197,9 +197,9 @@ struct CheckStepLimited {
 	void add_allowed_location(const Coords& c) {
 		allowed_locations_.insert(c);
 	}
-	bool allowed(
+	[[nodiscard]] bool allowed(
 	   const Map&, const FCoords& start, const FCoords& end, int32_t dir, CheckStep::StepId) const;
-	bool reachable_dest(const Map&, FCoords dest) const;
+	[[nodiscard]] bool reachable_dest(const Map&, FCoords dest) const;
 
 private:
 	// The ordering of the set does not matter, as long as it is system

--- a/src/logic/map_objects/checkstep.h
+++ b/src/logic/map_objects/checkstep.h
@@ -51,10 +51,10 @@ private:
 		}
 
 		[[nodiscard]] bool allowed(const Map& map,
-		             const FCoords& start,
-		             const FCoords& end,
-		             int32_t const dir,
-		             StepId const id) const override {
+		                           const FCoords& start,
+		                           const FCoords& end,
+		                           int32_t const dir,
+		                           StepId const id) const override {
 			return op.allowed(map, start, end, dir, id);
 		}
 		[[nodiscard]] bool reachable_dest(const Map& map, const FCoords& dest) const override {
@@ -79,10 +79,10 @@ public:
 	 * direction) is allowed.
 	 */
 	[[nodiscard]] bool allowed(const Map& map,
-	             const FCoords& start,
-	             const FCoords& end,
-	             int32_t const dir,
-	             StepId const id) const {
+	                           const FCoords& start,
+	                           const FCoords& end,
+	                           int32_t const dir,
+	                           StepId const id) const {
 		return capsule->allowed(map, start, end, dir, id);
 	}
 
@@ -103,10 +103,10 @@ struct CheckStepAnd {
 	void add(const CheckStep& sub);
 
 	[[nodiscard]] bool allowed(const Map&,
-	             const FCoords& start,
-	             const FCoords& end,
-	             int32_t dir,
-	             CheckStep::StepId id) const;
+	                           const FCoords& start,
+	                           const FCoords& end,
+	                           int32_t dir,
+	                           CheckStep::StepId id) const;
 	[[nodiscard]] bool reachable_dest(const Map&, const FCoords& dest) const;
 
 private:

--- a/src/logic/map_objects/description_maintainer.h
+++ b/src/logic/map_objects/description_maintainer.h
@@ -35,16 +35,16 @@ template <typename T> struct DescriptionMaintainer {
 	Widelands::DescriptionIndex add(T* entry);
 
 	// Returns the number of entries in the container.
-	Widelands::DescriptionIndex size() const {
+	[[nodiscard]] Widelands::DescriptionIndex size() const {
 		return items_.size();
 	}
 
 	// Returns the entry with the given 'name' if it exists or nullptr.
-	T* exists(const std::string& name) const;
+	[[nodiscard]] T* exists(const std::string& name) const;
 
 	// Returns the index of the entry with the given 'name' or INVALID_INDEX if the entry
 	// is not in the container.
-	Widelands::DescriptionIndex get_index(const std::string& name) const {
+	[[nodiscard]] Widelands::DescriptionIndex get_index(const std::string& name) const {
 		NameToIndexMap::const_iterator i = name_to_index_.find(name);
 		if (i == name_to_index_.end()) {
 			return Widelands::INVALID_INDEX;
@@ -54,13 +54,13 @@ template <typename T> struct DescriptionMaintainer {
 
 	// Returns the entry with the given 'idx' or nullptr if 'idx' is out of
 	// bounds. Ownership is retained.
-	T* get_mutable(const Widelands::DescriptionIndex idx) const {
+	[[nodiscard]] T* get_mutable(const Widelands::DescriptionIndex idx) const {
 		return (idx < items_.size()) ? items_[idx].get() : nullptr;
 	}
 
 	// Returns the entry at 'index'. If 'index' is out of bounds the result is
 	// undefined.
-	const T& get(const Widelands::DescriptionIndex index) const {
+	[[nodiscard]] const T& get(const Widelands::DescriptionIndex index) const {
 		assert(index < items_.size());
 		return *items_.at(index);
 	}

--- a/src/logic/map_objects/description_manager.h
+++ b/src/logic/map_objects/description_manager.h
@@ -63,9 +63,9 @@ public:
 	void load_description(const std::string& description_name);
 
 	/// Return the attributes registered to the given description name.
-	const std::vector<std::string>& get_attributes(const std::string& description_name) const;
+	[[nodiscard]] const std::vector<std::string>& get_attributes(const std::string& description_name) const;
 
-	const RegistryCallerInfo& get_registry_caller_info(const std::string& description_name) const;
+	[[nodiscard]] const RegistryCallerInfo& get_registry_caller_info(const std::string& description_name) const;
 
 	/// Deregister all scenario object descrptions
 	void clear_scenario_descriptions();
@@ -79,7 +79,7 @@ public:
 	 * The exact order in which all units have been loaded, e.g.
 	 * {"barbarians", "barbarians_ship", "barbarians_well", ...}.
 	 */
-	const std::vector<std::string>& load_order() const {
+	[[nodiscard]] const std::vector<std::string>& load_order() const {
 		return load_order_;
 	}
 

--- a/src/logic/map_objects/description_manager.h
+++ b/src/logic/map_objects/description_manager.h
@@ -63,9 +63,11 @@ public:
 	void load_description(const std::string& description_name);
 
 	/// Return the attributes registered to the given description name.
-	[[nodiscard]] const std::vector<std::string>& get_attributes(const std::string& description_name) const;
+	[[nodiscard]] const std::vector<std::string>&
+	get_attributes(const std::string& description_name) const;
 
-	[[nodiscard]] const RegistryCallerInfo& get_registry_caller_info(const std::string& description_name) const;
+	[[nodiscard]] const RegistryCallerInfo&
+	get_registry_caller_info(const std::string& description_name) const;
 
 	/// Deregister all scenario object descrptions
 	void clear_scenario_descriptions();

--- a/src/logic/map_objects/descriptions.h
+++ b/src/logic/map_objects/descriptions.h
@@ -176,8 +176,8 @@ public:
 	/// when we don't know whether it's a ware or worker.
 	/// Throws GameDataError if object hasn't been registered.
 	/// This function is safe for map/savegame compatibility.
-	[[nodiscard]] std::pair<WareWorker, DescriptionIndex>
-	load_ware_or_worker(const std::string& objectname) const;
+	std::pair<WareWorker, DescriptionIndex>
+	load_ware_or_worker(const std::string& objectname) const;  // NOLINT not nodiscard
 	/// Try to load a building or immovable that has been registered previously with
 	/// 'register_description' when we don't know whether it's a building or immovable. Throws
 	/// GameDataError if object hasn't been registered. If first == 'true', we have a building.

--- a/src/logic/map_objects/descriptions.h
+++ b/src/logic/map_objects/descriptions.h
@@ -176,7 +176,8 @@ public:
 	/// when we don't know whether it's a ware or worker.
 	/// Throws GameDataError if object hasn't been registered.
 	/// This function is safe for map/savegame compatibility.
-	[[nodiscard]] std::pair<WareWorker, DescriptionIndex> load_ware_or_worker(const std::string& objectname) const;
+	[[nodiscard]] std::pair<WareWorker, DescriptionIndex>
+	load_ware_or_worker(const std::string& objectname) const;
 	/// Try to load a building or immovable that has been registered previously with
 	/// 'register_description' when we don't know whether it's a building or immovable. Throws
 	/// GameDataError if object hasn't been registered. If first == 'true', we have a building.

--- a/src/logic/map_objects/descriptions.h
+++ b/src/logic/map_objects/descriptions.h
@@ -50,89 +50,89 @@ public:
 	explicit Descriptions(LuaInterface* lua, const AddOns::AddOnsList&);
 	~Descriptions();
 
-	const DescriptionMaintainer<CritterDescr>& critters() const;
-	const DescriptionMaintainer<TerrainDescription>& terrains() const;
-	const DescriptionMaintainer<ImmovableDescr>& immovables() const;
-	const DescriptionMaintainer<WorkerDescr>& workers() const;
+	[[nodiscard]] const DescriptionMaintainer<CritterDescr>& critters() const;
+	[[nodiscard]] const DescriptionMaintainer<TerrainDescription>& terrains() const;
+	[[nodiscard]] const DescriptionMaintainer<ImmovableDescr>& immovables() const;
+	[[nodiscard]] const DescriptionMaintainer<WorkerDescr>& workers() const;
 
-	size_t nr_buildings() const;
-	size_t nr_critters() const;
-	size_t nr_immovables() const;
-	size_t nr_terrains() const;
-	size_t nr_tribes() const;
-	size_t nr_resources() const;
-	size_t nr_wares() const;
-	size_t nr_workers() const;
+	[[nodiscard]] size_t nr_buildings() const;
+	[[nodiscard]] size_t nr_critters() const;
+	[[nodiscard]] size_t nr_immovables() const;
+	[[nodiscard]] size_t nr_terrains() const;
+	[[nodiscard]] size_t nr_tribes() const;
+	[[nodiscard]] size_t nr_resources() const;
+	[[nodiscard]] size_t nr_wares() const;
+	[[nodiscard]] size_t nr_workers() const;
 
-	bool building_exists(const std::string& buildingname) const;
-	bool building_exists(DescriptionIndex index) const;
-	bool immovable_exists(const std::string& immoname) const;
-	bool immovable_exists(DescriptionIndex index) const;
-	bool ship_exists(DescriptionIndex index) const;
-	bool tribe_exists(const std::string& tribename) const;
-	bool tribe_exists(DescriptionIndex index) const;
-	bool ware_exists(const std::string& warename) const;
-	bool ware_exists(DescriptionIndex index) const;
-	bool worker_exists(const std::string& workername) const;
-	bool worker_exists(DescriptionIndex index) const;
-	bool terrain_exists(const std::string& terrainname) const;
-	bool terrain_exists(DescriptionIndex index) const;
+	[[nodiscard]] bool building_exists(const std::string& buildingname) const;
+	[[nodiscard]] bool building_exists(DescriptionIndex index) const;
+	[[nodiscard]] bool immovable_exists(const std::string& immoname) const;
+	[[nodiscard]] bool immovable_exists(DescriptionIndex index) const;
+	[[nodiscard]] bool ship_exists(DescriptionIndex index) const;
+	[[nodiscard]] bool tribe_exists(const std::string& tribename) const;
+	[[nodiscard]] bool tribe_exists(DescriptionIndex index) const;
+	[[nodiscard]] bool ware_exists(const std::string& warename) const;
+	[[nodiscard]] bool ware_exists(DescriptionIndex index) const;
+	[[nodiscard]] bool worker_exists(const std::string& workername) const;
+	[[nodiscard]] bool worker_exists(DescriptionIndex index) const;
+	[[nodiscard]] bool terrain_exists(const std::string& terrainname) const;
+	[[nodiscard]] bool terrain_exists(DescriptionIndex index) const;
 
 	/// Returns the index for 'buildingname' and throws an exception if the building can't be found.
 	/// This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_building_index(const std::string& buildingname) const;
+	[[nodiscard]] DescriptionIndex safe_building_index(const std::string& buildingname) const;
 	/// Returns the index for 'crittername' and throws an exception if the critter can't be found.
 	/// This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_critter_index(const std::string& crittername) const;
+	[[nodiscard]] DescriptionIndex safe_critter_index(const std::string& crittername) const;
 	/// Returns the index for 'immovablename' and throws an exception if the immovable can't be
 	/// found. This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_immovable_index(const std::string& immovablename) const;
+	[[nodiscard]] DescriptionIndex safe_immovable_index(const std::string& immovablename) const;
 	/// Returns the index for 'warename' and throws an exception if the ware can't be found.
 	/// This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_resource_index(const std::string& resourcename) const;
+	[[nodiscard]] DescriptionIndex safe_resource_index(const std::string& resourcename) const;
 	/// Returns the index for 'shipname' and throws an exception if the ship can't be found.
 	/// This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_ship_index(const std::string& shipname) const;
+	[[nodiscard]] DescriptionIndex safe_ship_index(const std::string& shipname) const;
 	/// Returns the index for 'terrainname' and throws an exception if the terrain can't be found.
 	/// This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_terrain_index(const std::string& terrainname) const;
+	[[nodiscard]] DescriptionIndex safe_terrain_index(const std::string& terrainname) const;
 	/// Returns the index for 'tribename' and throws an exception if the tribe can't be found.
-	DescriptionIndex safe_tribe_index(const std::string& tribename) const;
+	[[nodiscard]] DescriptionIndex safe_tribe_index(const std::string& tribename) const;
 	/// Returns the index for 'warename' and throws an exception if the ware can't be found.
 	/// This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_ware_index(const std::string& warename) const;
+	[[nodiscard]] DescriptionIndex safe_ware_index(const std::string& warename) const;
 	/// Returns the index for 'workername' and throws an exception if the worker can't be found.
 	/// This function is safe for map/savegame compatibility.
-	DescriptionIndex safe_worker_index(const std::string& workername) const;
+	[[nodiscard]] DescriptionIndex safe_worker_index(const std::string& workername) const;
 
-	DescriptionIndex building_index(const std::string& buildingname) const;
-	DescriptionIndex critter_index(const std::string& crittername) const;
-	DescriptionIndex immovable_index(const std::string& immovablename) const;
-	DescriptionIndex resource_index(const std::string& resourcename) const;
-	DescriptionIndex ship_index(const std::string& shipname) const;
-	DescriptionIndex terrain_index(const std::string& terrainname) const;
-	DescriptionIndex tribe_index(const std::string& tribename) const;
-	DescriptionIndex ware_index(const std::string& warename) const;
-	DescriptionIndex worker_index(const std::string& workername) const;
+	[[nodiscard]] DescriptionIndex building_index(const std::string& buildingname) const;
+	[[nodiscard]] DescriptionIndex critter_index(const std::string& crittername) const;
+	[[nodiscard]] DescriptionIndex immovable_index(const std::string& immovablename) const;
+	[[nodiscard]] DescriptionIndex resource_index(const std::string& resourcename) const;
+	[[nodiscard]] DescriptionIndex ship_index(const std::string& shipname) const;
+	[[nodiscard]] DescriptionIndex terrain_index(const std::string& terrainname) const;
+	[[nodiscard]] DescriptionIndex tribe_index(const std::string& tribename) const;
+	[[nodiscard]] DescriptionIndex ware_index(const std::string& warename) const;
+	[[nodiscard]] DescriptionIndex worker_index(const std::string& workername) const;
 
-	const BuildingDescr* get_building_descr(DescriptionIndex index) const;
-	BuildingDescr* get_mutable_building_descr(DescriptionIndex index) const;
-	const CritterDescr* get_critter_descr(DescriptionIndex index) const;
-	const CritterDescr* get_critter_descr(const std::string& name) const;
-	const ImmovableDescr* get_immovable_descr(DescriptionIndex index) const;
-	ImmovableDescr* get_mutable_immovable_descr(DescriptionIndex index) const;
-	const ResourceDescription* get_resource_descr(DescriptionIndex index) const;
-	ResourceDescription* get_mutable_resource_descr(DescriptionIndex index) const;
-	const ShipDescr* get_ship_descr(DescriptionIndex index) const;
-	const TerrainDescription* get_terrain_descr(DescriptionIndex index) const;
-	const TerrainDescription* get_terrain_descr(const std::string& name) const;
-	TerrainDescription* get_mutable_terrain_descr(DescriptionIndex index) const;
-	const WareDescr* get_ware_descr(DescriptionIndex index) const;
-	WareDescr* get_mutable_ware_descr(DescriptionIndex index) const;
-	const WorkerDescr* get_worker_descr(DescriptionIndex index) const;
-	WorkerDescr* get_mutable_worker_descr(DescriptionIndex index) const;
-	const TribeDescr* get_tribe_descr(DescriptionIndex index) const;
-	TribeDescr* get_mutable_tribe_descr(DescriptionIndex index) const;
+	[[nodiscard]] const BuildingDescr* get_building_descr(DescriptionIndex index) const;
+	[[nodiscard]] BuildingDescr* get_mutable_building_descr(DescriptionIndex index) const;
+	[[nodiscard]] const CritterDescr* get_critter_descr(DescriptionIndex index) const;
+	[[nodiscard]] const CritterDescr* get_critter_descr(const std::string& name) const;
+	[[nodiscard]] const ImmovableDescr* get_immovable_descr(DescriptionIndex index) const;
+	[[nodiscard]] ImmovableDescr* get_mutable_immovable_descr(DescriptionIndex index) const;
+	[[nodiscard]] const ResourceDescription* get_resource_descr(DescriptionIndex index) const;
+	[[nodiscard]] ResourceDescription* get_mutable_resource_descr(DescriptionIndex index) const;
+	[[nodiscard]] const ShipDescr* get_ship_descr(DescriptionIndex index) const;
+	[[nodiscard]] const TerrainDescription* get_terrain_descr(DescriptionIndex index) const;
+	[[nodiscard]] const TerrainDescription* get_terrain_descr(const std::string& name) const;
+	[[nodiscard]] TerrainDescription* get_mutable_terrain_descr(DescriptionIndex index) const;
+	[[nodiscard]] const WareDescr* get_ware_descr(DescriptionIndex index) const;
+	[[nodiscard]] WareDescr* get_mutable_ware_descr(DescriptionIndex index) const;
+	[[nodiscard]] const WorkerDescr* get_worker_descr(DescriptionIndex index) const;
+	[[nodiscard]] WorkerDescr* get_mutable_worker_descr(DescriptionIndex index) const;
+	[[nodiscard]] const TribeDescr* get_tribe_descr(DescriptionIndex index) const;
+	[[nodiscard]] TribeDescr* get_mutable_tribe_descr(DescriptionIndex index) const;
 
 	// ************************ Loading *************************
 
@@ -176,29 +176,29 @@ public:
 	/// when we don't know whether it's a ware or worker.
 	/// Throws GameDataError if object hasn't been registered.
 	/// This function is safe for map/savegame compatibility.
-	std::pair<WareWorker, DescriptionIndex> load_ware_or_worker(const std::string& objectname) const;
+	[[nodiscard]] std::pair<WareWorker, DescriptionIndex> load_ware_or_worker(const std::string& objectname) const;
 	/// Try to load a building or immovable that has been registered previously with
 	/// 'register_description' when we don't know whether it's a building or immovable. Throws
 	/// GameDataError if object hasn't been registered. If first == 'true', we have a building.
 	/// Otherwise, it's an immovable. This function is safe for map/savegame compatibility.
-	std::pair<bool, DescriptionIndex>
+	[[nodiscard]] std::pair<bool, DescriptionIndex>
 	load_building_or_immovable(const std::string& objectname) const;
 
 	/** Register the tribes if they have not been registered yet. */
 	void ensure_tribes_are_registered();
 
-	uint32_t get_largest_workarea() const;
+	[[nodiscard]] uint32_t get_largest_workarea() const;
 	void increase_largest_workarea(uint32_t workarea);
 
 	/// For loading old maps
 	void set_old_world_name(const std::string& name);
 
-	const AllTribes& all_tribes() const {
+	[[nodiscard]] const AllTribes& all_tribes() const {
 		return all_tribes_;
 	}
 
 	/** The order in which all units have been loaded. */
-	const std::vector<std::string>& load_order() const {
+	[[nodiscard]] const std::vector<std::string>& load_order() const {
 		return description_manager_->load_order();
 	}
 

--- a/src/logic/map_objects/descriptions_compatibility_table.h
+++ b/src/logic/map_objects/descriptions_compatibility_table.h
@@ -35,34 +35,34 @@ public:
 	virtual ~DescriptionsCompatibilityTable() = default;
 
 	/// Looks up the new name for the 'resource'.
-	virtual std::string lookup_resource(const std::string& resource) const = 0;
+	[[nodiscard]] virtual std::string lookup_resource(const std::string& resource) const = 0;
 
 	/// Looks up the new name for the 'terrain'.
-	virtual std::string lookup_terrain(const std::string& terrain) const = 0;
+	[[nodiscard]] virtual std::string lookup_terrain(const std::string& terrain) const = 0;
 
 	/// Looks up the new name for the 'critter'.
-	virtual std::string lookup_critter(const std::string& critter) const = 0;
+	[[nodiscard]] virtual std::string lookup_critter(const std::string& critter) const = 0;
 
 	/// Looks up the new name for the 'immovable'.
-	virtual std::string lookup_immovable(const std::string& immovable) const = 0;
+	[[nodiscard]] virtual std::string lookup_immovable(const std::string& immovable) const = 0;
 
 	/// Looks up the new name for the 'worker'.
-	const std::string& lookup_worker(const std::string& worker) const;
+	[[nodiscard]] const std::string& lookup_worker(const std::string& worker) const;
 
 	/// Looks up the new name for the 'ware'.
-	const std::string& lookup_ware(const std::string& ware) const;
+	[[nodiscard]] const std::string& lookup_ware(const std::string& ware) const;
 
 	/// Looks up the new name for the 'building'.
-	const std::string& lookup_building(const std::string& building) const;
+	[[nodiscard]] const std::string& lookup_building(const std::string& building) const;
 
 	/// Looks up the new name for the 'ship'.
-	const std::string& lookup_ship(const std::string& ship) const;
+	[[nodiscard]] const std::string& lookup_ship(const std::string& ship) const;
 
 	/// Looks up the new name for the 'program'.
-	const std::string& lookup_program(const std::string& program) const;
+	[[nodiscard]] const std::string& lookup_program(const std::string& program) const;
 
 protected:
-	const std::string& lookup_entry(const std::string& entry,
+	[[nodiscard]] const std::string& lookup_entry(const std::string& entry,
 	                                const std::map<std::string, std::string>& table) const;
 
 	// <old name, new name>
@@ -83,10 +83,10 @@ public:
 	PostOneWorldLegacyLookupTable();
 
 	// Implements DescriptionsCompatibilityTable.
-	std::string lookup_resource(const std::string& resource) const override;
-	std::string lookup_terrain(const std::string& terrain) const override;
-	std::string lookup_critter(const std::string& critter) const override;
-	std::string lookup_immovable(const std::string& immovable) const override;
+	[[nodiscard]] std::string lookup_resource(const std::string& resource) const override;
+	[[nodiscard]] std::string lookup_terrain(const std::string& terrain) const override;
+	[[nodiscard]] std::string lookup_critter(const std::string& critter) const override;
+	[[nodiscard]] std::string lookup_immovable(const std::string& immovable) const override;
 
 private:
 	// <old name, new name>
@@ -101,13 +101,13 @@ public:
 	explicit OneWorldLegacyLookupTable(const std::string& old_world_name);
 
 	// Implements DescriptionsCompatibilityTable.
-	std::string lookup_resource(const std::string& resource) const override;
-	std::string lookup_terrain(const std::string& terrain) const override;
-	std::string lookup_critter(const std::string& critter) const override;
-	std::string lookup_immovable(const std::string& immovable) const override;
+	[[nodiscard]] std::string lookup_resource(const std::string& resource) const override;
+	[[nodiscard]] std::string lookup_terrain(const std::string& terrain) const override;
+	[[nodiscard]] std::string lookup_critter(const std::string& critter) const override;
+	[[nodiscard]] std::string lookup_immovable(const std::string& immovable) const override;
 
 private:
-	const std::string&
+	[[nodiscard]] const std::string&
 	lookup_world_entry(const std::string& entry,
 	                   const std::map<std::string, std::map<std::string, std::string>>& table) const;
 

--- a/src/logic/map_objects/descriptions_compatibility_table.h
+++ b/src/logic/map_objects/descriptions_compatibility_table.h
@@ -62,8 +62,8 @@ public:
 	[[nodiscard]] const std::string& lookup_program(const std::string& program) const;
 
 protected:
-	[[nodiscard]] const std::string& lookup_entry(const std::string& entry,
-	                                const std::map<std::string, std::string>& table) const;
+	[[nodiscard]] const std::string&
+	lookup_entry(const std::string& entry, const std::map<std::string, std::string>& table) const;
 
 	// <old name, new name>
 	const std::map<std::string, std::string> workers_;

--- a/src/logic/map_objects/findimmovable.cc
+++ b/src/logic/map_objects/findimmovable.cc
@@ -27,7 +27,7 @@
 namespace Widelands {
 
 struct FindImmovableAlwaysTrueImpl {
-	bool accept(const BaseImmovable& /* immovable */) const {
+	[[nodiscard]] bool accept(const BaseImmovable& /* immovable */) const {
 		return true;
 	}
 };

--- a/src/logic/map_objects/findimmovable.h
+++ b/src/logic/map_objects/findimmovable.h
@@ -42,14 +42,14 @@ private:
 			if (--refcount == 0)
 				delete this;
 		}
-		virtual bool accept(const BaseImmovable&) const = 0;
+		[[nodiscard]] virtual bool accept(const BaseImmovable&) const = 0;
 
 		int refcount;
 	};
 	template <typename T> struct Capsule : public BaseCapsule {
 		explicit Capsule(const T& init_op) : op(init_op) {
 		}
-		bool accept(const BaseImmovable& imm) const override {
+		[[nodiscard]] bool accept(const BaseImmovable& imm) const override {
 			return op.accept(imm);
 		}
 
@@ -79,7 +79,7 @@ public:
 	}
 
 	// Return true if this node should be returned by find_fields()
-	bool accept(const BaseImmovable& imm) const {
+	[[nodiscard]] bool accept(const BaseImmovable& imm) const {
 		return capsule->accept(imm);
 	}
 };
@@ -92,7 +92,7 @@ struct FindImmovableSize {
 	   : min(init_min), max(init_max) {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
 private:
 	int32_t min, max;
@@ -101,7 +101,7 @@ struct FindImmovableType {
 	explicit FindImmovableType(MapObjectType const init_type) : type(init_type) {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
 private:
 	MapObjectType type;
@@ -110,7 +110,7 @@ struct FindImmovableAttribute {
 	explicit FindImmovableAttribute(uint32_t const init_attrib) : attrib(init_attrib) {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
 private:
 	int32_t attrib;
@@ -119,13 +119,13 @@ struct FindImmovablePlayerImmovable {
 	FindImmovablePlayerImmovable() {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 };
 struct FindImmovablePlayerMilitarySite {
 	explicit FindImmovablePlayerMilitarySite(const Player& init_player) : player(init_player) {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
 	const Player& player;
 };
@@ -133,12 +133,12 @@ struct FindImmovableAttackTarget {
 	FindImmovableAttackTarget() {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 };
 struct FindForeignMilitarysite {
 	explicit FindForeignMilitarysite(const Player& init_player) : player(init_player) {
 	}
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 	const Player& player;
 };
 
@@ -146,7 +146,7 @@ struct FindImmovableByDescr {
 	explicit FindImmovableByDescr(const ImmovableDescr& init_descr) : descr(init_descr) {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
 	const ImmovableDescr& descr;
 };
@@ -154,7 +154,7 @@ struct FindFlagOf {
 	explicit FindFlagOf(const FindImmovable& init_finder) : finder(init_finder) {
 	}
 
-	bool accept(const BaseImmovable&) const;
+	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
 	const FindImmovable finder;
 };

--- a/src/logic/map_objects/findnode.h
+++ b/src/logic/map_objects/findnode.h
@@ -45,14 +45,14 @@ private:
 			if (--refcount == 0)
 				delete this;
 		}
-		virtual bool accept(const EditorGameBase&, const FCoords& coord) const = 0;
+		[[nodiscard]] virtual bool accept(const EditorGameBase&, const FCoords& coord) const = 0;
 
 		int refcount;
 	};
 	template <typename T> struct Capsule : public BaseCapsule {
 		explicit Capsule(const T& init_op) : op(init_op) {
 		}
-		bool accept(const EditorGameBase& map, const FCoords& coord) const override {
+		[[nodiscard]] bool accept(const EditorGameBase& map, const FCoords& coord) const override {
 			return op.accept(map, coord);
 		}
 
@@ -82,7 +82,7 @@ public:
 	}
 
 	// Return true if this node should be returned by find_fields()
-	bool accept(const EditorGameBase& map, const FCoords& coord) const {
+	[[nodiscard]] bool accept(const EditorGameBase& map, const FCoords& coord) const {
 		return capsule->accept(map, coord);
 	}
 };
@@ -91,7 +91,7 @@ struct FindNodeCaps {
 	explicit FindNodeCaps(uint8_t init_mincaps) : mincaps(init_mincaps) {
 	}
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	uint8_t mincaps;
@@ -104,7 +104,7 @@ struct FindNodeAnd {
 
 	void add(const FindNode&, bool negate = false);
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	struct Subfunctor {
@@ -133,7 +133,7 @@ struct FindNodeSize {
 	explicit FindNodeSize(Size init_size) : size(init_size) {
 	}
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	Size size;
@@ -146,7 +146,7 @@ struct FindNodeImmovableSize {
 	explicit FindNodeImmovableSize(uint32_t init_sizes) : sizes(init_sizes) {
 	}
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	uint32_t sizes;
@@ -157,7 +157,7 @@ struct FindNodeImmovableAttribute {
 	explicit FindNodeImmovableAttribute(uint32_t attrib) : attribute(attrib) {
 	}
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	uint32_t attribute;
@@ -168,7 +168,7 @@ struct FindNodeResource {
 	explicit FindNodeResource(DescriptionIndex res) : resource(res) {
 	}
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	DescriptionIndex resource;
@@ -182,7 +182,7 @@ struct FindNodeResourceBreedable {
 	   : resource(res), strictness(br) {
 	}
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	DescriptionIndex resource;
@@ -193,7 +193,7 @@ private:
 struct FindNodeTerraform {
 	FindNodeTerraform(const std::string& c) : category_(c) {
 	}
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 	const std::string category_;
 };
@@ -204,7 +204,7 @@ struct FindNodeShore {
 	explicit FindNodeShore(uint16_t f = 1) : min_fields(f) {
 	}
 
-	bool accept(const EditorGameBase&, const FCoords&) const;
+	[[nodiscard]] bool accept(const EditorGameBase&, const FCoords&) const;
 
 private:
 	// Minimal number of reachable swimmable fields. 1 is minimum for this to be considered "shore"

--- a/src/logic/map_objects/immovable.h
+++ b/src/logic/map_objects/immovable.h
@@ -129,39 +129,39 @@ public:
 	               Descriptions& descriptions);
 	~ImmovableDescr() override;
 
-	int32_t get_size() const {
+	[[nodiscard]] int32_t get_size() const {
 		return size_;
 	}
-	ImmovableProgram const* get_program(const std::string&) const;
+	[[nodiscard]] ImmovableProgram const* get_program(const std::string&) const;
 
 	Immovable& create(EditorGameBase&,
 	                  const Coords&,
 	                  const Widelands::BuildingDescr* former_building_descr) const;
 
-	const Buildcost& buildcost() const {
+	[[nodiscard]] const Buildcost& buildcost() const {
 		return buildcost_;
 	}
 
 	// A basic localized name for the immovable, used by trees
-	const std::string& species() const {
+	[[nodiscard]] const std::string& species() const {
 		return species_;
 	}
 
 	// Every immovable that can 'grow' needs to have terrain affinity defined,
 	// all others do not. Returns true if this one has it defined.
-	bool has_terrain_affinity() const;
+	[[nodiscard]] bool has_terrain_affinity() const;
 
 	// Returns the terrain affinity. If !has_terrain_affinity() this will return
 	// an undefined value.
-	const TerrainAffinity& terrain_affinity() const;
+	[[nodiscard]] const TerrainAffinity& terrain_affinity() const;
 
 	// Map object names that the immovable can transform/grow into
-	const std::set<std::pair<MapObjectType, std::string>>& becomes() const {
+	[[nodiscard]] const std::set<std::pair<MapObjectType, std::string>>& becomes() const {
 		return becomes_;
 	}
 
 	// A set of all productionsites that gather this immovable or any of its future types
-	const std::set<std::string> collected_by() const {
+	[[nodiscard]] const std::set<std::string> collected_by() const {
 		return collected_by_;
 	}
 	void add_collected_by(const Descriptions& descriptions,

--- a/src/logic/map_objects/immovable_program.h
+++ b/src/logic/map_objects/immovable_program.h
@@ -59,7 +59,7 @@ struct ImmovableProgram : public MapObjectProgram {
 	public:
 		ActAnimate(const std::vector<std::string>& arguments, const ImmovableDescr&);
 		void execute(Game&, Immovable&) const override;
-		uint32_t animation() const {
+		[[nodiscard]] uint32_t animation() const {
 			return parameters.animation;
 		}
 
@@ -149,10 +149,10 @@ struct ImmovableProgram : public MapObjectProgram {
 		ActConstruct(std::vector<std::string>& arguments, const ImmovableDescr&);
 		void execute(Game&, Immovable&) const override;
 
-		Duration buildtime() const {
+		[[nodiscard]] Duration buildtime() const {
 			return buildtime_;
 		}
-		Duration decaytime() const {
+		[[nodiscard]] Duration decaytime() const {
 			return decaytime_;
 		}
 
@@ -173,7 +173,7 @@ struct ImmovableProgram : public MapObjectProgram {
 	~ImmovableProgram() override {
 	}
 
-	size_t size() const {
+	[[nodiscard]] size_t size() const {
 		return actions_.size();
 	}
 	const Action& operator[](size_t const idx) const {
@@ -191,14 +191,14 @@ struct ImmovableActionData {
 	virtual ~ImmovableActionData() {
 	}
 
-	virtual const char* name() const = 0;
+	[[nodiscard]] virtual const char* name() const = 0;
 	virtual void save(FileWrite& fw, Immovable& imm) const = 0;
 
 	static ImmovableActionData* load(FileRead& fr, const Immovable& imm, const std::string& name);
 };
 
 struct ActConstructData : ImmovableActionData {
-	const char* name() const override;
+	[[nodiscard]] const char* name() const override;
 	void save(FileWrite& fw, Immovable& imm) const override;
 	static ActConstructData* load(FileRead& fr, const Immovable& imm);
 

--- a/src/logic/map_objects/map_object.h
+++ b/src/logic/map_objects/map_object.h
@@ -101,7 +101,8 @@ public:
 	                   std::map<std::string, std::string> localized_helptext);
 	/// Gets the tribe-specific ware or immovable helptext for the given tribe. Fails if it doesn't
 	/// exist.
-	[[nodiscard]] const std::map<std::string, std::string>& get_helptexts(const std::string& tribename) const;
+	[[nodiscard]] const std::map<std::string, std::string>&
+	get_helptexts(const std::string& tribename) const;
 	/// Returns whether a tribe-specific helptext exists for the given tribe
 	[[nodiscard]] bool has_helptext(const std::string& tribename) const;
 

--- a/src/logic/map_objects/map_object.h
+++ b/src/logic/map_objects/map_object.h
@@ -61,24 +61,24 @@ public:
 	               const LuaTable& table);
 	virtual ~MapObjectDescr();
 
-	const std::string& name() const {
+	[[nodiscard]] const std::string& name() const {
 		return name_;
 	}
-	const std::string& descname() const {
+	[[nodiscard]] const std::string& descname() const {
 		return descname_;
 	}
 
 	// Type of the MapObjectDescr.
-	MapObjectType type() const {
+	[[nodiscard]] MapObjectType type() const {
 		return type_;
 	}
 
 	virtual uint32_t get_animation(const std::string& animname, const MapObject* mo) const;
 
-	uint32_t main_animation() const;
-	std::string get_animation_name(uint32_t) const;  ///< needed for save, debug
+	[[nodiscard]] uint32_t main_animation() const;
+	[[nodiscard]] std::string get_animation_name(uint32_t) const;  ///< needed for save, debug
 
-	bool is_animation_known(const std::string& name) const;
+	[[nodiscard]] bool is_animation_known(const std::string& name) const;
 
 	/// Preload animation graphics at default scale
 	void load_graphics() const;
@@ -88,12 +88,12 @@ public:
 	const Image* representative_image(const RGBColor* player_color = nullptr) const;
 
 	/// Returns the menu image if the MapObject has one, nullptr otherwise
-	const Image* icon() const;
+	[[nodiscard]] const Image* icon() const;
 	/// Returns the image fileneme for the menu image if the MapObject has one, is empty otherwise
-	const std::string& icon_filename() const;
+	[[nodiscard]] const std::string& icon_filename() const;
 
-	bool has_attribute(AttributeIndex) const;
-	const MapObjectDescr::Attributes& attributes() const;
+	[[nodiscard]] bool has_attribute(AttributeIndex) const;
+	[[nodiscard]] const MapObjectDescr::Attributes& attributes() const;
 	static AttributeIndex get_attribute_id(const std::string& name, bool add_if_not_exists = false);
 
 	/// Sets a tribe-specific ware or immovable helptext for this MapObject
@@ -101,9 +101,9 @@ public:
 	                   std::map<std::string, std::string> localized_helptext);
 	/// Gets the tribe-specific ware or immovable helptext for the given tribe. Fails if it doesn't
 	/// exist.
-	const std::map<std::string, std::string>& get_helptexts(const std::string& tribename) const;
+	[[nodiscard]] const std::map<std::string, std::string>& get_helptexts(const std::string& tribename) const;
 	/// Returns whether a tribe-specific helptext exists for the given tribe
-	bool has_helptext(const std::string& tribename) const;
+	[[nodiscard]] bool has_helptext(const std::string& tribename) const;
 
 protected:
 	// Add attributes to the attribute list
@@ -441,14 +441,14 @@ struct ObjectPointer {
 		return *this;
 	}
 
-	bool is_set() const {
+	[[nodiscard]] bool is_set() const {
 		return serial_;
 	}
 
 	// TODO(unknown): dammit... without an EditorGameBase object, we can't implement a
 	// MapObject* operator (would be really nice)
 	MapObject* get(const EditorGameBase&);
-	MapObject* get(const EditorGameBase& egbase) const;
+	[[nodiscard]] MapObject* get(const EditorGameBase& egbase) const;
 
 	bool operator<(const ObjectPointer& other) const {
 		return serial_ < other.serial_;
@@ -460,7 +460,7 @@ struct ObjectPointer {
 		return serial_ != other.serial_;
 	}
 
-	uint32_t serial() const {
+	[[nodiscard]] uint32_t serial() const {
 		return serial_;
 	}
 
@@ -477,14 +477,14 @@ template <class T> struct OPtr {
 		return *this;
 	}
 
-	bool is_set() const {
+	[[nodiscard]] bool is_set() const {
 		return m.is_set();
 	}
 
 	T* get(const EditorGameBase& egbase) {
 		return static_cast<T*>(m.get(egbase));
 	}
-	T* get(const EditorGameBase& egbase) const {
+	[[nodiscard]] T* get(const EditorGameBase& egbase) const {
 		return static_cast<T*>(m.get(egbase));
 	}
 
@@ -498,7 +498,7 @@ template <class T> struct OPtr {
 		return m != other.m;
 	}
 
-	Serial serial() const {
+	[[nodiscard]] Serial serial() const {
 		return m.serial();
 	}
 
@@ -515,7 +515,7 @@ struct CmdDestroyMapObject : public GameLogicCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kDestroyMapObject;
 	}
 
@@ -533,7 +533,7 @@ struct CmdAct : public GameLogicCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kAct;
 	}
 

--- a/src/logic/map_objects/map_object_program.h
+++ b/src/logic/map_objects/map_object_program.h
@@ -36,7 +36,7 @@ class MapObjectDescr;
 struct MapObjectProgram {
 	static constexpr const char* const kMainProgram = "main";
 
-	const std::string& name() const;
+	[[nodiscard]] const std::string& name() const;
 
 	explicit MapObjectProgram(const std::string& init_name);
 	virtual ~MapObjectProgram() = default;

--- a/src/logic/map_objects/pinned_note.cc
+++ b/src/logic/map_objects/pinned_note.cc
@@ -36,7 +36,7 @@ public:
 	              MapObjectDescr::OwnerType::kTribe) {
 	}
 
-	Bob& create_object() const override {
+	[[nodiscard]] Bob& create_object() const override {
 		return *new PinnedNote();
 	}
 

--- a/src/logic/map_objects/terrain_affinity.h
+++ b/src/logic/map_objects/terrain_affinity.h
@@ -40,17 +40,17 @@ public:
 	explicit TerrainAffinity(const LuaTable& table, const std::string& immovable_name);
 
 	// Preferred temperature is in arbitrary units.
-	int preferred_temperature() const;
+	[[nodiscard]] int preferred_temperature() const;
 
 	// Preferred fertility, ranging from 0 to 1000.
-	int preferred_fertility() const;
+	[[nodiscard]] int preferred_fertility() const;
 
 	// Preferred humidity, ranging from 0 to 1000.
-	int preferred_humidity() const;
+	[[nodiscard]] int preferred_humidity() const;
 
 	// A value in [0, 99] that defines how well this can deal with non-ideal
 	// situations. Lower means it is less picky, i.e. it can deal better.
-	int pickiness() const;
+	[[nodiscard]] int pickiness() const;
 
 private:
 	const int preferred_fertility_;

--- a/src/logic/map_objects/tribes/attack_target.h
+++ b/src/logic/map_objects/tribes/attack_target.h
@@ -37,10 +37,10 @@ public:
 	}
 
 	// Determines whether this building can be attacked right now.
-	virtual bool can_be_attacked() const = 0;
+	[[nodiscard]] virtual bool can_be_attacked() const = 0;
 
 	virtual void set_allow_conquer(PlayerNumber, bool) const = 0;
-	virtual bool get_allow_conquer(PlayerNumber) const = 0;
+	[[nodiscard]] virtual bool get_allow_conquer(PlayerNumber) const = 0;
 
 	// Called by an enemy soldier that enters a node with distance
 	// less than or equal to \ref kMaxProtectionRadius from the building.

--- a/src/logic/map_objects/tribes/building.h
+++ b/src/logic/map_objects/tribes/building.h
@@ -59,23 +59,23 @@ public:
 	~BuildingDescr() override {
 	}
 
-	bool is_buildable() const {
+	[[nodiscard]] bool is_buildable() const {
 		return buildable_;
 	}
-	bool can_be_dismantled() const {
+	[[nodiscard]] bool can_be_dismantled() const {
 		return can_be_dismantled_;
 	}
-	bool is_destructible() const {
+	[[nodiscard]] bool is_destructible() const {
 		return destructible_;
 	}
-	bool is_enhanced() const {
+	[[nodiscard]] bool is_enhanced() const {
 		return enhanced_building_;
 	}
 
 	/**
 	 * The build cost for direct construction
 	 */
-	const Buildcost& buildcost() const {
+	[[nodiscard]] const Buildcost& buildcost() const {
 		return buildcost_;
 	}
 	Buildcost& mutable_buildcost() {
@@ -85,7 +85,7 @@ public:
 	/**
 	 * Returned wares for dismantling
 	 */
-	const Buildcost& returns_on_dismantle() const {
+	[[nodiscard]] const Buildcost& returns_on_dismantle() const {
 		return returns_on_dismantle_;
 	}
 	Buildcost& mutable_returns_on_dismantle() {
@@ -95,7 +95,7 @@ public:
 	/**
 	 * The build cost for enhancing a previous building
 	 */
-	const Buildcost& enhancement_cost() const {
+	[[nodiscard]] const Buildcost& enhancement_cost() const {
 		return enhancement_cost_;
 	}
 	Buildcost& mutable_enhancement_cost() {
@@ -105,39 +105,39 @@ public:
 	/**
 	 * The returned wares for a enhaced building
 	 */
-	const Buildcost& enhancement_returns_on_dismantle() const {
+	[[nodiscard]] const Buildcost& enhancement_returns_on_dismantle() const {
 		return enhancement_returns_on_dismantle_;
 	}
 	Buildcost& mutable_enhancement_returns_on_dismantle() {
 		return enhancement_returns_on_dismantle_;
 	}
 
-	int32_t get_size() const {
+	[[nodiscard]] int32_t get_size() const {
 		return size_;
 	}
-	bool get_ismine() const {
+	[[nodiscard]] bool get_ismine() const {
 		return mine_;
 	}
-	bool get_isport() const {
+	[[nodiscard]] bool get_isport() const {
 		return port_;
 	}
-	bool needs_seafaring() const {
+	[[nodiscard]] bool needs_seafaring() const {
 		return needs_seafaring_;
 	}
-	bool needs_waterways() const {
+	[[nodiscard]] bool needs_waterways() const {
 		return needs_waterways_;
 	}
 
-	bool is_useful_on_map(bool seafaring_allowed, bool waterways_allowed) const;
+	[[nodiscard]] bool is_useful_on_map(bool seafaring_allowed, bool waterways_allowed) const;
 
 	// Returns the enhancement this building can become or
 	// INVALID_INDEX if it cannot be enhanced.
-	const DescriptionIndex& enhancement() const {
+	[[nodiscard]] const DescriptionIndex& enhancement() const {
 		return enhancement_;
 	}
 	// Returns the building from which this building can be enhanced or
 	// INVALID_INDEX if it cannot be built as an enhanced building.
-	const DescriptionIndex& enhanced_from() const {
+	[[nodiscard]] const DescriptionIndex& enhanced_from() const {
 		return enhanced_from_;
 	}
 	void set_enhanced_from(const DescriptionIndex& index) {
@@ -161,10 +161,10 @@ public:
 	                 bool loading = false,
 	                 const FormerBuildings& former_buildings = FormerBuildings()) const;
 
-	virtual uint32_t get_conquers() const;
-	virtual uint32_t vision_range() const;
+	[[nodiscard]] virtual uint32_t get_conquers() const;
+	[[nodiscard]] virtual uint32_t vision_range() const;
 
-	const WorkareaInfo& workarea_info() const {
+	[[nodiscard]] const WorkareaInfo& workarea_info() const {
 		return workarea_info_;
 	}
 
@@ -172,17 +172,17 @@ public:
 	// in many places.
 	WorkareaInfo workarea_info_;
 
-	bool suitability(const Map&, const FCoords&) const;
-	const AI::BuildingHints& hints() const;
+	[[nodiscard]] bool suitability(const Map&, const FCoords&) const;
+	[[nodiscard]] const AI::BuildingHints& hints() const;
 	void set_hints_trainingsites_max_percent(int percent);
 
-	uint32_t get_unoccupied_animation() const;
+	[[nodiscard]] uint32_t get_unoccupied_animation() const;
 
-	DescriptionIndex get_built_over_immovable() const {
+	[[nodiscard]] DescriptionIndex get_built_over_immovable() const {
 		return built_over_immovable_;
 	}
 
-	const std::string& get_owning_tribe() const {
+	[[nodiscard]] const std::string& get_owning_tribe() const {
 		return owning_tribe_;
 	}
 	void set_owning_tribe(const std::string&);
@@ -190,8 +190,8 @@ public:
 	void set_enhancement(Descriptions&, LuaTable&);
 
 protected:
-	virtual Building& create_object() const = 0;
-	Building& create_constructionsite() const;
+	[[nodiscard]] virtual Building& create_object() const = 0;
+	[[nodiscard]] Building& create_constructionsite() const;
 
 private:
 	void set_enhancement_cost(const Buildcost& enhance_cost, const Buildcost& return_enhanced);

--- a/src/logic/map_objects/tribes/carrier.h
+++ b/src/logic/map_objects/tribes/carrier.h
@@ -34,7 +34,7 @@ public:
 	}
 
 protected:
-	Bob& create_object() const override;
+	[[nodiscard]] Bob& create_object() const override;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(CarrierDescr);

--- a/src/logic/map_objects/tribes/constructionsite.cc
+++ b/src/logic/map_objects/tribes/constructionsite.cc
@@ -45,8 +45,6 @@
 
 namespace Widelands {
 
-
-
 void ConstructionsiteInformation::draw(const Vector2f& point_on_dst,
                                        const Widelands::Coords& coords,
                                        float scale,

--- a/src/logic/map_objects/tribes/constructionsite.cc
+++ b/src/logic/map_objects/tribes/constructionsite.cc
@@ -45,7 +45,7 @@
 
 namespace Widelands {
 
-constexpr Duration ConstructionSite::kConstructionsiteStepTime;
+
 
 void ConstructionsiteInformation::draw(const Vector2f& point_on_dst,
                                        const Widelands::Coords& coords,

--- a/src/logic/map_objects/tribes/constructionsite.h
+++ b/src/logic/map_objects/tribes/constructionsite.h
@@ -80,9 +80,9 @@ public:
 	~ConstructionSiteDescr() override {
 	}
 
-	Building& create_object() const override;
+	[[nodiscard]] Building& create_object() const override;
 
-	FxId creation_fx() const;
+	[[nodiscard]] FxId creation_fx() const;
 
 private:
 	const FxId creation_fx_;

--- a/src/logic/map_objects/tribes/dismantlesite.cc
+++ b/src/logic/map_objects/tribes/dismantlesite.cc
@@ -32,7 +32,7 @@
 
 namespace Widelands {
 
-constexpr Duration DismantleSite::kDismantlesiteStepTime;
+
 
 /**
  * The contents of 'table' are documented in

--- a/src/logic/map_objects/tribes/dismantlesite.cc
+++ b/src/logic/map_objects/tribes/dismantlesite.cc
@@ -32,8 +32,6 @@
 
 namespace Widelands {
 
-
-
 /**
  * The contents of 'table' are documented in
  * /data/tribes/buildings/partially_finished/dismantlesite/init.lua

--- a/src/logic/map_objects/tribes/dismantlesite.h
+++ b/src/logic/map_objects/tribes/dismantlesite.h
@@ -48,9 +48,9 @@ public:
 	~DismantleSiteDescr() override {
 	}
 
-	Building& create_object() const override;
+	[[nodiscard]] Building& create_object() const override;
 
-	FxId creation_fx() const;
+	[[nodiscard]] FxId creation_fx() const;
 
 private:
 	const FxId creation_fx_;

--- a/src/logic/map_objects/tribes/ferry.h
+++ b/src/logic/map_objects/tribes/ferry.h
@@ -36,10 +36,10 @@ public:
 	~FerryDescr() override {
 	}
 
-	uint32_t movecaps() const override;
+	[[nodiscard]] uint32_t movecaps() const override;
 
 protected:
-	Bob& create_object() const override;
+	[[nodiscard]] Bob& create_object() const override;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(FerryDescr);

--- a/src/logic/map_objects/tribes/market.h
+++ b/src/logic/map_objects/tribes/market.h
@@ -34,9 +34,9 @@ public:
 	~MarketDescr() override {
 	}
 
-	Building& create_object() const override;
+	[[nodiscard]] Building& create_object() const override;
 
-	DescriptionIndex carrier() const {
+	[[nodiscard]] DescriptionIndex carrier() const {
 		return carrier_;
 	}
 
@@ -74,10 +74,10 @@ private:
 		std::vector<Worker*> workers;
 
 		// The number of individual wares in 'items', i.e. the sum of all '.second's.
-		int num_wares_per_batch() const;
+		[[nodiscard]] int num_wares_per_batch() const;
 
 		// True if the 'num_shipped_batches' equals the 'initial_num_batches'
-		bool fulfilled() const;
+		[[nodiscard]] bool fulfilled() const;
 	};
 
 	static void

--- a/src/logic/map_objects/tribes/militarysite.h
+++ b/src/logic/map_objects/tribes/militarysite.h
@@ -44,21 +44,21 @@ public:
 	~MilitarySiteDescr() override {
 	}
 
-	Building& create_object() const override;
+	[[nodiscard]] Building& create_object() const override;
 
-	uint32_t get_conquers() const override {
+	[[nodiscard]] uint32_t get_conquers() const override {
 		return conquer_radius_;
 	}
 	void set_conquers(uint32_t c) {
 		conquer_radius_ = c;
 	}
-	Quantity get_max_number_of_soldiers() const {
+	[[nodiscard]] Quantity get_max_number_of_soldiers() const {
 		return num_soldiers_;
 	}
 	void set_max_number_of_soldiers(Quantity q) {
 		num_soldiers_ = q;
 	}
-	uint32_t get_heal_per_second() const {
+	[[nodiscard]] uint32_t get_heal_per_second() const {
 		return heal_per_second_;
 	}
 	void set_heal_per_second(uint32_t h) {
@@ -167,12 +167,12 @@ private:
 		explicit SoldierControl(MilitarySite* military_site) : military_site_(military_site) {
 		}
 
-		std::vector<Soldier*> present_soldiers() const override;
-		std::vector<Soldier*> stationed_soldiers() const override;
-		std::vector<Soldier*> associated_soldiers() const override;
-		Quantity min_soldier_capacity() const override;
-		Quantity max_soldier_capacity() const override;
-		Quantity soldier_capacity() const override;
+		[[nodiscard]] std::vector<Soldier*> present_soldiers() const override;
+		[[nodiscard]] std::vector<Soldier*> stationed_soldiers() const override;
+		[[nodiscard]] std::vector<Soldier*> associated_soldiers() const override;
+		[[nodiscard]] Quantity min_soldier_capacity() const override;
+		[[nodiscard]] Quantity max_soldier_capacity() const override;
+		[[nodiscard]] Quantity soldier_capacity() const override;
 		void set_soldier_capacity(Quantity capacity) override;
 		void drop_soldier(Soldier&) override;
 		int incorporate_soldier(EditorGameBase& egbase, Soldier& s) override;

--- a/src/logic/map_objects/tribes/production_program.h
+++ b/src/logic/map_objects/tribes/production_program.h
@@ -76,13 +76,13 @@ struct ProductionProgram : public MapObjectProgram {
 		 */
 		virtual void building_work_failed(Game&, ProductionSite&, Worker&) const;
 
-		const Groups& consumed_wares_workers() const {
+		[[nodiscard]] const Groups& consumed_wares_workers() const {
 			return consumed_wares_workers_;
 		}
-		const BillOfMaterials& produced_wares() const {
+		[[nodiscard]] const BillOfMaterials& produced_wares() const {
 			return produced_wares_;
 		}
-		const BillOfMaterials& recruited_workers() const {
+		[[nodiscard]] const BillOfMaterials& recruited_workers() const {
 			return recruited_workers_;
 		}
 
@@ -165,9 +165,9 @@ struct ProductionProgram : public MapObjectProgram {
 
 		struct Condition {
 			virtual ~Condition() = default;
-			virtual bool evaluate(const ProductionSite&) const = 0;
-			virtual std::string description(const Descriptions&) const = 0;
-			virtual std::string description_negation(const Descriptions&) const = 0;
+			[[nodiscard]] virtual bool evaluate(const ProductionSite&) const = 0;
+			[[nodiscard]] virtual std::string description(const Descriptions&) const = 0;
+			[[nodiscard]] virtual std::string description_negation(const Descriptions&) const = 0;
 		};
 		static Condition* create_condition(const std::vector<std::string>& arguments,
 		                                   std::vector<std::string>::const_iterator& begin,
@@ -182,11 +182,11 @@ struct ProductionProgram : public MapObjectProgram {
 			         const ProductionSiteDescr& descr,
 			         const Descriptions& descriptions);
 			~Negation() override;
-			bool evaluate(const ProductionSite&) const override;
+			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
 			// Just a dummy to satisfy the superclass interface. Do not use.
-			std::string description(const Descriptions&) const override;
+			[[nodiscard]] std::string description(const Descriptions&) const override;
 			// Just a dummy to satisfy the superclass interface. Do not use.
-			std::string description_negation(const Descriptions&) const override;
+			[[nodiscard]] std::string description_negation(const Descriptions&) const override;
 
 		private:
 			Condition* const operand;
@@ -196,9 +196,9 @@ struct ProductionProgram : public MapObjectProgram {
 		struct EconomyNeedsWare : public Condition {
 			explicit EconomyNeedsWare(const DescriptionIndex& i) : ware_type(i) {
 			}
-			bool evaluate(const ProductionSite&) const override;
-			std::string description(const Descriptions& descriptions) const override;
-			std::string description_negation(const Descriptions& descriptions) const override;
+			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
+			[[nodiscard]] std::string description(const Descriptions& descriptions) const override;
+			[[nodiscard]] std::string description_negation(const Descriptions& descriptions) const override;
 
 		private:
 			DescriptionIndex ware_type;
@@ -208,9 +208,9 @@ struct ProductionProgram : public MapObjectProgram {
 		struct EconomyNeedsWorker : public Condition {
 			explicit EconomyNeedsWorker(const DescriptionIndex& i) : worker_type(i) {
 			}
-			bool evaluate(const ProductionSite&) const override;
-			std::string description(const Descriptions& descriptions) const override;
-			std::string description_negation(const Descriptions& descriptions) const override;
+			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
+			[[nodiscard]] std::string description(const Descriptions& descriptions) const override;
+			[[nodiscard]] std::string description_negation(const Descriptions& descriptions) const override;
 
 		private:
 			DescriptionIndex worker_type;
@@ -224,9 +224,9 @@ struct ProductionProgram : public MapObjectProgram {
 			        std::vector<std::string>::const_iterator end,
 			        const ProductionSiteDescr& descr,
 			        const Descriptions& descriptions);
-			bool evaluate(const ProductionSite&) const override;
-			std::string description(const Descriptions& descriptions) const override;
-			std::string description_negation(const Descriptions& descriptions) const override;
+			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
+			[[nodiscard]] std::string description(const Descriptions& descriptions) const override;
+			[[nodiscard]] std::string description_negation(const Descriptions& descriptions) const override;
 
 		private:
 			WareTypeGroup group;
@@ -235,9 +235,9 @@ struct ProductionProgram : public MapObjectProgram {
 		/// Tests whether any of the workers at the site needs experience to
 		/// become upgraded.
 		struct WorkersNeedExperience : public Condition {
-			bool evaluate(const ProductionSite&) const override;
-			std::string description(const Descriptions&) const override;
-			std::string description_negation(const Descriptions&) const override;
+			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
+			[[nodiscard]] std::string description(const Descriptions&) const override;
+			[[nodiscard]] std::string description_negation(const Descriptions&) const override;
 		};
 
 		using Conditions = std::vector<Condition*>;
@@ -282,7 +282,7 @@ struct ProductionProgram : public MapObjectProgram {
 		explicit ActCall(const std::vector<std::string>& arguments);
 		void execute(Game&, ProductionSite&) const override;
 
-		const std::string& program_name() const {
+		[[nodiscard]] const std::string& program_name() const {
 			return program_name_;
 		}
 
@@ -306,7 +306,7 @@ struct ProductionProgram : public MapObjectProgram {
 		void execute(Game&, ProductionSite&) const override;
 		bool get_building_work(Game&, ProductionSite&, Worker&) const override;
 		void building_work_failed(Game&, ProductionSite&, Worker&) const override;
-		const std::string& program() const {
+		[[nodiscard]] const std::string& program() const {
 			return program_;
 		}
 
@@ -475,7 +475,7 @@ struct ProductionProgram : public MapObjectProgram {
 		                         const ProductionSiteDescr& descr);
 		void execute(Game&, ProductionSite& ps) const override;
 
-		TrainingParameters training() const {
+		[[nodiscard]] TrainingParameters training() const {
 			return training_;
 		}
 
@@ -488,7 +488,7 @@ struct ProductionProgram : public MapObjectProgram {
 		                  const ProductionSiteDescr& descr);
 		void execute(Game&, ProductionSite& ps) const override;
 
-		TrainingParameters training() const {
+		[[nodiscard]] TrainingParameters training() const {
 			return training_;
 		}
 
@@ -540,7 +540,7 @@ struct ProductionProgram : public MapObjectProgram {
 		bool get_building_work(Game&, ProductionSite&, Worker&) const override;
 		void building_work_failed(Game&, ProductionSite&, Worker&) const override;
 
-		const ImmovableDescr& get_construction_descr(const Descriptions& descriptions) const;
+		[[nodiscard]] const ImmovableDescr& get_construction_descr(const Descriptions& descriptions) const;
 
 	private:
 		std::string objectname;
@@ -553,14 +553,14 @@ struct ProductionProgram : public MapObjectProgram {
 	                  Descriptions& descriptions,
 	                  ProductionSiteDescr* building);
 
-	const std::string& descname() const;
+	[[nodiscard]] const std::string& descname() const;
 
-	size_t size() const;
+	[[nodiscard]] size_t size() const;
 	const ProductionProgram::Action& operator[](size_t const idx) const;
 
-	const ProductionProgram::Groups& consumed_wares_workers() const;
-	const Buildcost& produced_wares() const;
-	const Buildcost& recruited_workers() const;
+	[[nodiscard]] const ProductionProgram::Groups& consumed_wares_workers() const;
+	[[nodiscard]] const Buildcost& produced_wares() const;
+	[[nodiscard]] const Buildcost& recruited_workers() const;
 	// Throws a GameDataError if we're trying to call an unknown program
 	void validate_calls(const ProductionSiteDescr& descr) const;
 

--- a/src/logic/map_objects/tribes/production_program.h
+++ b/src/logic/map_objects/tribes/production_program.h
@@ -198,7 +198,8 @@ struct ProductionProgram : public MapObjectProgram {
 			}
 			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
 			[[nodiscard]] std::string description(const Descriptions& descriptions) const override;
-			[[nodiscard]] std::string description_negation(const Descriptions& descriptions) const override;
+			[[nodiscard]] std::string
+			description_negation(const Descriptions& descriptions) const override;
 
 		private:
 			DescriptionIndex ware_type;
@@ -210,7 +211,8 @@ struct ProductionProgram : public MapObjectProgram {
 			}
 			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
 			[[nodiscard]] std::string description(const Descriptions& descriptions) const override;
-			[[nodiscard]] std::string description_negation(const Descriptions& descriptions) const override;
+			[[nodiscard]] std::string
+			description_negation(const Descriptions& descriptions) const override;
 
 		private:
 			DescriptionIndex worker_type;
@@ -226,7 +228,8 @@ struct ProductionProgram : public MapObjectProgram {
 			        const Descriptions& descriptions);
 			[[nodiscard]] bool evaluate(const ProductionSite&) const override;
 			[[nodiscard]] std::string description(const Descriptions& descriptions) const override;
-			[[nodiscard]] std::string description_negation(const Descriptions& descriptions) const override;
+			[[nodiscard]] std::string
+			description_negation(const Descriptions& descriptions) const override;
 
 		private:
 			WareTypeGroup group;
@@ -540,7 +543,8 @@ struct ProductionProgram : public MapObjectProgram {
 		bool get_building_work(Game&, ProductionSite&, Worker&) const override;
 		void building_work_failed(Game&, ProductionSite&, Worker&) const override;
 
-		[[nodiscard]] const ImmovableDescr& get_construction_descr(const Descriptions& descriptions) const;
+		[[nodiscard]] const ImmovableDescr&
+		get_construction_descr(const Descriptions& descriptions) const;
 
 	private:
 		std::string objectname;

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -57,37 +57,37 @@ public:
 	                    const LuaTable& t,
 	                    Descriptions& descriptions);
 
-	Building& create_object() const override;
+	[[nodiscard]] Building& create_object() const override;
 
 	// List of wares to register having economy checks. Parsed by the tribes during postload and must
 	// be nullptr after loading has finished
-	std::set<DescriptionIndex>* ware_demand_checks() const;
+	[[nodiscard]] std::set<DescriptionIndex>* ware_demand_checks() const;
 	// List of workers to register having economy checks. Parsed by the tribes during postload and
 	// must be nullptr after loading has finished
-	std::set<DescriptionIndex>* worker_demand_checks() const;
+	[[nodiscard]] std::set<DescriptionIndex>* worker_demand_checks() const;
 	// Clear ware and worker demand check info
 	void clear_demand_checks();
 
-	uint32_t nr_working_positions() const {
+	[[nodiscard]] uint32_t nr_working_positions() const {
 		uint32_t result = 0;
 		for (const auto& working_pos : working_positions()) {
 			result += working_pos.second;
 		}
 		return result;
 	}
-	const BillOfMaterials& working_positions() const {
+	[[nodiscard]] const BillOfMaterials& working_positions() const {
 		return working_positions_;
 	}
-	bool is_output_ware_type(const DescriptionIndex& i) const {
+	[[nodiscard]] bool is_output_ware_type(const DescriptionIndex& i) const {
 		return output_ware_types_.count(i);
 	}
-	bool is_output_worker_type(const DescriptionIndex& i) const {
+	[[nodiscard]] bool is_output_worker_type(const DescriptionIndex& i) const {
 		return output_worker_types_.count(i);
 	}
-	const BillOfMaterials& input_wares() const {
+	[[nodiscard]] const BillOfMaterials& input_wares() const {
 		return input_wares_;
 	}
-	const BillOfMaterials& input_workers() const {
+	[[nodiscard]] const BillOfMaterials& input_workers() const {
 		return input_workers_;
 	}
 	BillOfMaterials& mutable_input_wares() {
@@ -97,25 +97,25 @@ public:
 		return input_workers_;
 	}
 	using Output = std::set<DescriptionIndex>;
-	const Output& output_ware_types() const {
+	[[nodiscard]] const Output& output_ware_types() const {
 		return output_ware_types_;
 	}
-	const Output& output_worker_types() const {
+	[[nodiscard]] const Output& output_worker_types() const {
 		return output_worker_types_;
 	}
 	/// Map objects that this production site needs nearby according to attribute, without removing
 	/// them from the map
-	const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
+	[[nodiscard]] const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
 	needed_attributes() const {
 		return needed_attributes_;
 	}
 	/// Map objects that are collected from the map by this production site according to attribute
-	const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
+	[[nodiscard]] const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
 	collected_attributes() const {
 		return collected_attributes_;
 	}
 	/// Map objects that are placed on the map by this production site according to attribute
-	const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
+	[[nodiscard]] const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
 	created_attributes() const {
 		return created_attributes_;
 	}
@@ -130,15 +130,15 @@ public:
 
 	/// The resources that this production site needs to collect from the map, the max percent it can
 	/// achieve, and the chance when depleted
-	const std::map<std::string, CollectedResourceInfo>& collected_resources() const {
+	[[nodiscard]] const std::map<std::string, CollectedResourceInfo>& collected_resources() const {
 		return collected_resources_;
 	}
 	/// The resources that this production site will place on the map
-	const std::set<std::string>& created_resources() const {
+	[[nodiscard]] const std::set<std::string>& created_resources() const {
 		return created_resources_;
 	}
 	/// The bobs (critters) that this production site needs to collect from the map
-	const std::set<std::string>& collected_bobs() const {
+	[[nodiscard]] const std::set<std::string>& collected_bobs() const {
 		return collected_bobs_;
 	}
 	/// Set that this production site needs to collect the given bob from the map
@@ -146,7 +146,7 @@ public:
 		collected_bobs_.insert(bobname);
 	}
 	/// The bobs (critters or workers) that this production site will place on the map
-	const std::set<std::string>& created_bobs() const {
+	[[nodiscard]] const std::set<std::string>& created_bobs() const {
 		return created_bobs_;
 	}
 	/// Set that this production site will place the given bob on the map
@@ -154,11 +154,11 @@ public:
 		created_bobs_.insert(bobname);
 	}
 	/// The immovables that this production site needs to be nearby
-	const std::set<std::string>& needed_immovables() const {
+	[[nodiscard]] const std::set<std::string>& needed_immovables() const {
 		return needed_immovables_;
 	}
 	/// The immovables that this production site needs to collect from the map
-	const std::set<std::string>& collected_immovables() const {
+	[[nodiscard]] const std::set<std::string>& collected_immovables() const {
 		return collected_immovables_;
 	}
 	/// Set that this production site makes use of the given immovable nearby
@@ -170,7 +170,7 @@ public:
 		collected_immovables_.insert(immovablename);
 	}
 	/// The immovables that this production site will place on the map
-	const std::set<std::string>& created_immovables() const {
+	[[nodiscard]] const std::set<std::string>& created_immovables() const {
 		return created_immovables_;
 	}
 	/// Set that this production site will place the given immovable on the map
@@ -178,32 +178,32 @@ public:
 		created_immovables_.insert(immovablename);
 	}
 
-	const ProductionProgram* get_program(const std::string&) const;
+	[[nodiscard]] const ProductionProgram* get_program(const std::string&) const;
 	using Programs = std::map<std::string, std::unique_ptr<ProductionProgram>>;
-	const Programs& programs() const {
+	[[nodiscard]] const Programs& programs() const {
 		return programs_;
 	}
 	Programs& mutable_programs() {
 		return programs_;
 	}
 
-	const std::string& out_of_resource_title() const {
+	[[nodiscard]] const std::string& out_of_resource_title() const {
 		return out_of_resource_title_;
 	}
 
-	const std::string& out_of_resource_heading() const {
+	[[nodiscard]] const std::string& out_of_resource_heading() const {
 		return out_of_resource_heading_;
 	}
 
-	const std::string& out_of_resource_message() const {
+	[[nodiscard]] const std::string& out_of_resource_message() const {
 		return out_of_resource_message_;
 	}
 
-	const std::string& resource_not_needed_message() const {
+	[[nodiscard]] const std::string& resource_not_needed_message() const {
 		return resource_not_needed_message_;
 	}
 
-	uint32_t out_of_resource_productivity_threshold() const {
+	[[nodiscard]] uint32_t out_of_resource_productivity_threshold() const {
 		return out_of_resource_productivity_threshold_;
 	}
 
@@ -220,21 +220,21 @@ public:
 	void add_supported_by_productionsite(const std::string& productionsite);
 	/// Returns whether this production site competes with the given 'productionsite' for map
 	/// resources.
-	bool competes_with_productionsite(const std::string& productionsite) const;
+	[[nodiscard]] bool competes_with_productionsite(const std::string& productionsite) const;
 	/// Returns whether this production site creates map resources or objects that the given
 	/// 'productionsite' needs.
-	bool supports_productionsite(const std::string& productionsite) const;
+	[[nodiscard]] bool supports_productionsite(const std::string& productionsite) const;
 	/// Returns whether the given 'productionsite' creates map resources or objects that this
 	/// production site needs.
-	bool is_supported_by_productionsite(const std::string& productionsite) const;
+	[[nodiscard]] bool is_supported_by_productionsite(const std::string& productionsite) const;
 	/// Returns the production sites that need a map resource or object that this production site
 	/// will place on the map.
-	std::set<std::string> supported_productionsites() const {
+	[[nodiscard]] std::set<std::string> supported_productionsites() const {
 		return supported_productionsites_;
 	}
 	/// Returns the production sites that create a map resource or object that this production site
 	/// needs.
-	std::set<std::string> supported_by_productionsites() const {
+	[[nodiscard]] std::set<std::string> supported_by_productionsites() const {
 		return supported_by_productionsites_;
 	}
 
@@ -533,10 +533,10 @@ struct Input {
 	~Input() {
 	}
 
-	DescriptionIndex ware() const {
+	[[nodiscard]] DescriptionIndex ware() const {
 		return ware_;
 	}
-	uint8_t max() const {
+	[[nodiscard]] uint8_t max() const {
 		return max_;
 	}
 

--- a/src/logic/map_objects/tribes/requirements.h
+++ b/src/logic/map_objects/tribes/requirements.h
@@ -50,16 +50,16 @@ private:
 		virtual ~BaseCapsule() {
 		}
 
-		virtual bool check(const MapObject&) const = 0;
+		[[nodiscard]] virtual bool check(const MapObject&) const = 0;
 		virtual void write(FileWrite&, EditorGameBase&, MapObjectSaver&) const = 0;
-		virtual const RequirementsStorage& storage() const = 0;
+		[[nodiscard]] virtual const RequirementsStorage& storage() const = 0;
 	};
 
 	template <typename T> struct Capsule : public BaseCapsule {
 		explicit Capsule(const T& init_m) : m(init_m) {
 		}
 
-		bool check(const MapObject& obj) const override {
+		[[nodiscard]] bool check(const MapObject& obj) const override {
 			return m.check(obj);
 		}
 
@@ -67,7 +67,7 @@ private:
 			m.write(fw, egbase, mos);
 		}
 
-		const RequirementsStorage& storage() const override {
+		[[nodiscard]] const RequirementsStorage& storage() const override {
 			return T::storage;
 		}
 
@@ -84,7 +84,7 @@ public:
 	/**
 	 * \return \c true if the object satisfies the requirements.
 	 */
-	bool check(const MapObject&) const;
+	[[nodiscard]] bool check(const MapObject&) const;
 
 	// For Save/Load Games
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&);
@@ -112,7 +112,7 @@ struct RequirementsStorage {
 	using Reader = Requirements (*)(FileRead&, EditorGameBase&, MapObjectLoader&);
 
 	RequirementsStorage(uint32_t id, Reader reader);
-	uint32_t id() const;
+	[[nodiscard]] uint32_t id() const;
 
 	static Requirements read(FileRead&, EditorGameBase&, MapObjectLoader&);
 
@@ -132,7 +132,7 @@ private:
 struct RequireOr {
 	void add(const Requirements&);
 
-	bool check(const MapObject&) const;
+	[[nodiscard]] bool check(const MapObject&) const;
 	void write(FileWrite&, EditorGameBase& egbase, MapObjectSaver&) const;
 
 	static const RequirementsStorage storage;
@@ -148,7 +148,7 @@ private:
 struct RequireAnd {
 	void add(const Requirements&);
 
-	bool check(const MapObject&) const;
+	[[nodiscard]] bool check(const MapObject&) const;
 	void write(FileWrite&, EditorGameBase& egbase, MapObjectSaver&) const;
 
 	static const RequirementsStorage storage;
@@ -167,15 +167,15 @@ struct RequireAttribute {
 
 	RequireAttribute() : at(TrainingAttribute::kTotal), min(SHRT_MIN), max(SHRT_MAX) {
 	}
-	bool check(const MapObject&) const;
+	[[nodiscard]] bool check(const MapObject&) const;
 	void write(FileWrite&, EditorGameBase& egbase, MapObjectSaver&) const;
 
 	static const RequirementsStorage storage;
 
-	int32_t get_min() const {
+	[[nodiscard]] int32_t get_min() const {
 		return min;
 	}
-	int32_t get_max() const {
+	[[nodiscard]] int32_t get_max() const {
 		return max;
 	}
 

--- a/src/logic/map_objects/tribes/road_textures.h
+++ b/src/logic/map_objects/tribes/road_textures.h
@@ -29,9 +29,9 @@ class RoadTextures {
 public:
 	// Returns the road texture that should be used for 'coords' and the road
 	// going into direction 'direction' (which can be any number).
-	const Image& get_normal_texture(const Widelands::Coords& coords, int direction) const;
-	const Image& get_busy_texture(const Widelands::Coords& coords, int direction) const;
-	const Image& get_waterway_texture(const Widelands::Coords& coords, int direction) const;
+	[[nodiscard]] const Image& get_normal_texture(const Widelands::Coords& coords, int direction) const;
+	[[nodiscard]] const Image& get_busy_texture(const Widelands::Coords& coords, int direction) const;
+	[[nodiscard]] const Image& get_waterway_texture(const Widelands::Coords& coords, int direction) const;
 
 	// Adds a new road texture.
 	void add_normal_road_texture(const Image* image);

--- a/src/logic/map_objects/tribes/road_textures.h
+++ b/src/logic/map_objects/tribes/road_textures.h
@@ -29,9 +29,12 @@ class RoadTextures {
 public:
 	// Returns the road texture that should be used for 'coords' and the road
 	// going into direction 'direction' (which can be any number).
-	[[nodiscard]] const Image& get_normal_texture(const Widelands::Coords& coords, int direction) const;
-	[[nodiscard]] const Image& get_busy_texture(const Widelands::Coords& coords, int direction) const;
-	[[nodiscard]] const Image& get_waterway_texture(const Widelands::Coords& coords, int direction) const;
+	[[nodiscard]] const Image& get_normal_texture(const Widelands::Coords& coords,
+	                                              int direction) const;
+	[[nodiscard]] const Image& get_busy_texture(const Widelands::Coords& coords,
+	                                            int direction) const;
+	[[nodiscard]] const Image& get_waterway_texture(const Widelands::Coords& coords,
+	                                                int direction) const;
 
 	// Adds a new road texture.
 	void add_normal_road_texture(const Image* image);

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -57,18 +57,18 @@ public:
 	~ShipDescr() override {
 	}
 
-	Bob& create_object() const override;
+	[[nodiscard]] Bob& create_object() const override;
 
-	uint32_t movecaps() const override;
-	const DirAnimations& get_sail_anims() const {
+	[[nodiscard]] uint32_t movecaps() const override;
+	[[nodiscard]] const DirAnimations& get_sail_anims() const {
 		return sail_anims_;
 	}
 
-	Quantity get_default_capacity() const {
+	[[nodiscard]] Quantity get_default_capacity() const {
 		return default_capacity_;
 	}
 
-	const std::vector<std::string>& get_ship_names() const {
+	[[nodiscard]] const std::vector<std::string>& get_ship_names() const {
 		return ship_names_;
 	}
 

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -806,7 +806,7 @@ void Soldier::init_auto_task(Game& game) {
 struct FindNodeOwned {
 	explicit FindNodeOwned(PlayerNumber owner) : owner_(owner) {
 	}
-	bool accept(const EditorGameBase& /* egbase */, const FCoords& coords) const {
+	[[nodiscard]] bool accept(const EditorGameBase& /* egbase */, const FCoords& coords) const {
 		return (coords.field->get_owned_by() == owner_);
 	}
 

--- a/src/logic/map_objects/tribes/soldier.h
+++ b/src/logic/map_objects/tribes/soldier.h
@@ -41,7 +41,7 @@ struct SoldierLevelRange {
 	SoldierLevelRange& operator=(const SoldierLevelRange& other) = default;
 
 	bool matches(const Soldier* soldier) const;
-	bool matches(int32_t health, int32_t attack, int32_t defense, int32_t evade) const;
+	[[nodiscard]] bool matches(int32_t health, int32_t attack, int32_t defense, int32_t evade) const;
 
 	bool operator==(const SoldierLevelRange& other) const {
 		return min_health == other.min_health && min_attack == other.min_attack &&

--- a/src/logic/map_objects/tribes/soldiercontrol.h
+++ b/src/logic/map_objects/tribes/soldiercontrol.h
@@ -43,35 +43,35 @@ public:
 	/**
 	 * \return a list of soldiers that are currently present in the building.
 	 */
-	virtual std::vector<Soldier*> present_soldiers() const = 0;
+	[[nodiscard]] virtual std::vector<Soldier*> present_soldiers() const = 0;
 
 	/**
 	 * \return a list of soldiers that are currently stationed in the building.
 	 */
-	virtual std::vector<Soldier*> stationed_soldiers() const = 0;
+	[[nodiscard]] virtual std::vector<Soldier*> stationed_soldiers() const = 0;
 
 	/**
 	 * \return a list of soldiers that are currently stationed in or coming to the building.
 	 */
-	virtual std::vector<Soldier*> associated_soldiers() const = 0;
+	[[nodiscard]] virtual std::vector<Soldier*> associated_soldiers() const = 0;
 
 	/**
 	 * \return the minimum number of soldiers that this building can be
 	 * configured to hold.
 	 */
-	virtual Quantity min_soldier_capacity() const = 0;
+	[[nodiscard]] virtual Quantity min_soldier_capacity() const = 0;
 
 	/**
 	 * \return the maximum number of soldiers that this building can be
 	 * configured to hold.
 	 */
-	virtual Quantity max_soldier_capacity() const = 0;
+	[[nodiscard]] virtual Quantity max_soldier_capacity() const = 0;
 
 	/**
 	 * \return the number of soldiers this building is configured to hold
 	 * right now.
 	 */
-	virtual Quantity soldier_capacity() const = 0;
+	[[nodiscard]] virtual Quantity soldier_capacity() const = 0;
 
 	/**
 	 * Sets the capacity for soldiers of this building.

--- a/src/logic/map_objects/tribes/trainingsite.h
+++ b/src/logic/map_objects/tribes/trainingsite.h
@@ -38,66 +38,66 @@ public:
 	~TrainingSiteDescr() override {
 	}
 
-	Building& create_object() const override;
+	[[nodiscard]] Building& create_object() const override;
 
-	Quantity get_max_number_of_soldiers() const {
+	[[nodiscard]] Quantity get_max_number_of_soldiers() const {
 		return num_soldiers_;
 	}
 	void set_max_number_of_soldiers(Quantity q) {
 		num_soldiers_ = q;
 	}
-	bool get_train_health() const {
+	[[nodiscard]] bool get_train_health() const {
 		return train_health_;
 	}
-	bool get_train_attack() const {
+	[[nodiscard]] bool get_train_attack() const {
 		return train_attack_;
 	}
-	bool get_train_defense() const {
+	[[nodiscard]] bool get_train_defense() const {
 		return train_defense_;
 	}
-	bool get_train_evade() const {
+	[[nodiscard]] bool get_train_evade() const {
 		return train_evade_;
 	}
 
-	unsigned get_min_level(TrainingAttribute) const;
-	unsigned get_max_level(TrainingAttribute) const;
-	int32_t get_max_stall() const {
+	[[nodiscard]] unsigned get_min_level(TrainingAttribute) const;
+	[[nodiscard]] unsigned get_max_level(TrainingAttribute) const;
+	[[nodiscard]] int32_t get_max_stall() const {
 		return max_stall_;
 	}
 	void set_max_stall(int32_t trainer_patience) {
 		max_stall_ = trainer_patience;
 	}
 
-	const std::vector<std::vector<std::string>>& get_food_health() const {
+	[[nodiscard]] const std::vector<std::vector<std::string>>& get_food_health() const {
 		return food_health_;
 	}
-	const std::vector<std::vector<std::string>>& get_food_attack() const {
+	[[nodiscard]] const std::vector<std::vector<std::string>>& get_food_attack() const {
 		return food_attack_;
 	}
-	const std::vector<std::vector<std::string>>& get_food_defense() const {
+	[[nodiscard]] const std::vector<std::vector<std::string>>& get_food_defense() const {
 		return food_defense_;
 	}
-	const std::vector<std::vector<std::string>>& get_food_evade() const {
+	[[nodiscard]] const std::vector<std::vector<std::string>>& get_food_evade() const {
 		return food_evade_;
 	}
-	const std::vector<std::string>& get_weapons_health() const {
+	[[nodiscard]] const std::vector<std::string>& get_weapons_health() const {
 		return weapons_health_;
 	}
-	const std::vector<std::string>& get_weapons_attack() const {
+	[[nodiscard]] const std::vector<std::string>& get_weapons_attack() const {
 		return weapons_attack_;
 	}
-	const std::vector<std::string>& get_weapons_defense() const {
+	[[nodiscard]] const std::vector<std::string>& get_weapons_defense() const {
 		return weapons_defense_;
 	}
-	const std::vector<std::string>& get_weapons_evade() const {
+	[[nodiscard]] const std::vector<std::string>& get_weapons_evade() const {
 		return weapons_evade_;
 	}
 
-	const std::string& no_soldier_to_train_message() const {
+	[[nodiscard]] const std::string& no_soldier_to_train_message() const {
 		return no_soldier_to_train_message_;
 	}
 
-	const std::string& no_soldier_for_training_level_message() const {
+	[[nodiscard]] const std::string& no_soldier_for_training_level_message() const {
 		return no_soldier_for_training_level_message_;
 	}
 
@@ -227,12 +227,12 @@ private:
 		explicit SoldierControl(TrainingSite* training_site) : training_site_(training_site) {
 		}
 
-		std::vector<Soldier*> present_soldiers() const override;
-		std::vector<Soldier*> stationed_soldiers() const override;
-		std::vector<Soldier*> associated_soldiers() const override;
-		Quantity min_soldier_capacity() const override;
-		Quantity max_soldier_capacity() const override;
-		Quantity soldier_capacity() const override;
+		[[nodiscard]] std::vector<Soldier*> present_soldiers() const override;
+		[[nodiscard]] std::vector<Soldier*> stationed_soldiers() const override;
+		[[nodiscard]] std::vector<Soldier*> associated_soldiers() const override;
+		[[nodiscard]] Quantity min_soldier_capacity() const override;
+		[[nodiscard]] Quantity max_soldier_capacity() const override;
+		[[nodiscard]] Quantity soldier_capacity() const override;
 		void set_soldier_capacity(Quantity capacity) override;
 		void drop_soldier(Soldier&) override;
 		int incorporate_soldier(EditorGameBase& egbase, Soldier& s) override;

--- a/src/logic/map_objects/tribes/tribe_descr.h
+++ b/src/logic/map_objects/tribes/tribe_descr.h
@@ -63,145 +63,145 @@ public:
 	           const LuaTable& table,
 	           const LuaTable* scenario_table = nullptr);
 
-	const std::string& name() const;
-	const std::string& descname() const;
+	[[nodiscard]] const std::string& name() const;
+	[[nodiscard]] const std::string& descname() const;
 
-	size_t get_nrwares() const;
-	size_t get_nrworkers() const;
+	[[nodiscard]] size_t get_nrwares() const;
+	[[nodiscard]] size_t get_nrworkers() const;
 
-	const std::set<DescriptionIndex>& buildings() const;
-	const std::set<DescriptionIndex>& wares() const;
-	const std::set<DescriptionIndex>& workers() const;
-	const std::set<DescriptionIndex>& immovables() const;
-	const ResourceIndicatorSet& resource_indicators() const;
+	[[nodiscard]] const std::set<DescriptionIndex>& buildings() const;
+	[[nodiscard]] const std::set<DescriptionIndex>& wares() const;
+	[[nodiscard]] const std::set<DescriptionIndex>& workers() const;
+	[[nodiscard]] const std::set<DescriptionIndex>& immovables() const;
+	[[nodiscard]] const ResourceIndicatorSet& resource_indicators() const;
 
 	std::set<DescriptionIndex>& mutable_wares();
 	std::set<DescriptionIndex>& mutable_workers();
 	std::set<DescriptionIndex>& mutable_buildings();
 	std::set<DescriptionIndex>& mutable_immovables();
 
-	bool has_building(const DescriptionIndex& index) const;
-	bool has_ware(const DescriptionIndex& index) const;
-	bool has_worker(const DescriptionIndex& index) const;
-	bool has_immovable(const DescriptionIndex& index) const;
+	[[nodiscard]] bool has_building(const DescriptionIndex& index) const;
+	[[nodiscard]] bool has_ware(const DescriptionIndex& index) const;
+	[[nodiscard]] bool has_worker(const DescriptionIndex& index) const;
+	[[nodiscard]] bool has_immovable(const DescriptionIndex& index) const;
 
 	// A ware is a construction material if it appears in a building's buildcost or enhancement cost
-	bool is_construction_material(const DescriptionIndex& ware_index) const;
+	[[nodiscard]] bool is_construction_material(const DescriptionIndex& ware_index) const;
 
-	DescriptionIndex building_index(const std::string& buildingname) const;
-	DescriptionIndex immovable_index(const std::string& immovablename) const;
-	DescriptionIndex ware_index(const std::string& warename) const;
-	DescriptionIndex worker_index(const std::string& workername) const;
+	[[nodiscard]] DescriptionIndex building_index(const std::string& buildingname) const;
+	[[nodiscard]] DescriptionIndex immovable_index(const std::string& immovablename) const;
+	[[nodiscard]] DescriptionIndex ware_index(const std::string& warename) const;
+	[[nodiscard]] DescriptionIndex worker_index(const std::string& workername) const;
 
 	/// Return the given building or die trying
-	DescriptionIndex safe_building_index(const std::string& buildingname) const;
+	[[nodiscard]] DescriptionIndex safe_building_index(const std::string& buildingname) const;
 	/// Return the given ware or die trying
-	DescriptionIndex safe_ware_index(const std::string& warename) const;
+	[[nodiscard]] DescriptionIndex safe_ware_index(const std::string& warename) const;
 	/// Return the given worker or die trying
-	DescriptionIndex safe_worker_index(const std::string& workername) const;
+	[[nodiscard]] DescriptionIndex safe_worker_index(const std::string& workername) const;
 
-	BuildingDescr const* get_building_descr(const DescriptionIndex& index) const;
-	ImmovableDescr const* get_immovable_descr(const DescriptionIndex& index) const;
-	WareDescr const* get_ware_descr(const DescriptionIndex& index) const;
-	WorkerDescr const* get_worker_descr(const DescriptionIndex& index) const;
+	[[nodiscard]] BuildingDescr const* get_building_descr(const DescriptionIndex& index) const;
+	[[nodiscard]] ImmovableDescr const* get_immovable_descr(const DescriptionIndex& index) const;
+	[[nodiscard]] WareDescr const* get_ware_descr(const DescriptionIndex& index) const;
+	[[nodiscard]] WorkerDescr const* get_worker_descr(const DescriptionIndex& index) const;
 
-	DescriptionIndex builder() const;
-	DescriptionIndex geologist() const;
-	DescriptionIndex scouts_house() const;
-	DescriptionIndex soldier() const;
-	DescriptionIndex ship() const;
-	DescriptionIndex ferry() const;
-	DescriptionIndex port() const;
-	const std::vector<DescriptionIndex>& carriers() const {
+	[[nodiscard]] DescriptionIndex builder() const;
+	[[nodiscard]] DescriptionIndex geologist() const;
+	[[nodiscard]] DescriptionIndex scouts_house() const;
+	[[nodiscard]] DescriptionIndex soldier() const;
+	[[nodiscard]] DescriptionIndex ship() const;
+	[[nodiscard]] DescriptionIndex ferry() const;
+	[[nodiscard]] DescriptionIndex port() const;
+	[[nodiscard]] const std::vector<DescriptionIndex>& carriers() const {
 		return carriers_;
 	}
 
-	const std::vector<DescriptionIndex>& trainingsites() const;
-	const std::vector<DescriptionIndex>& worker_types_without_cost() const;
+	[[nodiscard]] const std::vector<DescriptionIndex>& trainingsites() const;
+	[[nodiscard]] const std::vector<DescriptionIndex>& worker_types_without_cost() const;
 
-	uint32_t frontier_animation() const;
-	uint32_t flag_animation() const;
-	uint32_t pinned_note_animation() const;
-	uint32_t bridge_animation(uint8_t dir, bool busy) const;
+	[[nodiscard]] uint32_t frontier_animation() const;
+	[[nodiscard]] uint32_t flag_animation() const;
+	[[nodiscard]] uint32_t pinned_note_animation() const;
+	[[nodiscard]] uint32_t bridge_animation(uint8_t dir, bool busy) const;
 
 	// Bridge height in pixels at 1x scale, for drawing bobs walking over a bridge
-	uint32_t bridge_height() const;
+	[[nodiscard]] uint32_t bridge_height() const;
 
 	// The road textures used for drawing roads and waterways.
-	const RoadTextures& road_textures() const;
+	[[nodiscard]] const RoadTextures& road_textures() const;
 
 	DescriptionIndex get_resource_indicator(const ResourceDescription* const res,
 	                                        const ResourceAmount amount) const;
 
 	// Returns the initalization at 'index' (which must not be out of bounds).
-	const Widelands::TribeBasicInfo::Initialization& initialization(const uint8_t index) const {
+	[[nodiscard]] const Widelands::TribeBasicInfo::Initialization& initialization(const uint8_t index) const {
 		return basic_info_.initializations.at(index);
 	}
 
-	const Widelands::TribeBasicInfo& basic_info() const {
+	[[nodiscard]] const Widelands::TribeBasicInfo& basic_info() const {
 		return basic_info_;
 	}
 
 	using WaresOrder = std::vector<std::vector<Widelands::DescriptionIndex>>;
-	const WaresOrder& wares_order() const {
+	[[nodiscard]] const WaresOrder& wares_order() const {
 		return wares_order_;
 	}
 	WaresOrder& mutable_wares_order() {
 		return wares_order_;
 	}
 
-	const WaresOrder& workers_order() const {
+	[[nodiscard]] const WaresOrder& workers_order() const {
 		return workers_order_;
 	}
 	WaresOrder& mutable_workers_order() {
 		return workers_order_;
 	}
 
-	bool uses_resource(const std::string& name) const {
+	[[nodiscard]] bool uses_resource(const std::string& name) const {
 		return used_resources_.count(name);
 	}
 	// Warning: Do not use pointer arithmetics in logic code!
-	const std::set<const BuildingDescr*>& buildings_built_over_immovables() const {
+	[[nodiscard]] const std::set<const BuildingDescr*>& buildings_built_over_immovables() const {
 		return buildings_built_over_immovables_;
 	}
 
-	const std::vector<std::pair<std::string, int>>& collectors_points_table() const {
+	[[nodiscard]] const std::vector<std::pair<std::string, int>>& collectors_points_table() const {
 		return collectors_points_table_;
 	}
 
-	const std::string& get_productionsite_worker_missing_string() const {
+	[[nodiscard]] const std::string& get_productionsite_worker_missing_string() const {
 		return productionsite_worker_missing_;
 	}
-	const std::string& get_productionsite_worker_coming_string() const {
+	[[nodiscard]] const std::string& get_productionsite_worker_coming_string() const {
 		return productionsite_worker_coming_;
 	}
-	const std::string& get_productionsite_workers_missing_string() const {
+	[[nodiscard]] const std::string& get_productionsite_workers_missing_string() const {
 		return productionsite_workers_missing_;
 	}
-	const std::string& get_productionsite_workers_coming_string() const {
+	[[nodiscard]] const std::string& get_productionsite_workers_coming_string() const {
 		return productionsite_workers_coming_;
 	}
-	const std::string& get_productionsite_experienced_worker_missing_string() const {
+	[[nodiscard]] const std::string& get_productionsite_experienced_worker_missing_string() const {
 		return productionsite_experienced_worker_missing_;
 	}
-	const std::string& get_productionsite_experienced_workers_missing_string() const {
+	[[nodiscard]] const std::string& get_productionsite_experienced_workers_missing_string() const {
 		return productionsite_experienced_workers_missing_;
 	}
 
-	const std::string& get_soldier_context_string() const {
+	[[nodiscard]] const std::string& get_soldier_context_string() const {
 		return soldier_context_;
 	}
-	const std::string* get_soldier_capacity_strings_sg() const {
+	[[nodiscard]] const std::string* get_soldier_capacity_strings_sg() const {
 		return soldier_capacity_strings_sg_;
 	}
-	const std::string* get_soldier_capacity_strings_pl() const {
+	[[nodiscard]] const std::string* get_soldier_capacity_strings_pl() const {
 		return soldier_capacity_strings_pl_;
 	}
 
 	// The custom toolbar imageset if any. Can be nullptr.
-	ToolbarImageset* toolbar_image_set() const;
+	[[nodiscard]] ToolbarImageset* toolbar_image_set() const;
 
-	const std::map<std::string /* key */, std::string /* building */>& fastplace_defaults() const {
+	[[nodiscard]] const std::map<std::string /* key */, std::string /* building */>& fastplace_defaults() const {
 		return fastplace_defaults_;
 	}
 

--- a/src/logic/map_objects/tribes/tribe_descr.h
+++ b/src/logic/map_objects/tribes/tribe_descr.h
@@ -134,7 +134,8 @@ public:
 	                                        const ResourceAmount amount) const;
 
 	// Returns the initalization at 'index' (which must not be out of bounds).
-	[[nodiscard]] const Widelands::TribeBasicInfo::Initialization& initialization(const uint8_t index) const {
+	[[nodiscard]] const Widelands::TribeBasicInfo::Initialization&
+	initialization(const uint8_t index) const {
 		return basic_info_.initializations.at(index);
 	}
 
@@ -201,7 +202,8 @@ public:
 	// The custom toolbar imageset if any. Can be nullptr.
 	[[nodiscard]] ToolbarImageset* toolbar_image_set() const;
 
-	[[nodiscard]] const std::map<std::string /* key */, std::string /* building */>& fastplace_defaults() const {
+	[[nodiscard]] const std::map<std::string /* key */, std::string /* building */>&
+	fastplace_defaults() const {
 		return fastplace_defaults_;
 	}
 

--- a/src/logic/map_objects/tribes/warehouse.h
+++ b/src/logic/map_objects/tribes/warehouse.h
@@ -44,16 +44,16 @@ public:
 	~WarehouseDescr() override {
 	}
 
-	Building& create_object() const override;
+	[[nodiscard]] Building& create_object() const override;
 
-	uint32_t get_conquers() const override {
+	[[nodiscard]] uint32_t get_conquers() const override {
 		return conquers_;
 	}
 	void set_conquers(uint32_t c) {
 		conquers_ = c;
 	}
 
-	unsigned get_heal_per_second() const {
+	[[nodiscard]] unsigned get_heal_per_second() const {
 		return heal_per_second_;
 	}
 	void set_heal_per_second(unsigned h) {
@@ -223,12 +223,12 @@ private:
 		explicit SoldierControl(Warehouse* warehouse) : warehouse_(warehouse) {
 		}
 
-		std::vector<Soldier*> present_soldiers() const override;
-		std::vector<Soldier*> stationed_soldiers() const override;
-		std::vector<Soldier*> associated_soldiers() const override;
-		Quantity min_soldier_capacity() const override;
-		Quantity max_soldier_capacity() const override;
-		Quantity soldier_capacity() const override;
+		[[nodiscard]] std::vector<Soldier*> present_soldiers() const override;
+		[[nodiscard]] std::vector<Soldier*> stationed_soldiers() const override;
+		[[nodiscard]] std::vector<Soldier*> associated_soldiers() const override;
+		[[nodiscard]] Quantity min_soldier_capacity() const override;
+		[[nodiscard]] Quantity max_soldier_capacity() const override;
+		[[nodiscard]] Quantity soldier_capacity() const override;
 		void set_soldier_capacity(Quantity capacity) override;
 		void drop_soldier(Soldier&) override;
 		int incorporate_soldier(EditorGameBase& egbase, Soldier& s) override;
@@ -244,13 +244,13 @@ private:
 		explicit AttackTarget(Warehouse* warehouse) : warehouse_(warehouse) {
 		}
 
-		bool can_be_attacked() const override;
+		[[nodiscard]] bool can_be_attacked() const override;
 		void enemy_soldier_approaches(const Soldier&) const override;
 		Widelands::AttackTarget::AttackResult attack(Soldier*) const override;
 		void set_allow_conquer(PlayerNumber, bool) const override {
 			// Warehouses can never be conquered
 		}
-		bool get_allow_conquer(PlayerNumber) const override {
+		[[nodiscard]] bool get_allow_conquer(PlayerNumber) const override {
 			return false;
 		}
 

--- a/src/logic/map_objects/tribes/warelist.h
+++ b/src/logic/map_objects/tribes/warelist.h
@@ -39,7 +39,7 @@ struct WareList {
 	}  /// Clear the storage
 
 	/// \return Highest possible ware id
-	DescriptionIndex get_nrwareids() const {
+	[[nodiscard]] DescriptionIndex get_nrwareids() const {
 		return DescriptionIndex(wares_.size());
 	}
 
@@ -47,7 +47,7 @@ struct WareList {
 	void add(const WareList&);
 	void remove(DescriptionIndex, Quantity = 1);
 	void remove(const WareList& wl);
-	Quantity stock(DescriptionIndex) const;
+	[[nodiscard]] Quantity stock(DescriptionIndex) const;
 
 	void set_nrwares(DescriptionIndex const i) {
 		assert(wares_.empty());

--- a/src/logic/map_objects/tribes/worker.cc
+++ b/src/logic/map_objects/tribes/worker.cc
@@ -560,7 +560,7 @@ struct FindNodeSpace {
 	explicit FindNodeSpace(bool land) : landbased_(land) {
 	}
 
-	bool accept(const EditorGameBase& egbase, const FCoords& coords) const {
+	[[nodiscard]] bool accept(const EditorGameBase& egbase, const FCoords& coords) const {
 		if ((coords.field->nodecaps() & MOVECAPS_WALK) == 0) {
 			return false;
 		}
@@ -586,7 +586,7 @@ private:
 
 /** Accepts a node if and only if a ferry can reach it or depart from there. */
 struct FindNodeFerry {
-	bool accept(const EditorGameBase& egbase, const FCoords& coords) const {
+	[[nodiscard]] bool accept(const EditorGameBase& egbase, const FCoords& coords) const {
 		CheckStepFerry csf(egbase);
 		return csf.reachable_dest(egbase.map(), coords);
 	}
@@ -2652,7 +2652,7 @@ void Worker::start_task_fugitive(Game& game) {
 struct FindFlagWithPlayersWarehouse {
 	explicit FindFlagWithPlayersWarehouse(const Player& owner) : owner_(owner) {
 	}
-	bool accept(const BaseImmovable& imm) const {
+	[[nodiscard]] bool accept(const BaseImmovable& imm) const {
 		if (upcast(Flag const, flag, &imm)) {
 			if (flag->get_owner() == &owner_) {
 				if (!flag->economy(wwWORKER).warehouses().empty()) {

--- a/src/logic/map_objects/tribes/worker_descr.h
+++ b/src/logic/map_objects/tribes/worker_descr.h
@@ -49,17 +49,17 @@ public:
 	WorkerDescr(const std::string& init_descname, const LuaTable& t, Descriptions& descriptions);
 	~WorkerDescr() override;
 
-	Bob& create_object() const override;
+	[[nodiscard]] Bob& create_object() const override;
 
-	bool is_buildable() const {
+	[[nodiscard]] bool is_buildable() const {
 		return buildable_;
 	}
-	const Buildcost& buildcost() const {
+	[[nodiscard]] const Buildcost& buildcost() const {
 		assert(is_buildable());
 		return buildcost_;
 	}
 
-	const Vector2i& ware_hotspot() const {
+	[[nodiscard]] const Vector2i& ware_hotspot() const {
 		return ware_hotspot_;
 	}
 
@@ -67,7 +67,7 @@ public:
 	/// The special value std::numeric_limits<uint32_t>::max() means that the
 	/// the target quantity of this ware type will never be checked and should
 	/// not be configurable.
-	Quantity default_target_quantity() const {
+	[[nodiscard]] Quantity default_target_quantity() const {
 		return default_target_quantity_;
 	}
 	/// Sets the default target quantity. Overwrites if it already exists.
@@ -76,7 +76,7 @@ public:
 	/// This is an AI hint
 	void set_preciousness(const std::string& tribename, int preciousness);
 
-	bool has_demand_check() const {
+	[[nodiscard]] bool has_demand_check() const {
 		return default_target_quantity() != kInvalidWare;
 	}
 
@@ -92,31 +92,31 @@ public:
 	virtual const DirAnimations& get_right_walk_anims(bool const carries_ware, Worker*) const {
 		return carries_ware ? walkload_anims_ : walk_anims_;
 	}
-	WorkerProgram const* get_program(const std::string&) const;
+	[[nodiscard]] WorkerProgram const* get_program(const std::string&) const;
 
 	// For leveling
-	int32_t get_needed_experience() const {
+	[[nodiscard]] int32_t get_needed_experience() const {
 		return needed_experience_;
 	}
-	DescriptionIndex becomes() const {
+	[[nodiscard]] DescriptionIndex becomes() const {
 		return becomes_;
 	}
 	void set_becomes(Descriptions&, const std::string&);
-	DescriptionIndex worker_index() const;
-	bool can_act_as(DescriptionIndex) const;
+	[[nodiscard]] DescriptionIndex worker_index() const;
+	[[nodiscard]] bool can_act_as(DescriptionIndex) const;
 
 	// Add a building to the list of employers
 	void add_employer(const DescriptionIndex& building_index);
 
 	// The buildings where this worker can work
-	const std::set<DescriptionIndex>& employers() const;
+	[[nodiscard]] const std::set<DescriptionIndex>& employers() const;
 
 	Worker& create(EditorGameBase&, Player*, PlayerImmovable*, Coords) const;
 
-	uint32_t movecaps() const override;
+	[[nodiscard]] uint32_t movecaps() const override;
 
 	using Programs = std::map<std::string, std::unique_ptr<WorkerProgram>>;
-	const Programs& programs() const {
+	[[nodiscard]] const Programs& programs() const {
 		return programs_;
 	}
 	Programs& mutable_programs() {
@@ -124,7 +124,7 @@ public:
 	}
 
 	/// AI hints for this worker type. Can be nullptr.
-	const AI::WareWorkerHints* ai_hints() const {
+	[[nodiscard]] const AI::WareWorkerHints* ai_hints() const {
 		return ai_hints_.get();
 	}
 

--- a/src/logic/map_objects/tribes/worker_program.h
+++ b/src/logic/map_objects/tribes/worker_program.h
@@ -39,45 +39,45 @@ struct WorkerProgram : public MapObjectProgram {
 	              Descriptions& descriptions);
 
 	using Actions = std::vector<Worker::Action>;
-	Actions::size_type get_size() const {
+	[[nodiscard]] Actions::size_type get_size() const {
 		return actions_.size();
 	}
-	const Actions& actions() const {
+	[[nodiscard]] const Actions& actions() const {
 		return actions_;
 	}
-	Worker::Action const* get_action(int32_t idx) const {
+	[[nodiscard]] Worker::Action const* get_action(int32_t idx) const {
 		assert(idx >= 0);
 		assert(static_cast<uint32_t>(idx) < actions_.size());
 		return &actions_[idx];
 	}
 
-	const WorkareaInfo& get_workarea_info() const {
+	[[nodiscard]] const WorkareaInfo& get_workarea_info() const {
 		return workarea_info_;
 	}
-	const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
+	[[nodiscard]] const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
 	needed_attributes() const {
 		return needed_attributes_;
 	}
-	const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
+	[[nodiscard]] const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
 	collected_attributes() const {
 		return collected_attributes_;
 	}
-	const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
+	[[nodiscard]] const std::set<std::pair<MapObjectType, MapObjectDescr::AttributeIndex>>&
 	created_attributes() const {
 		return created_attributes_;
 	}
-	const std::set<std::string>& collected_resources() const {
+	[[nodiscard]] const std::set<std::string>& collected_resources() const {
 		return collected_resources_;
 	}
-	const std::set<std::string>& created_resources() const {
+	[[nodiscard]] const std::set<std::string>& created_resources() const {
 		return created_resources_;
 	}
-	const std::set<std::string>& created_bobs() const {
+	[[nodiscard]] const std::set<std::string>& created_bobs() const {
 		return created_bobs_;
 	}
 
 	/// Set of ware types produced by this program
-	const std::set<DescriptionIndex>& produced_ware_types() const {
+	[[nodiscard]] const std::set<DescriptionIndex>& produced_ware_types() const {
 		return produced_ware_types_;
 	}
 

--- a/src/logic/map_objects/world/critter.h
+++ b/src/logic/map_objects/world/critter.h
@@ -39,34 +39,34 @@ public:
 	             const std::vector<std::string>& attribs);
 	~CritterDescr() override = default;
 
-	Bob& create_object() const override;
+	[[nodiscard]] Bob& create_object() const override;
 
-	bool is_swimming() const;
-	uint32_t movecaps() const override;
-	const DirAnimations& get_walk_anims() const {
+	[[nodiscard]] bool is_swimming() const;
+	[[nodiscard]] uint32_t movecaps() const override;
+	[[nodiscard]] const DirAnimations& get_walk_anims() const {
 		return walk_anims_;
 	}
 
-	bool is_herbivore() const {
+	[[nodiscard]] bool is_herbivore() const {
 		return !food_plants_.empty();
 	}
-	bool is_carnivore() const {
+	[[nodiscard]] bool is_carnivore() const {
 		return carnivore_;
 	}
-	uint8_t get_size() const {
+	[[nodiscard]] uint8_t get_size() const {
 		return size_;
 	}
-	const std::set<uint32_t>& food_plants() const {
+	[[nodiscard]] const std::set<uint32_t>& food_plants() const {
 		return food_plants_;
 	}
-	uint8_t get_appetite() const {
+	[[nodiscard]] uint8_t get_appetite() const {
 		return appetite_;
 	}
-	uint8_t get_reproduction_rate() const {
+	[[nodiscard]] uint8_t get_reproduction_rate() const {
 		return reproduction_rate_;
 	}
 
-	CritterProgram const* get_program(const std::string&) const;
+	[[nodiscard]] CritterProgram const* get_program(const std::string&) const;
 
 private:
 	DirAnimations walk_anims_;

--- a/src/logic/map_objects/world/critter_program.h
+++ b/src/logic/map_objects/world/critter_program.h
@@ -44,7 +44,7 @@ struct CritterAction {
 struct CritterProgram : public MapObjectProgram {
 	explicit CritterProgram(const std::string& program_name, const LuaTable& actions_table);
 
-	int32_t get_size() const {
+	[[nodiscard]] int32_t get_size() const {
 		return actions_.size();
 	}
 	const CritterAction& operator[](size_t const idx) const {

--- a/src/logic/map_objects/world/map_gen.h
+++ b/src/logic/map_objects/world/map_gen.h
@@ -51,9 +51,9 @@ struct MapGenAreaInfo {
 
 	MapGenAreaInfo(const LuaTable& table, const Descriptions& descriptions, Area area_type);
 
-	size_t get_num_terrains(Terrain) const;
-	DescriptionIndex get_terrain(Terrain terrain_type, uint32_t index) const;
-	uint32_t get_weight() const {
+	[[nodiscard]] size_t get_num_terrains(Terrain) const;
+	[[nodiscard]] DescriptionIndex get_terrain(Terrain terrain_type, uint32_t index) const;
+	[[nodiscard]] uint32_t get_weight() const {
 		return weight_;
 	}
 
@@ -68,17 +68,17 @@ private:
 struct MapGenBobCategory {
 	explicit MapGenBobCategory(const LuaTable& table);
 
-	size_t num_immovables() const {
+	[[nodiscard]] size_t num_immovables() const {
 		return immovables_.size();
 	}
-	size_t num_critters() const {
+	[[nodiscard]] size_t num_critters() const {
 		return critters_.size();
 	}
 
-	const std::string& get_immovable(size_t index) const {
+	[[nodiscard]] const std::string& get_immovable(size_t index) const {
 		return immovables_[index];
 	}
-	const std::string& get_critter(size_t index) const {
+	[[nodiscard]] const std::string& get_critter(size_t index) const {
 		return critters_[index];
 	}
 
@@ -90,15 +90,15 @@ private:
 struct MapGenLandResource {
 	MapGenLandResource(const LuaTable& table, MapGenInfo& map_gen_info);
 
-	uint32_t get_weight() const {
+	[[nodiscard]] uint32_t get_weight() const {
 		return weight_;
 	}
-	const MapGenBobCategory* get_bob_category(MapGenAreaInfo::Terrain terrain_type) const;
+	[[nodiscard]] const MapGenBobCategory* get_bob_category(MapGenAreaInfo::Terrain terrain_type) const;
 
-	uint8_t get_immovable_density() const {
+	[[nodiscard]] uint8_t get_immovable_density() const {
 		return immovable_density_;
 	}
-	uint8_t get_moveable_density() const {
+	[[nodiscard]] uint8_t get_moveable_density() const {
 		return critter_density_;
 	}
 

--- a/src/logic/map_objects/world/map_gen.h
+++ b/src/logic/map_objects/world/map_gen.h
@@ -93,7 +93,8 @@ struct MapGenLandResource {
 	[[nodiscard]] uint32_t get_weight() const {
 		return weight_;
 	}
-	[[nodiscard]] const MapGenBobCategory* get_bob_category(MapGenAreaInfo::Terrain terrain_type) const;
+	[[nodiscard]] const MapGenBobCategory*
+	get_bob_category(MapGenAreaInfo::Terrain terrain_type) const;
 
 	[[nodiscard]] uint8_t get_immovable_density() const {
 		return immovable_density_;

--- a/src/logic/map_objects/world/resource_description.h
+++ b/src/logic/map_objects/world/resource_description.h
@@ -38,29 +38,29 @@ public:
 	explicit ResourceDescription(const LuaTable& table);
 
 	/// Returns the in engine name of this resource.
-	const std::string& name() const;
+	[[nodiscard]] const std::string& name() const;
 
 	/// Returns the name of this resource for users. Usually translated.
-	const std::string& descname() const;
+	[[nodiscard]] const std::string& descname() const;
 
 	/// Returns if this resource is detectable by a geologist.
-	bool detectable() const;
+	[[nodiscard]] bool detectable() const;
 
 	/// Returns the time for which nearby geologist messages for this resource are muted
-	uint32_t timeout_ms() const;
+	[[nodiscard]] uint32_t timeout_ms() const;
 
 	/// Returns the radius within which geologist messages for this resource are temporarily muted
-	uint32_t timeout_radius() const;
+	[[nodiscard]] uint32_t timeout_radius() const;
 
 	/// Returns the maximum amount that can be in a field for this resource.
-	ResourceAmount max_amount() const;
+	[[nodiscard]] ResourceAmount max_amount() const;
 
 	/// Returns the path to the image that should be used in the editor to
 	/// represent an 'amount' of this resource.
-	const std::string& editor_image(uint32_t amount) const;
+	[[nodiscard]] const std::string& editor_image(uint32_t amount) const;
 
 	/// Returns the path to the image that should be used in menus to represent this resource
-	const std::string& representative_image() const {
+	[[nodiscard]] const std::string& representative_image() const {
 		return representative_image_;
 	}
 

--- a/src/logic/map_objects/world/terrain_description.h
+++ b/src/logic/map_objects/world/terrain_description.h
@@ -67,15 +67,15 @@ public:
 	~TerrainDescription() = default;
 
 	/// The name used internally for this terrain.
-	const std::string& name() const;
+	[[nodiscard]] const std::string& name() const;
 
 	/// The name showed to users of Widelands. Usually translated.
-	const std::string& descname() const;
+	[[nodiscard]] const std::string& descname() const;
 
-	const std::vector<std::string>& texture_paths() const;
+	[[nodiscard]] const std::vector<std::string>& texture_paths() const;
 
 	/// Returns the texture for the given gametime.
-	const Image& get_texture(uint32_t gametime) const;
+	[[nodiscard]] const Image& get_texture(uint32_t gametime) const;
 	void add_texture(const Image* texture);
 
 	// Sets the base minimap color.
@@ -83,48 +83,48 @@ public:
 
 	// Return the basic terrain colour to be used in the minimap.
 	// 'shade' must be a brightness value, i.e. in [-128, 127].
-	const RGBColor& get_minimap_color(int shade) const;
+	[[nodiscard]] const RGBColor& get_minimap_color(int shade) const;
 
 	/// Returns the type of terrain this is (water, walkable, and so on).
-	Is get_is() const;
+	[[nodiscard]] Is get_is() const;
 	/// Returns a list of the types that match get_is()
-	const std::vector<TerrainDescription::Type> get_types() const;
+	[[nodiscard]] const std::vector<TerrainDescription::Type> get_types() const;
 
 	/// Returns the valid resource with the given index.
-	DescriptionIndex get_valid_resource(DescriptionIndex index) const;
+	[[nodiscard]] DescriptionIndex get_valid_resource(DescriptionIndex index) const;
 
 	/// Returns the number of valid resources.
-	size_t get_num_valid_resources() const;
+	[[nodiscard]] size_t get_num_valid_resources() const;
 
 	/// Returns the the valid resources.
-	std::vector<DescriptionIndex> valid_resources() const;
+	[[nodiscard]] std::vector<DescriptionIndex> valid_resources() const;
 
 	/// Returns true if this resource can be found in this terrain type.
-	bool is_resource_valid(DescriptionIndex res) const;
+	[[nodiscard]] bool is_resource_valid(DescriptionIndex res) const;
 
 	/// Returns the resource index that can by default always be found in this
 	/// terrain.
-	DescriptionIndex get_default_resource() const;
+	[[nodiscard]] DescriptionIndex get_default_resource() const;
 
 	/// Returns the default amount of resources you can find in this terrain.
-	ResourceAmount get_default_resource_amount() const;
+	[[nodiscard]] ResourceAmount get_default_resource_amount() const;
 
 	/// Returns the dither layer, i.e. the information in which zlayer this
 	/// texture should be drawn.
-	int32_t dither_layer() const;
+	[[nodiscard]] int32_t dither_layer() const;
 
 	/// Parameters for terrain affinity of immovables.
 	/// Temperature is in arbitrary units.
-	int temperature() const;
+	[[nodiscard]] int temperature() const;
 
 	/// Humidity, ranging from 0 to 1000.
-	int humidity() const;
+	[[nodiscard]] int humidity() const;
 
 	/// Fertility, ranging from 0 to 1000.
-	int fertility() const;
+	[[nodiscard]] int fertility() const;
 
 	// The terrain which certain workers can transform this terrain into.
-	std::string enhancement(const std::string& category) const;
+	[[nodiscard]] std::string enhancement(const std::string& category) const;
 	void set_enhancement(const std::string& category, const std::string& terrain);
 
 	void replace_textures(const LuaTable&);

--- a/src/logic/mapastar.h
+++ b/src/logic/mapastar.h
@@ -32,7 +32,7 @@ struct MapAStarBase {
 	   : map(m), pathfields(m.pathfieldmgr_->allocate()), queue(type) {
 	}
 
-	bool empty() const {
+	[[nodiscard]] bool empty() const {
 		return queue.empty();
 	}
 	void pathto(Coords dest, Path& path) const;
@@ -41,7 +41,7 @@ protected:
 	Pathfield& pathfield(Coords where) {
 		return pathfields->fields[map.get_index(where, map.get_width())];
 	}
-	const Pathfield& pathfield(Coords where) const {
+	[[nodiscard]] const Pathfield& pathfield(Coords where) const {
 		return pathfields->fields[map.get_index(where, map.get_width())];
 	}
 
@@ -64,7 +64,7 @@ struct StepEvalAStar {
 		return est;
 	}
 
-	int32_t stepcost(
+	[[nodiscard]] int32_t stepcost(
 	   const Map& map, FCoords from, int32_t /* fromcost */, WalkingDir dir, FCoords to) const {
 		if ((swim_ && !(to.field->nodecaps() & MOVECAPS_SWIM)) ||
 		    (!swim_ && !(to.field->nodecaps() & MOVECAPS_WALK)))

--- a/src/logic/mapdifferenceregion.h
+++ b/src/logic/mapdifferenceregion.h
@@ -64,7 +64,7 @@ template <typename AreaType = Area<>> struct MapDifferenceRegion {
 		direction_ = direction;
 	}
 
-	typename AreaType::CoordsType& location() const {
+	[[nodiscard]] typename AreaType::CoordsType& location() const {
 		return area_;
 	}
 
@@ -78,7 +78,7 @@ template <typename AreaType = Area<>> struct MapDifferenceRegion {
 	 */
 	bool advance(const Map& map);
 
-	typename AreaType::RadiusType radius() const {
+	[[nodiscard]] typename AreaType::RadiusType radius() const {
 		return area_.radius;
 	}
 

--- a/src/logic/mapfringeregion.h
+++ b/src/logic/mapfringeregion.h
@@ -38,7 +38,7 @@ template <typename AreaType = Area<>> struct MapFringeRegion {
 			map.get_tln(area_, &area_);
 	}
 
-	const typename AreaType::CoordsType& location() const {
+	[[nodiscard]] const typename AreaType::CoordsType& location() const {
 		return area_;
 	}
 
@@ -67,7 +67,7 @@ template <typename AreaType = Area<>> struct MapFringeRegion {
 		phase_ = 6;
 	}
 
-	typename AreaType::RadiusType radius() const {
+	[[nodiscard]] typename AreaType::RadiusType radius() const {
 		return area_.radius;
 	}
 

--- a/src/logic/maphollowregion.h
+++ b/src/logic/maphollowregion.h
@@ -33,7 +33,7 @@ namespace Widelands {
 template <typename AreaType = Area<>> struct MapHollowRegion {
 	MapHollowRegion(const Map& map, const HollowArea<AreaType>& hollow_area);
 
-	const typename AreaType::CoordsType& location() const {
+	[[nodiscard]] const typename AreaType::CoordsType& location() const {
 		return hollow_area_;
 	}
 

--- a/src/logic/mapregion.h
+++ b/src/logic/mapregion.h
@@ -39,7 +39,7 @@ template <typename AreaType = Area<>> struct MapRegion {
 		left_ = area_;
 	}
 
-	const typename AreaType::CoordsType& location() const {
+	[[nodiscard]] const typename AreaType::CoordsType& location() const {
 		return area_;
 	}
 
@@ -65,7 +65,7 @@ template <typename AreaType = Area<>> struct MapRegion {
 		return true;
 	}
 
-	typename AreaType::RadiusType radius() const {
+	[[nodiscard]] typename AreaType::RadiusType radius() const {
 		return area_.radius;
 	}
 

--- a/src/logic/maptriangleregion.h
+++ b/src/logic/maptriangleregion.h
@@ -68,7 +68,7 @@ template <> struct MapTriangleRegion<FCoords> {
 		left_ = area_.node;
 	}
 
-	const TCoords<FCoords>& location() const {
+	[[nodiscard]] const TCoords<FCoords>& location() const {
 		return area_;
 	}
 
@@ -105,7 +105,7 @@ private:
 template <typename CoordsType> struct MapTriangleRegion<TCoords<CoordsType>> {
 	MapTriangleRegion(const Map&, Area<TCoords<CoordsType>, uint16_t>);
 
-	const TCoords<CoordsType>& location() const {
+	[[nodiscard]] const TCoords<CoordsType>& location() const {
 		return location_;
 	}
 

--- a/src/logic/message.h
+++ b/src/logic/message.h
@@ -81,37 +81,37 @@ struct Message {
 	     status_(s) {
 	}
 
-	Message::Type type() const {
+	[[nodiscard]] Message::Type type() const {
 		return type_;
 	}
-	const std::string& sub_type() const {
+	[[nodiscard]] const std::string& sub_type() const {
 		return sub_type_;
 	}
-	const Time& sent() const {
+	[[nodiscard]] const Time& sent() const {
 		return sent_;
 	}
-	const std::string& title() const {
+	[[nodiscard]] const std::string& title() const {
 		return title_;
 	}
-	const std::string& icon_filename() const {
+	[[nodiscard]] const std::string& icon_filename() const {
 		return icon_filename_;
 	}
-	const Image* icon() const {
+	[[nodiscard]] const Image* icon() const {
 		return icon_;
 	}
-	const std::string& heading() const {
+	[[nodiscard]] const std::string& heading() const {
 		return heading_;
 	}
-	const std::string& body() const {
+	[[nodiscard]] const std::string& body() const {
 		return body_;
 	}
-	const Widelands::Coords& position() const {
+	[[nodiscard]] const Widelands::Coords& position() const {
 		return position_;
 	}
-	Widelands::Serial serial() const {
+	[[nodiscard]] Widelands::Serial serial() const {
 		return serial_;
 	}
-	Status status() const {
+	[[nodiscard]] Status status() const {
 		return status_;
 	}
 	Status set_status(Status const s) {
@@ -121,7 +121,7 @@ struct Message {
 	/**
 	 * Returns the main type for the message's sub type
 	 */
-	Message::Type message_type_category() const {
+	[[nodiscard]] Message::Type message_type_category() const {
 		if (type_ >= Widelands::Message::Type::kWarfare) {
 			return Widelands::Message::Type::kWarfare;
 

--- a/src/logic/message_id.h
+++ b/src/logic/message_id.h
@@ -60,7 +60,7 @@ struct MessageId {
 	operator bool() const {
 		return *this != null();
 	}
-	uint32_t value() const {
+	[[nodiscard]] uint32_t value() const {
 		return id;
 	}
 

--- a/src/logic/message_queue.h
+++ b/src/logic/message_queue.h
@@ -47,13 +47,13 @@ struct MessageQueue {
 	//  Make some selected inherited members public.
 	//  TODO(sirver): This is weird design. Instead pass out a const ref& to
 	//  'messages_'?
-	MessageMap::const_iterator begin() const {
+	[[nodiscard]] MessageMap::const_iterator begin() const {
 		return messages_.begin();
 	}
-	MessageMap::const_iterator end() const {
+	[[nodiscard]] MessageMap::const_iterator end() const {
 		return messages_.end();
 	}
-	size_t count(uint32_t const i) const {
+	[[nodiscard]] size_t count(uint32_t const i) const {
 		MutexLock m(MutexLock::ID::kMessages);
 		assert_counts();
 		return messages_.count(MessageId(i));
@@ -68,7 +68,7 @@ struct MessageQueue {
 	}
 
 	/// \returns the number of messages with the given status.
-	uint32_t nr_messages(Message::Status const status) const {
+	[[nodiscard]] uint32_t nr_messages(Message::Status const status) const {
 		MutexLock m(MutexLock::ID::kMessages);
 		assert_counts();
 		assert(static_cast<int>(status) < 3);
@@ -124,14 +124,14 @@ struct MessageQueue {
 		assert_counts();
 	}
 
-	MessageId current_message_id() const {
+	[[nodiscard]] MessageId current_message_id() const {
 		return current_message_id_;
 	}
 
 	/// \returns whether all messages with id 1, 2, 3, ..., current_message_id
 	/// exist. This should be the case when messages have been loaded from a map
 	/// file/savegame but the simulation has not started to run yet.
-	bool is_continuous() const {
+	[[nodiscard]] bool is_continuous() const {
 		MutexLock m(MutexLock::ID::kMessages);
 		assert_counts();
 		return current_message_id().value() == messages_.size();

--- a/src/logic/mutable_addon.h
+++ b/src/logic/mutable_addon.h
@@ -46,31 +46,31 @@ public:
 	// May throw a WLWarning, if it fails
 	virtual bool write_to_disk();
 
-	const std::string& get_internal_name() const {
+	[[nodiscard]] const std::string& get_internal_name() const {
 		return internal_name_;
 	}
-	const std::string& get_descname() const {
+	[[nodiscard]] const std::string& get_descname() const {
 		return descname_;
 	}
-	const std::string& get_description() const {
+	[[nodiscard]] const std::string& get_description() const {
 		return description_;
 	}
-	const std::string& get_author() const {
+	[[nodiscard]] const std::string& get_author() const {
 		return author_;
 	}
-	const std::string& get_version() const {
+	[[nodiscard]] const std::string& get_version() const {
 		return version_;
 	}
-	const std::string& get_min_wl_version() const {
+	[[nodiscard]] const std::string& get_min_wl_version() const {
 		return min_wl_version_;
 	}
-	const std::string& get_max_wl_version() const {
+	[[nodiscard]] const std::string& get_max_wl_version() const {
 		return max_wl_version_;
 	}
 	void set_version(const std::string& version) {
 		version_ = version;
 	}
-	AddOnCategory get_category() const {
+	[[nodiscard]] AddOnCategory get_category() const {
 		return category_;
 	}
 
@@ -129,7 +129,7 @@ public:
 	void set_dirname(const std::string& dir, const std::string& name) {
 		dirnames_[dir] = name;
 	}
-	std::string get_dirname(const std::string& dir) const {
+	[[nodiscard]] std::string get_dirname(const std::string& dir) const {
 		const auto it = dirnames_.find(dir);
 		return it != dirnames_.end() ? it->second : "";
 	}

--- a/src/logic/objective.h
+++ b/src/logic/objective.h
@@ -36,12 +36,12 @@ public:
 	}
 
 	// Unique internal name of the objective.
-	const std::string& name() const {
+	[[nodiscard]] const std::string& name() const {
 		return name_;
 	}
 
 	// User facing (translated) descriptive name.
-	const std::string& descname() const {
+	[[nodiscard]] const std::string& descname() const {
 		return descname_;
 	}
 	void set_descname(const std::string& new_name) {
@@ -49,7 +49,7 @@ public:
 	}
 
 	// Description text of this name.
-	const std::string& descr() const {
+	[[nodiscard]] const std::string& descr() const {
 		return descr_;
 	}
 	void set_descr(const std::string& new_descr) {
@@ -57,7 +57,7 @@ public:
 	}
 
 	// True, if this objective is fulfilled.
-	bool done() const {
+	[[nodiscard]] bool done() const {
 		return done_;
 	}
 
@@ -66,7 +66,7 @@ public:
 	}
 
 	// True, if this objective is visible to the user.
-	bool visible() const {
+	[[nodiscard]] bool visible() const {
 		return visible_;
 	}
 	void set_visible(const bool t) {

--- a/src/logic/path.h
+++ b/src/logic/path.h
@@ -48,15 +48,15 @@ struct Path {
 
 	void reverse();
 
-	Coords get_start() const {
+	[[nodiscard]] Coords get_start() const {
 		return start_;
 	}
-	Coords get_end() const {
+	[[nodiscard]] Coords get_end() const {
 		return end_;
 	}
 
 	using StepVector = std::vector<Direction>;
-	StepVector::size_type get_nsteps() const {
+	[[nodiscard]] StepVector::size_type get_nsteps() const {
 		return path_.size();
 	}
 	Direction operator[](StepVector::size_type const i) const {
@@ -89,29 +89,29 @@ struct CoordPath {
 	}
 	CoordPath(const Map& map, const Path& path);
 
-	Coords get_start() const {
+	[[nodiscard]] Coords get_start() const {
 		return coords_.front();
 	}
-	Coords get_end() const {
+	[[nodiscard]] Coords get_end() const {
 		return coords_.back();
 	}
-	const std::vector<Coords>& get_coords() const {
+	[[nodiscard]] const std::vector<Coords>& get_coords() const {
 		return coords_;
 	}
 
 	using StepVector = std::vector<Direction>;
-	StepVector::size_type get_nsteps() const {
+	[[nodiscard]] StepVector::size_type get_nsteps() const {
 		return path_.size();
 	}
 	Direction operator[](StepVector::size_type const i) const {
 		assert(i < path_.size());
 		return path_[i];
 	}
-	const StepVector& steps() const {
+	[[nodiscard]] const StepVector& steps() const {
 		return path_;
 	}
 
-	int32_t get_index(const Coords& field) const;
+	[[nodiscard]] int32_t get_index(const Coords& field) const;
 
 	void reverse();
 	void truncate(const std::vector<char>::size_type after);

--- a/src/logic/pathfield.h
+++ b/src/logic/pathfield.h
@@ -50,7 +50,7 @@ struct Pathfield {
 	uint16_t cycle;
 	uint8_t backlink;  //  how we got here (WALK_*)
 
-	int32_t cost(WareWorker) const {
+	[[nodiscard]] int32_t cost(WareWorker) const {
 		return real_cost + estim_cost;
 	}
 	Queue::Cookie& cookie(WareWorker) {

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -2216,5 +2216,5 @@ void Player::write_statistics(FileWrite& fw) const {
 	}
 }
 
-constexpr Time Player::AiPersistentState::kNoExpedition;
+
 }  // namespace Widelands

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -2216,5 +2216,4 @@ void Player::write_statistics(FileWrite& fw) const {
 	}
 }
 
-
 }  // namespace Widelands

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -314,7 +314,7 @@ public:
 		/// east, as far as this player knows.
 		/// Only valid when this player has seen this node or the node to the
 		/// east.
-		RoadSegment road_e() const {
+		[[nodiscard]] RoadSegment road_e() const {
 			return r_e;
 		}
 
@@ -322,7 +322,7 @@ public:
 		/// southeast, as far as this player knows.
 		/// Only valid when this player has seen this node or the node to the
 		/// southeast.
-		RoadSegment road_se() const {
+		[[nodiscard]] RoadSegment road_se() const {
 			return r_se;
 		}
 
@@ -330,7 +330,7 @@ public:
 		/// southwest, as far as this player knows.
 		/// Only valid when this player has seen this node or the node to the
 		/// southwest.
-		RoadSegment road_sw() const {
+		[[nodiscard]] RoadSegment road_sw() const {
 			return r_sw;
 		}
 

--- a/src/logic/playercommand.h
+++ b/src/logic/playercommand.h
@@ -52,10 +52,10 @@ public:
 
 	void write_id_and_sender(StreamWrite& ser);
 
-	PlayerNumber sender() const {
+	[[nodiscard]] PlayerNumber sender() const {
 		return sender_;
 	}
-	uint32_t cmdserial() const {
+	[[nodiscard]] uint32_t cmdserial() const {
 		return cmdserial_;
 	}
 	void set_cmdserial(const uint32_t s) {
@@ -87,7 +87,7 @@ struct CmdBulldoze : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kBulldoze;
 	}
 
@@ -111,7 +111,7 @@ struct CmdBuild : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kBuild;
 	}
 
@@ -134,7 +134,7 @@ struct CmdBuildFlag : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kBuildFlag;
 	}
 
@@ -156,7 +156,7 @@ struct CmdBuildRoad : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kBuildRoad;
 	}
 
@@ -181,7 +181,7 @@ struct CmdBuildWaterway : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kBuildWaterway;
 	}
 
@@ -205,7 +205,7 @@ struct CmdFlagAction : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kFlagAction;
 	}
 
@@ -229,7 +229,7 @@ struct CmdStartStopBuilding : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kStartStopBuilding;
 	}
 
@@ -256,7 +256,7 @@ struct CmdMilitarySiteSetSoldierPreference : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kMilitarysiteSetSoldierPreference;
 	}
 
@@ -279,7 +279,7 @@ struct CmdStartOrCancelExpedition : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kStartOrCancelExpedition;
 	}
 
@@ -304,7 +304,7 @@ struct CmdExpeditionConfig : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kExpeditionConfig;
 	}
 
@@ -332,7 +332,7 @@ struct CmdEnhanceBuilding : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kEnhanceBuilding;
 	}
 
@@ -358,7 +358,7 @@ struct CmdDismantleBuilding : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kDismantleBuilding;
 	}
 
@@ -383,7 +383,7 @@ struct CmdEvictWorker : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kEvictWorker;
 	}
 
@@ -406,7 +406,7 @@ struct CmdShipScoutDirection : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kShipScoutDirection;
 	}
 
@@ -430,7 +430,7 @@ struct CmdShipConstructPort : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kShipConstructPort;
 	}
 
@@ -458,7 +458,7 @@ struct CmdShipExploreIsland : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kShipExploreIsland;
 	}
 
@@ -481,7 +481,7 @@ struct CmdShipSink : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kShipSink;
 	}
 
@@ -504,7 +504,7 @@ struct CmdShipCancelExpedition : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kShipCancelExpedition;
 	}
 
@@ -538,7 +538,7 @@ struct CmdSetWarePriority : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kSetWarePriority;
 	}
 
@@ -575,7 +575,7 @@ struct CmdSetInputMaxFill : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kSetInputMaxFill;
 	}
 
@@ -609,10 +609,10 @@ struct CmdChangeTargetQuantity : public PlayerCommand {
 	void serialize(StreamWrite&) override;
 
 protected:
-	Serial economy() const {
+	[[nodiscard]] Serial economy() const {
 		return economy_;
 	}
-	DescriptionIndex ware_type() const {
+	[[nodiscard]] DescriptionIndex ware_type() const {
 		return ware_type_;
 	}
 
@@ -634,7 +634,7 @@ struct CmdSetWareTargetQuantity : public CmdChangeTargetQuantity {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kSetWareTargetQuantity;
 	}
 
@@ -660,7 +660,7 @@ struct CmdSetWorkerTargetQuantity : public CmdChangeTargetQuantity {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kSetWorkerTargetQuantity;
 	}
 
@@ -689,7 +689,7 @@ struct CmdChangeTrainingOptions : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kChangeTrainingOptions;
 	}
 
@@ -715,7 +715,7 @@ struct CmdDropSoldier : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kDropSoldier;
 	}
 
@@ -740,7 +740,7 @@ struct CmdChangeSoldierCapacity : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kChangeSoldierCapacity;
 	}
 
@@ -765,7 +765,7 @@ struct CmdEnemyFlagAction : public PlayerCommand {
 	void write(FileWrite&, EditorGameBase&, MapObjectSaver&) override;
 	void read(FileRead&, EditorGameBase&, MapObjectLoader&) override;
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kEnemyFlagAction;
 	}
 
@@ -793,7 +793,7 @@ struct PlayerMessageCommand : public PlayerCommand {
 
 	explicit PlayerMessageCommand(StreamRead&);
 
-	MessageId message_id() const {
+	[[nodiscard]] MessageId message_id() const {
 		return message_id_;
 	}
 
@@ -808,7 +808,7 @@ struct CmdMessageSetStatusRead : public PlayerMessageCommand {
 	   : PlayerMessageCommand(t, p, i) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kMessageSetStatusRead;
 	}
 
@@ -826,7 +826,7 @@ struct CmdMessageSetStatusArchived : public PlayerMessageCommand {
 	   : PlayerMessageCommand(t, p, i) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kMessageSetStatusArchived;
 	}
 
@@ -848,7 +848,7 @@ struct CmdSetStockPolicy : PlayerCommand {
 	                  DescriptionIndex ware,
 	                  StockPolicy policy);
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kSetStockPolicy;
 	}
 
@@ -873,7 +873,7 @@ private:
 struct CmdProposeTrade : PlayerCommand {
 	CmdProposeTrade(const Time& time, PlayerNumber pn, const Trade& trade);
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kProposeTrade;
 	}
 
@@ -897,7 +897,7 @@ struct CmdToggleMuteMessages : PlayerCommand {
 	   : PlayerCommand(t, p), building_(b.serial()), all_(a) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kToggleMuteMessages;
 	}
 
@@ -921,7 +921,7 @@ struct CmdMarkMapObjectForRemoval : PlayerCommand {
 	   : PlayerCommand(t, p), object_(mo.serial()), mark_(m) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kMarkMapObjectForRemoval;
 	}
 
@@ -945,7 +945,7 @@ struct CmdDiplomacy : PlayerCommand {
 	   : PlayerCommand(t, p), action_(a), other_player_(o) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kDiplomacy;
 	}
 
@@ -974,7 +974,7 @@ struct CmdPinnedNote : PlayerCommand {
 	   : PlayerCommand(t, p), text_(text), pos_(pos), rgb_(rgb), delete_(del) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kPinnedNote;
 	}
 
@@ -1000,7 +1000,7 @@ struct CmdPickCustomStartingPosition : PlayerCommand {
 	   : PlayerCommand(t, p), coords_(c) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kPickCustomStartingPosition;
 	}
 

--- a/src/logic/playersmanager.h
+++ b/src/logic/playersmanager.h
@@ -68,12 +68,12 @@ public:
 	                   const std::string& tribe,
 	                   const std::string& name,
 	                   TeamNumber team = 0);
-	Player* get_player(int32_t n) const {
+	[[nodiscard]] Player* get_player(int32_t n) const {
 		assert(1 <= n);
 		assert(n <= kMaxPlayers);
 		return players_[n - 1];
 	}
-	const Player& player(int32_t n) const {
+	[[nodiscard]] const Player& player(int32_t n) const {
 		assert(1 <= n);
 		assert(n <= kMaxPlayers);
 		return *players_[n - 1];
@@ -82,7 +82,7 @@ public:
 	/**
 	 * \return the number of players (human or ai)
 	 */
-	uint8_t get_number_of_players() const {
+	[[nodiscard]] uint8_t get_number_of_players() const {
 		return number_of_players_;
 	}
 
@@ -91,7 +91,7 @@ public:
 	 */
 	void add_player_end_status(const PlayerEndStatus& status, bool change_existing = false);
 
-	const PlayerEndStatus* get_player_end_status(PlayerNumber player) const;
+	[[nodiscard]] const PlayerEndStatus* get_player_end_status(PlayerNumber player) const;
 
 private:
 	Player* players_[kMaxPlayers];

--- a/src/logic/replay.cc
+++ b/src/logic/replay.cc
@@ -56,7 +56,7 @@ public:
 	   : Command(init_duetime), hash_(hash) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kReplaySyncRead;
 	}
 
@@ -233,7 +233,7 @@ public:
 	explicit CmdReplaySyncWrite(const Time& init_duetime) : Command(init_duetime) {
 	}
 
-	QueueCommandTypes id() const override {
+	[[nodiscard]] QueueCommandTypes id() const override {
 		return QueueCommandTypes::kReplaySyncWrite;
 	}
 

--- a/src/logic/replay_game_controller.h
+++ b/src/logic/replay_game_controller.h
@@ -50,7 +50,7 @@ private:
 		explicit CmdReplayEnd(const Time& init_duetime) : Widelands::Command(init_duetime) {
 		}
 		void execute(Widelands::Game& game) override;
-		Widelands::QueueCommandTypes id() const override;
+		[[nodiscard]] Widelands::QueueCommandTypes id() const override;
 	};
 
 	Widelands::Game& game_;

--- a/src/logic/save_handler.h
+++ b/src/logic/save_handler.h
@@ -35,7 +35,7 @@ public:
 	SaveHandler();
 
 	void think(Widelands::Game&);
-	std::string create_file_name(const std::string& dir, const std::string& filename) const;
+	[[nodiscard]] std::string create_file_name(const std::string& dir, const std::string& filename) const;
 
 	// Saves the game, overwrites file, handles errors
 	bool save_game(Widelands::Game&, const std::string& filename, std::string* error_str = nullptr);
@@ -63,7 +63,7 @@ public:
 		save_filename_ = filename;
 	}
 
-	uint32_t last_save_time() const {
+	[[nodiscard]] uint32_t last_save_time() const {
 		return last_save_realtime_;
 	}
 

--- a/src/logic/save_handler.h
+++ b/src/logic/save_handler.h
@@ -35,7 +35,8 @@ public:
 	SaveHandler();
 
 	void think(Widelands::Game&);
-	[[nodiscard]] std::string create_file_name(const std::string& dir, const std::string& filename) const;
+	[[nodiscard]] std::string create_file_name(const std::string& dir,
+	                                           const std::string& filename) const;
 
 	// Saves the game, overwrites file, handles errors
 	bool save_game(Widelands::Game&, const std::string& filename, std::string* error_str = nullptr);

--- a/src/logic/vision.h
+++ b/src/logic/vision.h
@@ -80,7 +80,7 @@ public:
 		return *this;
 	}
 
-	uint16_t value() const {
+	[[nodiscard]] uint16_t value() const {
 		return value_;
 	}
 	operator VisibleState() const {
@@ -109,22 +109,22 @@ public:
 		return value_ != other.value_ || override_ != other.override_;
 	}
 
-	bool is_explored() const {
+	[[nodiscard]] bool is_explored() const {
 		return value_ > 0;
 	}
-	bool is_visible() const {
+	[[nodiscard]] bool is_visible() const {
 		return value_ > 1;
 	}
-	bool is_seen_by_us() const {
+	[[nodiscard]] bool is_seen_by_us() const {
 		return seers() > 0 || is_revealed();
 	}
-	bool is_revealed() const {
+	[[nodiscard]] bool is_revealed() const {
 		return static_cast<Override>(override_) == Override::kRevealed;
 	}
-	bool is_hidden() const {
+	[[nodiscard]] bool is_hidden() const {
 		return static_cast<Override>(override_) == Override::kHidden;
 	}
-	uint16_t seers() const {
+	[[nodiscard]] uint16_t seers() const {
 		return value_ > 2 ? (value_ - 2) : 0;
 	}
 

--- a/src/logic/widelands_geometry.h
+++ b/src/logic/widelands_geometry.h
@@ -47,7 +47,7 @@ struct Coords {
 	static Coords unhash(uint32_t hash);
 
 	/// Hash coordinates to use them as keys in a container
-	uint32_t hash() const;
+	[[nodiscard]] uint32_t hash() const;
 
 	bool operator==(const Coords& other) const;
 	bool operator!=(const Coords& other) const;
@@ -147,7 +147,7 @@ struct NodeAndTriangle {
 struct HeightInterval {
 	HeightInterval(const uint8_t Min, const uint8_t Max) : min(Min), max(Max) {
 	}
-	bool valid() const {
+	[[nodiscard]] bool valid() const {
 		return min <= max;
 	}
 

--- a/src/map_io/map_elemental_packet.h
+++ b/src/map_io/map_elemental_packet.h
@@ -48,7 +48,7 @@ struct MapElementalPacket {
 
 	/// If this map was created before the one_world merge was done, this returns
 	/// the old world name, otherwise "".
-	const std::string& old_world_name() const {
+	[[nodiscard]] const std::string& old_world_name() const {
 		return old_world_name_;
 	}
 

--- a/src/map_io/map_loader.h
+++ b/src/map_io/map_loader.h
@@ -57,7 +57,7 @@ protected:
 	void set_state(State const s) {
 		state_ = s;
 	}
-	State get_state() const {
+	[[nodiscard]] State get_state() const {
 		return state_;
 	}
 	Map& map_;

--- a/src/map_io/map_object_loader.h
+++ b/src/map_io/map_object_loader.h
@@ -33,7 +33,7 @@ class Bob;
  */
 class MapObjectLoader {
 public:
-	bool is_object_known(uint32_t) const;
+	[[nodiscard]] bool is_object_known(uint32_t) const;
 
 	/// Registers the object as a new one.
 	///

--- a/src/map_io/map_object_saver.h
+++ b/src/map_io/map_object_saver.h
@@ -35,7 +35,7 @@ class MapObject;
 struct MapObjectSaver {
 	MapObjectSaver();
 
-	bool is_object_known(const MapObject&) const;
+	[[nodiscard]] bool is_object_known(const MapObject&) const;
 	Serial register_object(const MapObject&);
 
 	uint32_t get_object_file_index(const MapObject&);
@@ -47,28 +47,28 @@ struct MapObjectSaver {
 #ifndef NDEBUG
 	void detect_unsaved_objects() const;
 #endif
-	uint32_t get_nr_roads() const {
+	[[nodiscard]] uint32_t get_nr_roads() const {
 		return nr_roads_;
 	}
-	uint32_t get_nr_waterways() const {
+	[[nodiscard]] uint32_t get_nr_waterways() const {
 		return nr_waterways_;
 	}
-	uint32_t get_nr_flags() const {
+	[[nodiscard]] uint32_t get_nr_flags() const {
 		return nr_flags_;
 	}
-	uint32_t get_nr_buildings() const {
+	[[nodiscard]] uint32_t get_nr_buildings() const {
 		return nr_buildings_;
 	}
-	uint32_t get_nr_wares() const {
+	[[nodiscard]] uint32_t get_nr_wares() const {
 		return nr_wares_;
 	}
-	uint32_t get_nr_bobs() const {
+	[[nodiscard]] uint32_t get_nr_bobs() const {
 		return nr_bobs_;
 	}
-	uint32_t get_nr_immovables() const {
+	[[nodiscard]] uint32_t get_nr_immovables() const {
 		return nr_immovables_;
 	}
-	uint32_t get_nr_battles() const {
+	[[nodiscard]] uint32_t get_nr_battles() const {
 		return nr_battles_;
 	}
 

--- a/src/map_io/s2map.cc
+++ b/src/map_io/s2map.cc
@@ -252,7 +252,7 @@ std::string get_world_name(S2MapLoader::WorldType world) {
 class TerrainConverter {
 public:
 	explicit TerrainConverter(Widelands::Descriptions* descriptions);
-	Widelands::DescriptionIndex lookup(S2MapLoader::WorldType world, int8_t c) const;
+	[[nodiscard]] Widelands::DescriptionIndex lookup(S2MapLoader::WorldType world, int8_t c) const;
 
 protected:
 	Widelands::Descriptions* descriptions_;

--- a/src/map_io/widelands_map_loader.h
+++ b/src/map_io/widelands_map_loader.h
@@ -50,7 +50,7 @@ struct WidelandsMapLoader : public MapLoader {
 	}
 
 	// If this was made pre one-world, the name of the world.
-	const std::string& old_world_name() const {
+	[[nodiscard]] const std::string& old_world_name() const {
 		return old_world_name_;
 	}
 

--- a/src/network/bufferedconnection.h
+++ b/src/network/bufferedconnection.h
@@ -143,7 +143,7 @@ public:
 	 * Returns whether the connection is established.
 	 * \return \c true if the connection is open, \c false otherwise.
 	 */
-	bool is_connected() const;
+	[[nodiscard]] bool is_connected() const;
 
 	/**
 	 * Closes the connection.

--- a/src/network/gameclient.h
+++ b/src/network/gameclient.h
@@ -117,8 +117,8 @@ struct GameClient : public GameController, public GameSettingsProvider, public C
 
 	// ChatProvider interface
 	void send(const std::string& msg) override;
-	const std::vector<ChatMessage>& get_messages() const override;
-	bool has_been_set() const override {
+	[[nodiscard]] const std::vector<ChatMessage>& get_messages() const override;
+	[[nodiscard]] bool has_been_set() const override {
 		return true;
 	}
 

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -228,7 +228,7 @@ struct HostChatProvider : public ChatProvider {
 		h->send(c);
 	}
 
-	const std::vector<ChatMessage>& get_messages() const override {
+	[[nodiscard]] const std::vector<ChatMessage>& get_messages() const override {
 		return messages;
 	}
 
@@ -237,7 +237,7 @@ struct HostChatProvider : public ChatProvider {
 		Notifications::publish(msg);
 	}
 
-	bool has_been_set() const override {
+	[[nodiscard]] bool has_been_set() const override {
 		return true;
 	}
 

--- a/src/network/gamehost.h
+++ b/src/network/gamehost.h
@@ -57,7 +57,7 @@ public:
 	void run();
 	void run_direct();
 	void run_callback();
-	const std::string& get_local_playername() const;
+	[[nodiscard]] const std::string& get_local_playername() const;
 	int16_t get_local_playerposition();
 
 	// GameController interface
@@ -74,7 +74,7 @@ public:
 	// End GameController interface
 
 	// Pregame-related stuff
-	const GameSettings& settings() const;
+	[[nodiscard]] const GameSettings& settings() const;
 	/** return true in case all conditions for the game start are met */
 	bool can_launch();
 	void set_scenario(bool);
@@ -184,7 +184,7 @@ private:
 	void check_hung_clients();
 	void broadcast_real_speed(uint32_t speed);
 	void update_network_speed();
-	bool client_may_change_speed(uint8_t playernum) const;
+	[[nodiscard]] bool client_may_change_speed(uint8_t playernum) const;
 
 	std::string get_computer_player_name(uint8_t playernum);
 	bool has_user_name(const std::string& name, uint8_t ignoreplayer = UserSettings::none());

--- a/src/network/internet_gaming.h
+++ b/src/network/internet_gaming.h
@@ -170,7 +170,7 @@ struct InternetGaming : public ChatProvider {
 	}
 
 	/// ChatProvider: returns the list of chatmessages.
-	const std::vector<ChatMessage>& get_messages() const override {
+	[[nodiscard]] const std::vector<ChatMessage>& get_messages() const override {
 		return messages_;
 	}
 
@@ -185,7 +185,7 @@ struct InternetGaming : public ChatProvider {
 		ingame_system_chat_.clear();
 	}
 
-	bool has_been_set() const override {
+	[[nodiscard]] bool has_been_set() const override {
 		return true;
 	}
 

--- a/src/network/net_addons.h
+++ b/src/network/net_addons.h
@@ -35,10 +35,10 @@ struct NetAddons {
 	}
 	~NetAddons();
 
-	bool is_admin() const {
+	[[nodiscard]] bool is_admin() const {
 		return is_admin_;
 	}
-	const std::string& server_descname() const {
+	[[nodiscard]] const std::string& server_descname() const {
 		return server_descname_;
 	}
 
@@ -93,7 +93,7 @@ private:
 	void quit_connection();
 
 	// Read a '\n'-terminated string from the socket. The terminator is not part of the result.
-	std::string read_line() const;
+	[[nodiscard]] std::string read_line() const;
 	void read_file(int64_t length, const std::string& out) const;
 	void check_endofstream();
 	void write_to_server(const std::string&);

--- a/src/network/netclient.h
+++ b/src/network/netclient.h
@@ -44,7 +44,7 @@ public:
 	~NetClient() override;
 
 	// Inherited from NetClientInterface
-	bool is_connected() const override;
+	[[nodiscard]] bool is_connected() const override;
 	void close() override;
 	std::unique_ptr<RecvPacket> try_receive() override;
 	void send(const SendPacket& packet, NetPriority priority = NetPriority::kNormal) override;

--- a/src/network/netclient_interface.h
+++ b/src/network/netclient_interface.h
@@ -45,7 +45,7 @@ public:
 	 *
 	 * \return \c true if the connection is open, \c false otherwise.
 	 */
-	virtual bool is_connected() const = 0;
+	[[nodiscard]] virtual bool is_connected() const = 0;
 
 	/**
 	 * Closes the connection.

--- a/src/network/netclientproxy.h
+++ b/src/network/netclientproxy.h
@@ -44,7 +44,7 @@ public:
 	~NetClientProxy() override;
 
 	// Inherited from NetClientInterface
-	bool is_connected() const override;
+	[[nodiscard]] bool is_connected() const override;
 	void close() override;
 	std::unique_ptr<RecvPacket> try_receive() override;
 	void send(const SendPacket& packet, NetPriority priority = NetPriority::kNormal) override;

--- a/src/network/nethost.h
+++ b/src/network/nethost.h
@@ -45,7 +45,7 @@ public:
 	~NetHost() override;
 
 	// Inherited from NetHostInterface
-	bool is_connected(ConnectionId id) const override;
+	[[nodiscard]] bool is_connected(ConnectionId id) const override;
 	void close(ConnectionId id) override;
 	bool try_accept(ConnectionId* new_id) override;
 	std::unique_ptr<RecvPacket> try_receive(ConnectionId id) override;
@@ -67,7 +67,7 @@ private:
 	 * \return \c true if the server is listening, \c false otherwise.
 	 */
 	// Feel free to make this method public if you need it
-	bool is_listening() const;
+	[[nodiscard]] bool is_listening() const;
 
 	/**
 	 * Starts an asynchronous accept on the given acceptor.

--- a/src/network/nethost_interface.h
+++ b/src/network/nethost_interface.h
@@ -46,7 +46,7 @@ public:
 	 * \param The id of the client to check.
 	 * \return \c true if the connection is open, \c false otherwise.
 	 */
-	virtual bool is_connected(ConnectionId id) const = 0;
+	[[nodiscard]] virtual bool is_connected(ConnectionId id) const = 0;
 
 	/**
 	 * Closes the connection to the given client.

--- a/src/network/nethostproxy.h
+++ b/src/network/nethostproxy.h
@@ -46,7 +46,7 @@ public:
 	~NetHostProxy() override;
 
 	// Inherited from NetHostInterface
-	bool is_connected(ConnectionId id) const override;
+	[[nodiscard]] bool is_connected(ConnectionId id) const override;
 	void close(ConnectionId id) override;
 	bool try_accept(ConnectionId* new_id) override;
 	std::unique_ptr<RecvPacket> try_receive(ConnectionId id) override;

--- a/src/network/network.h
+++ b/src/network/network.h
@@ -72,13 +72,13 @@ struct NetAddress {
 	 * @return \c true if the stored IP is in IPv6 format, \c false otherwise.
 	 *   If it isn't an IPv6 address, it is an IPv4 address.
 	 */
-	bool is_ipv6() const;
+	[[nodiscard]] bool is_ipv6() const;
 
 	/**
 	 * Returns whether valid IP address and port are stored.
 	 * @return \c true if valid, \c false otherwise.
 	 */
-	bool is_valid() const;
+	[[nodiscard]] bool is_valid() const;
 
 	asio::ip::address ip;
 	uint16_t port;
@@ -95,7 +95,7 @@ struct CmdNetCheckSync : public Widelands::Command {
 
 	void execute(Widelands::Game&) override;
 
-	Widelands::QueueCommandTypes id() const override {
+	[[nodiscard]] Widelands::QueueCommandTypes id() const override {
 		return Widelands::QueueCommandTypes::kNetCheckSync;
 	}
 
@@ -120,8 +120,8 @@ public:
 	void fastforward();
 
 	void think(uint32_t speed);
-	const Time& time() const;
-	const Time& networktime() const;
+	[[nodiscard]] const Time& time() const;
+	[[nodiscard]] const Time& networktime() const;
 	void receive(const Time& ntime);
 
 private:
@@ -160,7 +160,7 @@ private:
 struct RecvPacket : public StreamRead {
 public:
 	size_t data(void* data, size_t bufsize) override;
-	bool end_of_file() const override;
+	[[nodiscard]] bool end_of_file() const override;
 
 private:
 	friend class BufferedConnection;
@@ -193,7 +193,7 @@ struct NetTransferFile {
 struct DisconnectException : public std::exception {
 	explicit DisconnectException(const char* fmt, ...) PRINTF_FORMAT(2, 3);
 
-	const char* what() const noexcept override;
+	[[nodiscard]] const char* what() const noexcept override;
 
 private:
 	std::string what_;
@@ -209,7 +209,7 @@ struct ProtocolException : public std::exception {
 	}
 
 	/// \returns the command number of the received message
-	const char* what() const noexcept override {
+	[[nodiscard]] const char* what() const noexcept override {
 		return what_.c_str();
 	}
 

--- a/src/scripting/lua_map.h
+++ b/src/scripting/lua_map.h
@@ -165,7 +165,7 @@ public:
 	 * C methods
 	 */
 protected:
-	const Widelands::TribeDescr* get() const {
+	[[nodiscard]] const Widelands::TribeDescr* get() const {
 		assert(tribedescr_ != nullptr);
 		return tribedescr_;
 	}
@@ -216,7 +216,7 @@ public:
 	 * C methods
 	 */
 protected:
-	const Widelands::MapObjectDescr* get() const {
+	[[nodiscard]] const Widelands::MapObjectDescr* get() const {
 		assert(mapobjectdescr_ != nullptr);
 		return mapobjectdescr_;
 	}
@@ -764,7 +764,7 @@ public:
 	 * C methods
 	 */
 protected:
-	const Widelands::ResourceDescription* get() const {
+	[[nodiscard]] const Widelands::ResourceDescription* get() const {
 		assert(resourcedescr_ != nullptr);
 		return resourcedescr_;
 	}
@@ -818,7 +818,7 @@ public:
 	/*
 	 * C methods
 	 */
-	const Widelands::TerrainDescription* get() const {
+	[[nodiscard]] const Widelands::TerrainDescription* get() const {
 		assert(terraindescr_ != nullptr);
 		return terraindescr_;
 	}
@@ -868,7 +868,7 @@ public:
 	 */
 
 protected:
-	Widelands::Economy* get() const {
+	[[nodiscard]] Widelands::Economy* get() const {
 		assert(economy_ != nullptr);
 		return economy_;
 	}

--- a/src/sound/fxset.h
+++ b/src/sound/fxset.h
@@ -38,7 +38,7 @@ struct FXset {
 	/**
 	 * Number of ticks since this FXSet was last played
 	 */
-	uint32_t ticks_since_last_play() const;
+	[[nodiscard]] uint32_t ticks_since_last_play() const;
 
 	/** Get a sound effect from the fxset. Load the audio on demand.
 	 * \param random A random number for picking a variant

--- a/src/sound/sound_handler.h
+++ b/src/sound/sound_handler.h
@@ -188,16 +188,16 @@ public:
 	void change_music(const std::string& songset_name = std::string(),
 	                  int fadeout_ms = kMinimumMusicFade);
 	void use_custom_songset(bool on);
-	bool use_custom_songset() const;
+	[[nodiscard]] bool use_custom_songset() const;
 
-	const std::string current_songset() const;
+	[[nodiscard]] const std::string current_songset() const;
 
-	bool is_sound_enabled(SoundType type) const;
+	[[nodiscard]] bool is_sound_enabled(SoundType type) const;
 	void set_enable_sound(SoundType type, bool enable);
-	int32_t get_volume(SoundType type) const;
+	[[nodiscard]] int32_t get_volume(SoundType type) const;
 	void set_volume(SoundType type, int32_t volume);
 
-	int32_t get_max_volume() const;
+	[[nodiscard]] int32_t get_max_volume() const;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(SoundHandler);

--- a/src/ui_basic/editbox.cc
+++ b/src/ui_basic/editbox.cc
@@ -66,12 +66,12 @@ struct EditBoxImpl {
 	const UI::PanelStyle style;
 
 	/// Background color and texture
-	inline const UI::PanelStyleInfo& background_style() const {
+	[[nodiscard]] inline const UI::PanelStyleInfo& background_style() const {
 		return g_style_manager->editbox_style(style).background();
 	}
 
 	/// Font style
-	inline const UI::FontStyleInfo& font_style() const {
+	[[nodiscard]] inline const UI::FontStyleInfo& font_style() const {
 		return g_style_manager->editbox_style(style).font();
 	}
 

--- a/src/ui_basic/table.h
+++ b/src/ui_basic/table.h
@@ -103,7 +103,7 @@ public:
 	uint32_t toggle_entry(uint32_t row);
 	void move_selection(int32_t offset);
 	struct NoSelection : public std::exception {
-		char const* what() const noexcept override {
+		[[nodiscard]] char const* what() const noexcept override {
 			return "UI::Table<Entry>: No selection";
 		}
 	};
@@ -136,9 +136,9 @@ public:
 		void set_picture(uint8_t col, const Image* pic, const std::string& str = std::string());
 		/// Text conventions: Title Case for the 'str'
 		void set_string(uint8_t col, const std::string& str);
-		const Image* get_picture(uint8_t col) const;
-		const std::string& get_string(uint8_t col) const;
-		void* entry() const {
+		[[nodiscard]] const Image* get_picture(uint8_t col) const;
+		[[nodiscard]] const std::string& get_string(uint8_t col) const;
+		[[nodiscard]] void* entry() const {
 			return entry_;
 		}
 
@@ -146,11 +146,11 @@ public:
 			font_style_.reset(new FontStyle(style));
 		}
 
-		const UI::FontStyleInfo* font_style() const {
+		[[nodiscard]] const UI::FontStyleInfo* font_style() const {
 			return font_style_ ? &g_style_manager->font_style(*font_style_) : nullptr;
 		}
 
-		bool is_disabled() const {
+		[[nodiscard]] bool is_disabled() const {
 			return disabled_;
 		}
 		void set_disabled(bool disable) {
@@ -261,7 +261,7 @@ public:
 	uint32_t toggle_entry(uint32_t row);
 	void move_selection(int32_t offset);
 	struct NoSelection : public std::exception {
-		char const* what() const noexcept override {
+		[[nodiscard]] char const* what() const noexcept override {
 			return "UI::Table<void *>: No selection";
 		}
 	};

--- a/src/ui_fsmenu/addons/contact.cc
+++ b/src/ui_fsmenu/addons/contact.cc
@@ -110,4 +110,4 @@ bool ContactForm::check_ok_button_enabled() {
 	return ok_.enabled();
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/contact.cc
+++ b/src/ui_fsmenu/addons/contact.cc
@@ -22,8 +22,7 @@
 #include "ui_basic/messagebox.h"
 #include "ui_fsmenu/addons/manager.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 ContactForm::ContactForm(AddOnsCtrl& ctrl)
    : UI::Window(&ctrl.get_topmost_forefather(),
@@ -111,5 +110,4 @@ bool ContactForm::check_ok_button_enabled() {
 	return ok_.enabled();
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/contact.h
+++ b/src/ui_fsmenu/addons/contact.h
@@ -44,6 +44,6 @@ private:
 	UI::Button ok_, cancel_;
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_CONTACT_H

--- a/src/ui_fsmenu/addons/contact.h
+++ b/src/ui_fsmenu/addons/contact.h
@@ -24,8 +24,7 @@
 #include "ui_basic/multilineeditbox.h"
 #include "ui_basic/window.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class AddOnsCtrl;
 
@@ -45,7 +44,6 @@ private:
 	UI::Button ok_, cancel_;
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_CONTACT_H

--- a/src/ui_fsmenu/addons/login_box.cc
+++ b/src/ui_fsmenu/addons/login_box.cc
@@ -23,8 +23,7 @@
 #include "ui_fsmenu/addons/manager.h"
 #include "wlapplication_options.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 AddOnsLoginBox::AddOnsLoginBox(AddOnsCtrl& ctrl)
    : UI::Window(&ctrl.get_topmost_forefather(),
@@ -177,5 +176,4 @@ void AddOnsLoginBox::reset() {
 	}
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/login_box.cc
+++ b/src/ui_fsmenu/addons/login_box.cc
@@ -176,4 +176,4 @@ void AddOnsLoginBox::reset() {
 	}
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/login_box.h
+++ b/src/ui_fsmenu/addons/login_box.h
@@ -49,6 +49,6 @@ private:
 	void reset();
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_LOGIN_BOX_H

--- a/src/ui_fsmenu/addons/login_box.h
+++ b/src/ui_fsmenu/addons/login_box.h
@@ -24,8 +24,7 @@
 #include "ui_basic/editbox.h"
 #include "ui_basic/window.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class AddOnsCtrl;
 
@@ -50,7 +49,6 @@ private:
 	void reset();
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_LOGIN_BOX_H

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -47,8 +47,7 @@
 #include "wlapplication.h"
 #include "wlapplication_options.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 constexpr const char* const kDocumentationURL = "https://www.widelands.org/documentation/add-ons/";
 constexpr const char* const kForumURL = "https://www.widelands.org/forum/forum/17/";
@@ -1625,5 +1624,4 @@ step1:
 }
 #endif
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -1624,4 +1624,4 @@ step1:
 }
 #endif
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/manager.h
+++ b/src/ui_fsmenu/addons/manager.h
@@ -36,8 +36,7 @@
 #include "ui_basic/window.h"
 #include "ui_fsmenu/main.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class RemoteAddOnRow;
 
@@ -147,7 +146,6 @@ private:
 	std::string username_, password_;
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_MANAGER_H

--- a/src/ui_fsmenu/addons/manager.h
+++ b/src/ui_fsmenu/addons/manager.h
@@ -146,6 +146,6 @@ private:
 	std::string username_, password_;
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_MANAGER_H

--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -542,4 +542,4 @@ bool AddOnsPackager::do_write_addon_to_disk(const std::string& addon) {
 	}
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -33,8 +33,7 @@
 #include "wlapplication.h"
 #include "wlapplication_options.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 constexpr int16_t kButtonSize = 32;
 constexpr int16_t kSpacing = 4;
@@ -543,5 +542,4 @@ bool AddOnsPackager::do_write_addon_to_disk(const std::string& addon) {
 	}
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/packager.h
+++ b/src/ui_fsmenu/addons/packager.h
@@ -29,8 +29,7 @@
 #include "ui_fsmenu/addons/packager_box.h"
 #include "ui_fsmenu/addons/progress.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class AddOnsPackager : public UI::Window {
 public:
@@ -84,7 +83,6 @@ private:
 	ProgressIndicatorWindow progress_window_;
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_PACKAGER_H

--- a/src/ui_fsmenu/addons/packager.h
+++ b/src/ui_fsmenu/addons/packager.h
@@ -83,6 +83,6 @@ private:
 	ProgressIndicatorWindow progress_window_;
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_PACKAGER_H

--- a/src/ui_fsmenu/addons/packager_box.cc
+++ b/src/ui_fsmenu/addons/packager_box.cc
@@ -597,4 +597,4 @@ void CampaignAddOnsPackagerBox::layout() {
 	AddOnsPackagerBox::layout();
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/packager_box.cc
+++ b/src/ui_fsmenu/addons/packager_box.cc
@@ -30,8 +30,7 @@
 #include "ui_basic/textarea.h"
 #include "ui_fsmenu/main.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 constexpr int16_t kButtonSize = 32;
 constexpr int16_t kSpacing = 4;
@@ -598,5 +597,4 @@ void CampaignAddOnsPackagerBox::layout() {
 	AddOnsPackagerBox::layout();
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/packager_box.h
+++ b/src/ui_fsmenu/addons/packager_box.h
@@ -27,8 +27,7 @@
 #include "ui_basic/multilinetextarea.h"
 #include "ui_fsmenu/main.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 /** Check whether the filename is valid. Returns the reason why it's invalid, or "" if valid. */
 std::string check_addon_filename_validity(const std::string&);
@@ -114,7 +113,6 @@ private:
 	AddOns::CampaignAddon* selected_;  // Not owned
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_PACKAGER_BOX_H

--- a/src/ui_fsmenu/addons/packager_box.h
+++ b/src/ui_fsmenu/addons/packager_box.h
@@ -113,6 +113,6 @@ private:
 	AddOns::CampaignAddon* selected_;  // Not owned
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_PACKAGER_BOX_H

--- a/src/ui_fsmenu/addons/progress.cc
+++ b/src/ui_fsmenu/addons/progress.cc
@@ -20,8 +20,7 @@
 
 #include "ui_fsmenu/addons/manager.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 ProgressIndicatorWindow::ProgressIndicatorWindow(UI::Panel* parent, const std::string& title)
    : UI::Window(parent,
@@ -72,5 +71,4 @@ ProgressIndicatorWindow::ProgressIndicatorWindow(UI::Panel* parent, const std::s
 	initialization_complete();
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/progress.cc
+++ b/src/ui_fsmenu/addons/progress.cc
@@ -71,4 +71,4 @@ ProgressIndicatorWindow::ProgressIndicatorWindow(UI::Panel* parent, const std::s
 	initialization_complete();
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/progress.h
+++ b/src/ui_fsmenu/addons/progress.h
@@ -24,8 +24,7 @@
 #include "ui_basic/textarea.h"
 #include "ui_basic/window.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class ProgressIndicatorWindow : public UI::Window {
 public:
@@ -52,7 +51,6 @@ private:
 	UI::ProgressBar progress_;
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_PROGRESS_H

--- a/src/ui_fsmenu/addons/progress.h
+++ b/src/ui_fsmenu/addons/progress.h
@@ -51,6 +51,6 @@ private:
 	UI::ProgressBar progress_;
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_PROGRESS_H

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -31,8 +31,7 @@
 #include "ui_basic/messagebox.h"
 #include "ui_fsmenu/addons/manager.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 static const std::string kVotingTabName("votes");
 
@@ -989,5 +988,4 @@ void RemoteInteractionWindow::login_changed() {
 	}
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -988,4 +988,4 @@ void RemoteInteractionWindow::login_changed() {
 	}
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/remote_interaction.h
+++ b/src/ui_fsmenu/addons/remote_interaction.h
@@ -155,6 +155,6 @@ private:
 	UI::Dropdown<AddOns::NetAddons::AdminAction> admin_action_;
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_REMOTE_INTERACTION_H

--- a/src/ui_fsmenu/addons/remote_interaction.h
+++ b/src/ui_fsmenu/addons/remote_interaction.h
@@ -34,8 +34,7 @@
 #include "ui_basic/textarea.h"
 #include "ui_basic/window.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class AddOnsCtrl;
 class RemoteInteractionWindow;
@@ -156,7 +155,6 @@ private:
 	UI::Dropdown<AddOns::NetAddons::AdminAction> admin_action_;
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_REMOTE_INTERACTION_H

--- a/src/ui_fsmenu/addons/rows_ui.cc
+++ b/src/ui_fsmenu/addons/rows_ui.cc
@@ -29,8 +29,7 @@
 #include "ui_fsmenu/addons/remote_interaction.h"
 #include "wlapplication_options.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 namespace {
 
@@ -526,5 +525,4 @@ bool RemoteAddOnRow::upgradeable() const {
 	return upgrade_.enabled();
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/rows_ui.cc
+++ b/src/ui_fsmenu/addons/rows_ui.cc
@@ -525,4 +525,4 @@ bool RemoteAddOnRow::upgradeable() const {
 	return upgrade_.enabled();
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/rows_ui.h
+++ b/src/ui_fsmenu/addons/rows_ui.h
@@ -27,8 +27,7 @@
 #include "ui_basic/multilinetextarea.h"
 #include "ui_basic/textarea.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class AddOnsCtrl;
 
@@ -81,7 +80,6 @@ private:
 	const bool full_upgrade_possible_;
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_ROWS_UI_H

--- a/src/ui_fsmenu/addons/rows_ui.h
+++ b/src/ui_fsmenu/addons/rows_ui.h
@@ -80,6 +80,6 @@ private:
 	const bool full_upgrade_possible_;
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_ROWS_UI_H

--- a/src/ui_fsmenu/addons/screenshot_upload.cc
+++ b/src/ui_fsmenu/addons/screenshot_upload.cc
@@ -142,4 +142,4 @@ void ScreenshotUploadWindow::think() {
 	UI::Window::think();
 }
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI

--- a/src/ui_fsmenu/addons/screenshot_upload.cc
+++ b/src/ui_fsmenu/addons/screenshot_upload.cc
@@ -26,8 +26,7 @@
 #include "ui_basic/messagebox.h"
 #include "ui_fsmenu/addons/manager.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 ScreenshotUploadWindow::ScreenshotUploadWindow(AddOnsCtrl& ctrl,
                                                std::shared_ptr<AddOns::AddOnInfo> info,
@@ -143,5 +142,4 @@ void ScreenshotUploadWindow::think() {
 	UI::Window::think();
 }
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu

--- a/src/ui_fsmenu/addons/screenshot_upload.h
+++ b/src/ui_fsmenu/addons/screenshot_upload.h
@@ -51,6 +51,6 @@ private:
 	UI::Textarea progress_;
 };
 
-}  // namespace FsMenu
+}  // namespace FsMenu::AddOnsUI
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_SCREENSHOT_UPLOAD_H

--- a/src/ui_fsmenu/addons/screenshot_upload.h
+++ b/src/ui_fsmenu/addons/screenshot_upload.h
@@ -30,8 +30,7 @@
 #include "ui_basic/textarea.h"
 #include "ui_basic/window.h"
 
-namespace FsMenu {
-namespace AddOnsUI {
+namespace FsMenu::AddOnsUI {
 
 class AddOnsCtrl;
 
@@ -52,7 +51,6 @@ private:
 	UI::Textarea progress_;
 };
 
-}  // namespace AddOnsUI
 }  // namespace FsMenu
 
 #endif  // end of include guard: WL_UI_FSMENU_ADDONS_SCREENSHOT_UPLOAD_H

--- a/src/website/json/json.h
+++ b/src/website/json/json.h
@@ -51,13 +51,13 @@ public:
 
 	void write_to_file(FileSystem& fs, const std::string& filename) const;
 
-	virtual std::string as_string() const;
+	[[nodiscard]] virtual std::string as_string() const;
 
 protected:
 	static const std::string tab_;
 
-	std::string values_as_string(const std::string& tabs) const;
-	std::string children_as_string() const;
+	[[nodiscard]] std::string values_as_string(const std::string& tabs) const;
+	[[nodiscard]] std::string children_as_string() const;
 	static std::string key_to_string(const std::string& value, bool value_is_empty = false);
 
 	std::string key_;
@@ -77,7 +77,7 @@ public:
 	// Constructor for root node
 	explicit Object() : JSON::Element("", 0) {
 	}
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 };
 
 class Array : public Element {
@@ -88,7 +88,7 @@ protected:
 	explicit Array(const std::string& key, int level);
 
 public:
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 };
 }  // namespace JSON
 #endif  // end of include guard: WL_WEBSITE_JSON_JSON_H

--- a/src/website/json/value.h
+++ b/src/website/json/value.h
@@ -27,12 +27,12 @@ namespace JSON {
 struct Value {
 	Value() = default;
 	virtual ~Value() = default;
-	virtual std::string as_string() const = 0;
+	[[nodiscard]] virtual std::string as_string() const = 0;
 };
 
 struct Boolean : Value {
 	explicit Boolean(bool value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const bool bool_value;
@@ -40,7 +40,7 @@ private:
 
 struct Double : Value {
 	explicit Double(double value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const double double_value;
@@ -48,12 +48,12 @@ private:
 
 struct Empty : Value {
 	Empty() = default;
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 };
 
 struct Int : Value {
 	explicit Int(int value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const int int_value;
@@ -61,7 +61,7 @@ private:
 
 struct String : Value {
 	explicit String(const std::string& value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const std::string string_value;

--- a/src/website/lua/lua_tree.h
+++ b/src/website/lua/lua_tree.h
@@ -50,7 +50,7 @@ public:
 
 	void write_to_file(FileSystem& fs, const std::string& filename) const;
 
-	virtual std::string as_string() const;
+	[[nodiscard]] virtual std::string as_string() const;
 
 protected:
 	static const std::string tab_;
@@ -64,9 +64,9 @@ protected:
 		std::unique_ptr<LuaTree::Value> value;
 	};
 
-	std::string keyless_values_as_string() const;
-	std::string values_as_string(const std::string& tabs) const;
-	std::string children_as_string() const;
+	[[nodiscard]] std::string keyless_values_as_string() const;
+	[[nodiscard]] std::string values_as_string(const std::string& tabs) const;
+	[[nodiscard]] std::string children_as_string() const;
 	static std::string key_to_string(const std::string& value, bool value_is_empty = false);
 
 	std::string key_;
@@ -87,7 +87,7 @@ public:
 	// Constructor for root node
 	explicit Object() : LuaTree::Element("", 0) {
 	}
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 };
 
 }  // namespace LuaTree

--- a/src/website/lua/value.h
+++ b/src/website/lua/value.h
@@ -27,12 +27,12 @@ namespace LuaTree {
 struct Value {
 	Value() = default;
 	virtual ~Value() = default;
-	virtual std::string as_string() const = 0;
+	[[nodiscard]] virtual std::string as_string() const = 0;
 };
 
 struct Boolean : Value {
 	explicit Boolean(bool value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const bool bool_value;
@@ -40,7 +40,7 @@ private:
 
 struct Double : Value {
 	explicit Double(double value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const double double_value;
@@ -48,12 +48,12 @@ private:
 
 struct Empty : Value {
 	Empty() = default;
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 };
 
 struct Int : Value {
 	explicit Int(int value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const int int_value;
@@ -61,7 +61,7 @@ private:
 
 struct String : Value {
 	explicit String(const std::string& value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const std::string string_value;
@@ -69,7 +69,7 @@ private:
 
 struct Raw : Value {
 	explicit Raw(const std::string& value);
-	std::string as_string() const override;
+	[[nodiscard]] std::string as_string() const override;
 
 private:
 	const std::string raw_value;

--- a/src/wlapplication.h
+++ b/src/wlapplication.h
@@ -147,13 +147,13 @@ struct WLApplication {
 	static void initialize_g_addons();
 
 	/// \warning true if an external entity wants us to quit
-	bool should_die() const {
+	[[nodiscard]] bool should_die() const {
 		return should_die_;
 	}
 
 	/// Get the state of the current KeyBoard Button
 	/// \warning This function doesn't check for dumbness
-	bool get_key_state(SDL_Scancode const key) const {
+	[[nodiscard]] bool get_key_state(SDL_Scancode const key) const {
 		return SDL_GetKeyboardState(nullptr)[key];
 	}
 
@@ -162,12 +162,12 @@ struct WLApplication {
 	void set_input_grab(bool grab);
 
 	/// The mouse's current coordinates
-	Vector2i get_mouse_position() const {
+	[[nodiscard]] Vector2i get_mouse_position() const {
 		return mouse_position_;
 	}
 	//
 	/// Find out whether the mouse is currently pressed
-	bool is_mouse_pressed() const {
+	[[nodiscard]] bool is_mouse_pressed() const {
 		return SDL_GetMouseState(nullptr, nullptr);
 	}
 
@@ -178,12 +178,12 @@ struct WLApplication {
 
 	/// Lock the mouse cursor into place (e.g., for scrolling the map)
 	void set_mouse_lock(bool locked);
-	bool is_mouse_locked() const {
+	[[nodiscard]] bool is_mouse_locked() const {
 		return mouse_locked_;
 	}
 	// @}
 
-	const std::string& get_datadir() const {
+	[[nodiscard]] const std::string& get_datadir() const {
 		return datadir_;
 	}
 

--- a/src/wlapplication_mousewheel_options.cc
+++ b/src/wlapplication_mousewheel_options.cc
@@ -44,7 +44,7 @@ public:
 		return MousewheelOption(n, MousewheelOptionType::kBool, def ? 1 : 0);
 	}
 
-	bool get_bool() const {
+	[[nodiscard]] bool get_bool() const {
 		assert(type_ == MousewheelOptionType::kBool);
 		const bool def = (default_ != 0);
 		if (internal_name_.empty()) {
@@ -52,7 +52,7 @@ public:
 		}
 		return get_config_bool("mousewheel", internal_name_, def);
 	}
-	uint16_t get_keymod() const {
+	[[nodiscard]] uint16_t get_keymod() const {
 		assert(type_ == MousewheelOptionType::kKeymod);
 		if (internal_name_.empty()) {
 			return default_;
@@ -127,17 +127,17 @@ struct MousewheelHandlerOptions {
 		}
 	}
 
-	bool can_handle(const int32_t x, const int32_t y, const uint16_t modstate) const {
+	[[nodiscard]] bool can_handle(const int32_t x, const int32_t y, const uint16_t modstate) const {
 		return ((((y != 0) && (current_sign_y_ != 0)) || ((x != 0) && (current_sign_x_ != 0))) &&
 		        matches_keymod(current_keymod_, modstate));
 	}
-	int32_t get_change(const int32_t x, const int32_t y, const uint16_t modstate) const {
+	[[nodiscard]] int32_t get_change(const int32_t x, const int32_t y, const uint16_t modstate) const {
 		if (can_handle(x, y, modstate)) {
 			return (x * current_sign_x_ + y * current_sign_y_);
 		}
 		return 0;
 	}
-	Vector2i get_change_2D(const int32_t x, const int32_t y, const uint16_t modstate) const {
+	[[nodiscard]] Vector2i get_change_2D(const int32_t x, const int32_t y, const uint16_t modstate) const {
 		if (can_handle(x, y, modstate)) {
 			return Vector2i(x * current_sign_x_, y * current_sign_y_);
 		}

--- a/src/wlapplication_mousewheel_options.cc
+++ b/src/wlapplication_mousewheel_options.cc
@@ -131,13 +131,15 @@ struct MousewheelHandlerOptions {
 		return ((((y != 0) && (current_sign_y_ != 0)) || ((x != 0) && (current_sign_x_ != 0))) &&
 		        matches_keymod(current_keymod_, modstate));
 	}
-	[[nodiscard]] int32_t get_change(const int32_t x, const int32_t y, const uint16_t modstate) const {
+	[[nodiscard]] int32_t
+	get_change(const int32_t x, const int32_t y, const uint16_t modstate) const {
 		if (can_handle(x, y, modstate)) {
 			return (x * current_sign_x_ + y * current_sign_y_);
 		}
 		return 0;
 	}
-	[[nodiscard]] Vector2i get_change_2D(const int32_t x, const int32_t y, const uint16_t modstate) const {
+	[[nodiscard]] Vector2i
+	get_change_2D(const int32_t x, const int32_t y, const uint16_t modstate) const {
 		if (can_handle(x, y, modstate)) {
 			return Vector2i(x * current_sign_x_, y * current_sign_y_);
 		}

--- a/src/wui/chat_overlay.cc
+++ b/src/wui/chat_overlay.cc
@@ -60,7 +60,7 @@ struct ChatOverlay::Impl {
 	void recompute();
 
 private:
-	bool has_chat_provider() const {
+	[[nodiscard]] bool has_chat_provider() const {
 		// The chat provider might not have been assigned a specific subclass,
 		// e.g. if there was an exception thrown.
 		return (chat_ != nullptr && chat_->has_been_set());

--- a/src/wui/debugconsole.cc
+++ b/src/wui/debugconsole.cc
@@ -79,7 +79,7 @@ struct Console : public ChatProvider, public Handler {
 		it->second(arg);
 	}
 
-	const std::vector<ChatMessage>& get_messages() const override {
+	[[nodiscard]] const std::vector<ChatMessage>& get_messages() const override {
 		return messages;
 	}
 

--- a/src/wui/mapauthordata.h
+++ b/src/wui/mapauthordata.h
@@ -27,10 +27,10 @@
  * Author data for a map or scenario.
  */
 struct MapAuthorData {
-	const std::string& get_names() const {
+	[[nodiscard]] const std::string& get_names() const {
 		return names_;
 	}
-	size_t get_number() const {
+	[[nodiscard]] size_t get_number() const {
 		return number_;
 	}
 

--- a/src/wui/mapdata.h
+++ b/src/wui/mapdata.h
@@ -63,9 +63,9 @@ public:
 	static MapData create_directory(const std::string& directory);
 
 	// Sorting functions to order by different categories.
-	bool compare_names(const MapData& other) const;
-	bool compare_players(const MapData& other) const;
-	bool compare_size(const MapData& other) const;
+	[[nodiscard]] bool compare_names(const MapData& other) const;
+	[[nodiscard]] bool compare_players(const MapData& other) const;
+	[[nodiscard]] bool compare_size(const MapData& other) const;
 
 	std::string filename;
 	std::string name;

--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -81,7 +81,7 @@ public:
 	   : start_(start), end_(end), dt_(dt) {
 	}
 
-	T value(const float time_ms) const {
+	[[nodiscard]] T value(const float time_ms) const {
 		const float t = math::clamp(time_ms / dt_, 0.f, 1.f);
 		return mix(math::sqr(t) * (3.f - 2.f * t), start_, end_);
 	}
@@ -101,7 +101,7 @@ public:
 	   : first_(start, middle, dt / 2.f), second_(middle, end, dt / 2.f), dt_(dt) {
 	}
 
-	T value(const float time_ms) const {
+	[[nodiscard]] T value(const float time_ms) const {
 		const float t = math::clamp(time_ms / dt_, 0.f, 1.f);
 		if (t < 0.5f) {
 			return first_.value(t * dt_);

--- a/src/wui/mapview.h
+++ b/src/wui/mapview.h
@@ -35,19 +35,19 @@ public:
 	class ViewArea {
 	public:
 		// View in map pixels that is spanned by this.
-		const Rectf& rect() const {
+		[[nodiscard]] const Rectf& rect() const {
 			return rect_;
 		}
 
 		// Returns true if 'coords' is contained inside this view. Containing
 		// is defined as such that the shortest distance between the center of
 		// 'rect()' is smaller than (rect().w / 2, rect().h / 2).
-		bool contains(const Widelands::Coords& coords) const;
+		[[nodiscard]] bool contains(const Widelands::Coords& coords) const;
 
 		// Returns a map pixel 'p' such that rect().x <= p.x <= rect().x + rect().w similar
 		// for y. This requires that 'contains' would return true for 'coords', otherwise this will
 		// be an infinite loop.
-		Vector2f find_pixel_for_coordinates(const Widelands::Coords& coords) const;
+		[[nodiscard]] Vector2f find_pixel_for_coordinates(const Widelands::Coords& coords) const;
 
 	private:
 		friend class MapView;
@@ -55,7 +55,7 @@ public:
 		ViewArea(const Rectf& rect, const Widelands::Map& map);
 
 		// Returns true if 'map_pixel' is inside this view area.
-		bool contains_map_pixel(const Vector2f& map_pixel) const;
+		[[nodiscard]] bool contains_map_pixel(const Vector2f& map_pixel) const;
 
 		const Rectf rect_;
 		const Widelands::Map& map_;
@@ -67,11 +67,11 @@ public:
 		View() : View(Vector2f::zero(), 1.0f) {
 		}
 
-		bool zoom_near(float other_zoom) const;
+		[[nodiscard]] bool zoom_near(float other_zoom) const;
 
-		bool view_near(const View& other) const;
+		[[nodiscard]] bool view_near(const View& other) const;
 
-		bool view_roughly_near(const View& other) const;
+		[[nodiscard]] bool view_roughly_near(const View& other) const;
 
 		// Mappixel of top-left pixel of this MapView.
 		Vector2f viewpoint;

--- a/src/wui/quicknavigation.h
+++ b/src/wui/quicknavigation.h
@@ -57,7 +57,7 @@ struct QuickNavigation {
 	void remove_landmark(size_t index);
 
 	/** Returns the vector of all landmarks. */
-	const std::vector<Landmark>& landmarks() const {
+	[[nodiscard]] const std::vector<Landmark>& landmarks() const {
 		return landmarks_;
 	}
 	std::vector<Landmark>& landmarks() {
@@ -68,8 +68,8 @@ struct QuickNavigation {
 	void goto_prev();
 	void goto_next();
 	void goto_landmark(int index);
-	bool can_goto_prev() const;
-	bool can_goto_next() const;
+	[[nodiscard]] bool can_goto_prev() const;
+	[[nodiscard]] bool can_goto_next() const;
 
 	bool handle_key(bool down, SDL_Keysym key);
 

--- a/src/wui/savegamedata.h
+++ b/src/wui/savegamedata.h
@@ -74,27 +74,27 @@ public:
 	/// Sets the mapname as a localized string
 	void set_mapname(const std::string& input_mapname);
 
-	bool is_directory() const;
+	[[nodiscard]] bool is_directory() const;
 
-	bool is_parent_directory() const;
+	[[nodiscard]] bool is_parent_directory() const;
 
-	bool is_sub_directory() const;
+	[[nodiscard]] bool is_sub_directory() const;
 
-	bool is_multiplayer() const;
+	[[nodiscard]] bool is_multiplayer() const;
 
-	bool is_multiplayer_host() const;
+	[[nodiscard]] bool is_multiplayer_host() const;
 
-	bool is_multiplayer_client() const;
+	[[nodiscard]] bool is_multiplayer_client() const;
 
-	bool is_singleplayer() const;
+	[[nodiscard]] bool is_singleplayer() const;
 
-	bool is_replay() const;
+	[[nodiscard]] bool is_replay() const;
 
-	bool compare_save_time(const SavegameData& other) const;
+	[[nodiscard]] bool compare_save_time(const SavegameData& other) const;
 
-	bool compare_directories(const SavegameData& other) const;
+	[[nodiscard]] bool compare_directories(const SavegameData& other) const;
 
-	bool compare_map_name(const SavegameData& other) const;
+	[[nodiscard]] bool compare_map_name(const SavegameData& other) const;
 
 private:
 	/// Savegame or directory

--- a/src/wui/savegamedeleter.h
+++ b/src/wui/savegamedeleter.h
@@ -34,21 +34,21 @@ public:
 
 	/// attempt to delete the passed savegames. Returns true, if deletion was actually attempted
 	/// (because deletion can be aborted by user via "cancel" in confirmation window)
-	bool delete_savegames(const std::vector<SavegameData>& to_be_deleted) const;
+	[[nodiscard]] bool delete_savegames(const std::vector<SavegameData>& to_be_deleted) const;
 
 	virtual ~SavegameDeleter() {
 	}
 
 private:
-	bool show_confirmation_window(const std::vector<SavegameData>& selections) const;
-	virtual const std::string
+	[[nodiscard]] bool show_confirmation_window(const std::vector<SavegameData>& selections) const;
+	[[nodiscard]] virtual const std::string
 	create_header_for_confirmation_window(const size_t no_selections) const;
 	void delete_and_count_failures(const std::vector<SavegameData>& to_be_deleted) const;
-	virtual uint32_t try_to_delete(const std::vector<SavegameData>& to_be_deleted) const;
+	[[nodiscard]] virtual uint32_t try_to_delete(const std::vector<SavegameData>& to_be_deleted) const;
 
 	void notify_deletion_failed(const std::vector<SavegameData>& to_be_deleted,
 	                            const uint32_t no_failed) const;
-	virtual std::string create_header_for_deletion_failed_window(size_t no_to_be_deleted,
+	[[nodiscard]] virtual std::string create_header_for_deletion_failed_window(size_t no_to_be_deleted,
 	                                                             size_t no_failed) const;
 
 	UI::Panel* parent_;
@@ -60,11 +60,11 @@ public:
 	ReplayDeleter(UI::Panel* parent, UI::WindowStyle);
 
 private:
-	const std::string
+	[[nodiscard]] const std::string
 	create_header_for_confirmation_window(const size_t no_selections) const override;
-	std::string create_header_for_deletion_failed_window(size_t no_to_be_deleted,
+	[[nodiscard]] std::string create_header_for_deletion_failed_window(size_t no_to_be_deleted,
 	                                                     size_t no_failed) const override;
-	uint32_t try_to_delete(const std::vector<SavegameData>& to_be_deleted) const override;
+	[[nodiscard]] uint32_t try_to_delete(const std::vector<SavegameData>& to_be_deleted) const override;
 };
 
 #endif  // WL_WUI_SAVEGAMEDELETER_H

--- a/src/wui/savegamedeleter.h
+++ b/src/wui/savegamedeleter.h
@@ -44,12 +44,13 @@ private:
 	[[nodiscard]] virtual const std::string
 	create_header_for_confirmation_window(const size_t no_selections) const;
 	void delete_and_count_failures(const std::vector<SavegameData>& to_be_deleted) const;
-	[[nodiscard]] virtual uint32_t try_to_delete(const std::vector<SavegameData>& to_be_deleted) const;
+	[[nodiscard]] virtual uint32_t
+	try_to_delete(const std::vector<SavegameData>& to_be_deleted) const;
 
 	void notify_deletion_failed(const std::vector<SavegameData>& to_be_deleted,
 	                            const uint32_t no_failed) const;
-	[[nodiscard]] virtual std::string create_header_for_deletion_failed_window(size_t no_to_be_deleted,
-	                                                             size_t no_failed) const;
+	[[nodiscard]] virtual std::string
+	create_header_for_deletion_failed_window(size_t no_to_be_deleted, size_t no_failed) const;
 
 	UI::Panel* parent_;
 	UI::WindowStyle style_;
@@ -62,9 +63,11 @@ public:
 private:
 	[[nodiscard]] const std::string
 	create_header_for_confirmation_window(const size_t no_selections) const override;
-	[[nodiscard]] std::string create_header_for_deletion_failed_window(size_t no_to_be_deleted,
-	                                                     size_t no_failed) const override;
-	[[nodiscard]] uint32_t try_to_delete(const std::vector<SavegameData>& to_be_deleted) const override;
+	[[nodiscard]] std::string
+	create_header_for_deletion_failed_window(size_t no_to_be_deleted,
+	                                         size_t no_failed) const override;
+	[[nodiscard]] uint32_t
+	try_to_delete(const std::vector<SavegameData>& to_be_deleted) const override;
 };
 
 #endif  // WL_WUI_SAVEGAMEDELETER_H

--- a/src/wui/savegameloader.h
+++ b/src/wui/savegameloader.h
@@ -33,8 +33,8 @@ public:
 	std::vector<SavegameData> load_files(const std::string& directory);
 
 private:
-	virtual bool is_valid_gametype(const SavegameData& gamedata) const = 0;
-	virtual std::string get_savename(const std::string& gamefilename) const;
+	[[nodiscard]] virtual bool is_valid_gametype(const SavegameData& gamedata) const = 0;
+	[[nodiscard]] virtual std::string get_savename(const std::string& gamefilename) const;
 
 	void add_general_information(SavegameData& gamedata,
 	                             const Widelands::GamePreloadPacket& gpdp) const;
@@ -55,8 +55,8 @@ public:
 	explicit ReplayLoader(Widelands::Game& game);
 
 private:
-	bool is_valid_gametype(const SavegameData& gamedata) const override;
-	std::string get_savename(const std::string& gamefilename) const override;
+	[[nodiscard]] bool is_valid_gametype(const SavegameData& gamedata) const override;
+	[[nodiscard]] std::string get_savename(const std::string& gamefilename) const override;
 };
 
 class MultiPlayerLoader : public SavegameLoader {
@@ -64,7 +64,7 @@ public:
 	explicit MultiPlayerLoader(Widelands::Game& game);
 
 private:
-	bool is_valid_gametype(const SavegameData& gamedata) const override;
+	[[nodiscard]] bool is_valid_gametype(const SavegameData& gamedata) const override;
 };
 
 class SinglePlayerLoader : public SavegameLoader {
@@ -72,7 +72,7 @@ public:
 	explicit SinglePlayerLoader(Widelands::Game& game);
 
 private:
-	bool is_valid_gametype(const SavegameData& gamedata) const override;
+	[[nodiscard]] bool is_valid_gametype(const SavegameData& gamedata) const override;
 };
 
 class EverythingLoader : public SavegameLoader {
@@ -80,7 +80,7 @@ public:
 	explicit EverythingLoader(Widelands::Game& game);
 
 private:
-	bool is_valid_gametype(const SavegameData& gamedata) const override;
+	[[nodiscard]] bool is_valid_gametype(const SavegameData& gamedata) const override;
 };
 
 #endif  // WL_WUI_SAVEGAMELOADER_H

--- a/src/wui/savegametable.cc
+++ b/src/wui/savegametable.cc
@@ -173,9 +173,9 @@ SavegameTableReplay::SavegameTableReplay(UI::Panel* parent,
 void SavegameTableReplay::add_columns() {
 	add_column(130, _("Save Date"), _("The date this game was saved"), UI::Align::kLeft);
 	std::string game_mode_tooltip =
-	/** TRANSLATORS: Tooltip header for the "Mode" column when choosing a game/replay to
-	load.*/
-	g_style_manager->font_style(tooltip_header_style_).as_font_tag(_("Game Mode"));
+	   /** TRANSLATORS: Tooltip header for the "Mode" column when choosing a game/replay to
+	   load.*/
+	   g_style_manager->font_style(tooltip_header_style_).as_font_tag(_("Game Mode"));
 
 	/** TRANSLATORS: Tooltip for the "Mode" column when choosing a game/replay to load. */
 	/** TRANSLATORS: Make sure that you keep consistency in your translation. */
@@ -236,9 +236,9 @@ SavegameTableMultiplayer::SavegameTableMultiplayer(UI::Panel* parent,
 void SavegameTableMultiplayer::add_columns() {
 	add_column(130, _("Save Date"), _("The date this game was saved"), UI::Align::kLeft);
 	std::string game_mode_tooltip =
-	/** TRANSLATORS: Tooltip header for the "Mode" column when choosing a game/replay to
-	load.*/
-	g_style_manager->font_style(tooltip_header_style_).as_font_tag(_("Game Mode"));
+	   /** TRANSLATORS: Tooltip header for the "Mode" column when choosing a game/replay to
+	   load.*/
+	   g_style_manager->font_style(tooltip_header_style_).as_font_tag(_("Game Mode"));
 
 	/** TRANSLATORS: Tooltip for the "Mode" column when choosing a game/replay to load. */
 	/** TRANSLATORS: Make sure that you keep consistency in your translation. */

--- a/src/wui/savegametable.cc
+++ b/src/wui/savegametable.cc
@@ -172,7 +172,7 @@ SavegameTableReplay::SavegameTableReplay(UI::Panel* parent,
 
 void SavegameTableReplay::add_columns() {
 	add_column(130, _("Save Date"), _("The date this game was saved"), UI::Align::kLeft);
-	std::string game_mode_tooltip;
+	std::string game_mode_tooltip =
 	/** TRANSLATORS: Tooltip header for the "Mode" column when choosing a game/replay to
 	load.*/
 	g_style_manager->font_style(tooltip_header_style_).as_font_tag(_("Game Mode"));
@@ -235,7 +235,7 @@ SavegameTableMultiplayer::SavegameTableMultiplayer(UI::Panel* parent,
 
 void SavegameTableMultiplayer::add_columns() {
 	add_column(130, _("Save Date"), _("The date this game was saved"), UI::Align::kLeft);
-	std::string game_mode_tooltip;
+	std::string game_mode_tooltip =
 	/** TRANSLATORS: Tooltip header for the "Mode" column when choosing a game/replay to
 	load.*/
 	g_style_manager->font_style(tooltip_header_style_).as_font_tag(_("Game Mode"));

--- a/utils/check_clang_tidy_results.py
+++ b/utils/check_clang_tidy_results.py
@@ -88,9 +88,6 @@ SUPPRESSED_CHECKS = {
     '[readability-convert-member-functions-to-static]',
     '[readability-function-size]',
     '[readability-magic-numbers]',
-    '[modernize-use-nodiscard]',
-    '[readability-redundant-declaration]',
-    '[modernize-concat-nested-namespaces]'
 }
 
 CHECK_REGEX = re.compile(r'.*\[([A-Za-z0-9.-]+)\]$')


### PR DESCRIPTION
- `modernize-use-nodiscard`: Functions that only perform a calculation and return the result without any side-effects should be annotated `[[nodiscard]]`. This annotation causes compilers to emit a warning when you invoke the function without using its result.
- `readability-redundant-declaration`: Sort of what the includes script already checks, but more sophisticated so it catches more occurrences. (The includes script also does something else which clang-tidy can't.)
- `modernize-concat-nested-namespaces`: More concise and readable declarations of nested namespaces.
- Re #5641