### PR TITLE
Fix hang on building window warp

### DIFF
--- a/src/wui/buildingwindow.h
+++ b/src/wui/buildingwindow.h
@@ -75,6 +75,9 @@ protected:
 	virtual void init(bool avoid_fastclick, bool workarea_preview_wanted);
 	void die() override;
 
+	// Actions performed when a NoteBuilding is received.
+	virtual void on_building_note(const Widelands::NoteBuilding& note);
+
 	UI::TabPanel* get_tabs() {
 		return tabs_;
 	}
@@ -111,9 +114,6 @@ protected:
 
 private:
 	void create_capsbuttons(UI::Box* buttons, Widelands::Building* building);
-
-	// Actions performed when a NoteBuilding is received.
-	void on_building_note(const Widelands::NoteBuilding& note);
 
 	// For ports only.
 	void update_expedition_button(bool expedition_was_canceled);

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -847,19 +847,22 @@ void InteractiveBase::think() {
 		}
 	}
 
-	for (const auto& pair : wanted_building_windows_) {
-		if (!pair.second->warp_done) {
+	for (auto it = wanted_building_windows_.begin(); it != wanted_building_windows_.end();) {
+		if (!it->second->warp_done) {
+			++it;
 			continue;
 		}
 
 		UI::UniqueWindow* building_window = show_building_window(
-		   Widelands::Coords::unhash(pair.first), true, pair.second->show_workarea);
-		building_window->set_pos(pair.second->window_position);
-		if (pair.second->minimize) {
+		   Widelands::Coords::unhash(it->first), true, it->second->show_workarea);
+
+		building_window->set_pos(it->second->window_position);
+		if (it->second->minimize) {
 			building_window->minimize();
 		}
-		building_window->set_pinned(pair.second->pin);
-		break;
+		building_window->set_pinned(it->second->pin);
+
+		it = wanted_building_windows_.erase(it);
 	}
 }
 

--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -852,8 +852,8 @@ void InteractiveBase::think() {
 			continue;
 		}
 
-		UI::UniqueWindow* building_window =
-		   show_building_window(Widelands::Coords::unhash(pair.first), true, pair.second->show_workarea);
+		UI::UniqueWindow* building_window = show_building_window(
+		   Widelands::Coords::unhash(pair.first), true, pair.second->show_workarea);
 		building_window->set_pos(pair.second->window_position);
 		if (pair.second->minimize) {
 			building_window->minimize();

--- a/src/wui/interactive_base.h
+++ b/src/wui/interactive_base.h
@@ -404,10 +404,12 @@ private:
 		const bool minimize;
 		const bool pin;
 		const bool show_workarea;
+
+		bool warp_done{false};
 	};
 
 	// Building coordinates, window position, whether the window was minimized
-	std::map<uint32_t, std::unique_ptr<const WantedBuildingWindow>> wanted_building_windows_;
+	std::map<uint32_t, std::unique_ptr<WantedBuildingWindow>> wanted_building_windows_;
 	std::unique_ptr<Notifications::Subscriber<Widelands::NoteBuilding>> buildingnotes_subscriber_;
 
 	MainToolbar& toolbar_;

--- a/src/wui/productionsitewindow.cc
+++ b/src/wui/productionsitewindow.cc
@@ -43,27 +43,28 @@ ProductionSiteWindow::ProductionSiteWindow(InteractiveBase& parent,
                                            bool avoid_fastclick,
                                            bool workarea_preview_wanted)
    : BuildingWindow(parent, reg, ps, avoid_fastclick), production_site_(&ps) {
-	productionsitenotes_subscriber_ = Notifications::subscribe<Widelands::NoteBuilding>(
-	   [this](const Widelands::NoteBuilding& note) {
-		   if (is_dying_) {
-			   return;
-		   }
-		   Widelands::ProductionSite* production_site = production_site_.get(ibase()->egbase());
-		   if (production_site == nullptr) {
-			   return;
-		   }
-		   if (note.serial == production_site->serial()) {
-			   switch (note.action) {
-			   case Widelands::NoteBuilding::Action::kWorkersChanged:
-				   update_worker_table(production_site);
-				   worker_table_selection_changed();
-				   break;
-			   default:
-				   break;
-			   }
-		   }
-	   });
 	init(avoid_fastclick, workarea_preview_wanted);
+}
+
+void ProductionSiteWindow::on_building_note(const Widelands::NoteBuilding& note) {
+	if (is_dying_) {
+		return;
+	}
+	Widelands::ProductionSite* production_site = production_site_.get(ibase()->egbase());
+	if (production_site == nullptr || note.serial != production_site->serial()) {
+		return;
+	}
+
+	switch (note.action) {
+	case Widelands::NoteBuilding::Action::kWorkersChanged:
+		update_worker_table(production_site);
+		worker_table_selection_changed();
+		break;
+	default:
+		break;
+   }
+
+	BuildingWindow::on_building_note(note);
 }
 
 void ProductionSiteWindow::init(bool avoid_fastclick, bool workarea_preview_wanted) {

--- a/src/wui/productionsitewindow.cc
+++ b/src/wui/productionsitewindow.cc
@@ -62,7 +62,7 @@ void ProductionSiteWindow::on_building_note(const Widelands::NoteBuilding& note)
 		break;
 	default:
 		break;
-   }
+	}
 
 	BuildingWindow::on_building_note(note);
 }

--- a/src/wui/productionsitewindow.h
+++ b/src/wui/productionsitewindow.h
@@ -37,6 +37,7 @@ protected:
 	void init(bool avoid_fastclick, bool workarea_preview_wanted) override;
 	void evict_worker();
 	void clicked_watch() override;
+	void on_building_note(const Widelands::NoteBuilding& note) override;
 
 private:
 	void update_worker_table(Widelands::ProductionSite* production_site);
@@ -44,8 +45,6 @@ private:
 	Widelands::OPtr<Widelands::ProductionSite> production_site_;
 	UI::Table<uintptr_t>* worker_table_{nullptr};
 	UI::Box* worker_caps_{nullptr};
-	std::unique_ptr<Notifications::Subscriber<Widelands::NoteBuilding>>
-	   productionsitenotes_subscriber_;
 
 	void worker_table_selection_changed();
 	void worker_table_dropdown_clicked();


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
Bugfix

**Issues(s) closed**
Fixes https://www.widelands.org/forum/topic/5733/

**To reproduce**
*If it's a bugfix:*
Steps to reproduce the behavior which cause the bug in master but not in your branch:
1. Build an amazon woodcutter's hut
2. Wait for its completion
3. Open the building's window
4. Enhance to rare wood cutter
5. Game hangs indefinitely

**New behavior**
Instead of opening the new buildingwindow immediately, push it in a queue and open buildings from that queue on next think. A one-frame delay is no visible to the user, and I have long hated this immediate-warping design.

**Possible regressions**
Anything related to the automatic reopening of a building window
