### PR TITLE
Forbid soldiers leaving buildings through the wall

### DIFF
--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -962,6 +962,11 @@ void Soldier::attack_update(Game& game, State& state) {
 		}
 	}
 
+	if (location != nullptr && get_position() == location->get_position()) {
+		// Still at home, need to go outside first
+		return start_task_leavebuilding(game, false);
+	}
+
 	if (battle_ != nullptr) {
 		return start_task_battle(game);
 	}


### PR DESCRIPTION
May not fix all cases of the bug, but it fixes the one where soldiers who leave a building to attack may exit through the wall instead of through the main entrance.