### PR TITLE
Fix map pixel to triangle computation regression

### DIFF
--- a/src/wui/mapviewpixelfunctions.cc
+++ b/src/wui/mapviewpixelfunctions.cc
@@ -160,6 +160,10 @@ MapviewPixelFunctions::calc_node_and_triangle(const Widelands::Map& map, uint32_
 	Widelands::TCoords<> result_triangle(Widelands::Coords::null(), Widelands::TriangleIndex::D);
 
 	//  Find out which of the 4 possible triangles (x, y) is in.
+	screen_y_base += kTriangleHeight;
+	row_number = (row_number + mapheight - 1) % mapheight;
+	next_row_number = (row_number + 1) % mapheight;
+	slash = !slash;
 	if (slash) {
 		int32_t Y_a = screen_y_base - kTriangleHeight -
 		              map[Widelands::Coords((right_col == 0 ? mapwidth : right_col) - 1, row_number)]


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
Bugfix

**Issues(s) closed**
Fixes #5738

**Additional context**
Previously, we found the node and triangle closest to the cursor by starting at the upper edge of the screen and searching row-by-row downwards. Now we start at the bottom of the screen moving upwards. So there was a mismatch in the rows used for the triangle computation after the node computation successfully stopped.