### PR TITLE
Update python formatting for docformatter 1.5

### DIFF
--- a/utils/confgettext.py
+++ b/utils/confgettext.py
@@ -10,14 +10,12 @@ from collections import defaultdict
 
 
 class occurences:
-
     def __init__(self, file, line):
         self.line = line
         self.file = file
 
 
 class trans_string:
-
     def __init__(self):
         self.occurences = []
         self.str = ''
@@ -76,7 +74,6 @@ def _format_msgid(tag, string, output):
 
 
 class Conf_GetText(object):
-
     def __init__(self):
         self.translatable_strings = []
 

--- a/utils/pywi/animation.py
+++ b/utils/pywi/animation.py
@@ -18,7 +18,6 @@ _re_blit = re.compile(r'(\d+),(\d+),(\d+),(\d+)@(-?\d+),(-?\d+)$')
 
 
 class Context(object):
-
     def __init__(self):
         self.filenames = set()
         self.spritemap_names = set()
@@ -72,7 +71,6 @@ class AnimationFullFrames(Animation):
 
 
 class Chunk(object):
-
     def __init__(self, pic, pc_pic=None):
         self.pic = pic
         self.pc_pic = pc_pic
@@ -89,7 +87,6 @@ Blit = collections.namedtuple('Blit', ('chunk', 'offset'))
 
 
 class ChunkSet(object):
-
     def __init__(self, has_player_color):
         self.has_player_color = has_player_color
         self._chunks = []
@@ -151,7 +148,6 @@ class ChunkSet(object):
 
 
 class AnimationBlits(Animation):
-
     def __init__(self, chunkset):
         super(AnimationBlits, self).__init__()
         self.chunkset = chunkset

--- a/utils/pywi/config.py
+++ b/utils/pywi/config.py
@@ -15,7 +15,6 @@ _re_entry = re.compile('(\\S+?)\\s*=_?\\s*([^#]*)')
 
 
 class Section(object):
-
     def __init__(self, file, line):
         self.file = file
         self.line = line

--- a/utils/pywi/packing.py
+++ b/utils/pywi/packing.py
@@ -86,7 +86,6 @@ class Packer(object):
 
 
 class Block(object):
-
     def __init__(self, w, h):
         self.w = w
         self.h = h

--- a/utils/pywi/tests.py
+++ b/utils/pywi/tests.py
@@ -12,7 +12,6 @@ root_dir = os.path.normpath(source_dir + '/../..')
 
 
 class TestConfig(unittest.TestCase):
-
     def sample_text(self):
         return """
 key = this is global
@@ -102,7 +101,6 @@ baz= quux
 
 
 class TestAnimation(unittest.TestCase):
-
     def test_load_conf(self):
         # This needs to be updated when the game data changes
         tests = [

--- a/utils/test/test_lua-xgettext.py
+++ b/utils/test/test_lua-xgettext.py
@@ -10,7 +10,6 @@ sys.path.append(os.path.dirname(__file__) + os.path.sep + '..')
 
 
 class TestXGettext(unittest.TestCase):
-
     def runTest(self):
         self.assertTrue(True)
 

--- a/utils/test/test_make_spritemap.py
+++ b/utils/test/test_make_spritemap.py
@@ -11,7 +11,6 @@ sys.path.append(os.path.normpath(
 
 
 class TestMinimumAverageCostRectangle(unittest.TestCase):
-
     def test_case1(self):
         FRAGMENT_COST = 4
         bitmask = np.array([
@@ -27,7 +26,6 @@ class TestMinimumAverageCostRectangle(unittest.TestCase):
 
 
 class TestMinimumAverageCostGrow(unittest.TestCase):
-
     def test_basic_right(self):
         bitmask = np.array([
             [False, False, False, False],
@@ -86,7 +84,6 @@ class TestMinimumAverageCostGrow(unittest.TestCase):
 
 
 class TestComputeRectangleCovering(unittest.TestCase):
-
     def test_basic(self):
         """Tests a case where the optimal solution consists of a single minimum
         average cost rectangle."""


### PR DESCRIPTION
**Type of change**
Bugfix

**Issues(s) closed**
Fixes #5725 

**New behavior**
Newest docformatter version has an API change which broke pyformat. Since pyformat does not seem to be maintained anymore, I included a corresponding function into our script.
Also the `call` calls are replaced by `check_call` to fail if a subprocess fails.

