### PR TITLE
Fix #5751: Crash when dialog opens and moving map

### DIFF
--- a/src/scripting/lua_game.cc
+++ b/src/scripting/lua_game.cc
@@ -551,6 +551,11 @@ int LuaPlayer::message_box(lua_State* L) {
 	}
 #undef CHECK_UINT
 
+	InteractivePlayer* ipl = game.get_ipl();
+	if (ipl != nullptr) {
+		ipl->map_view()->stop_dragging();
+	}
+
 	if (is_modal) {
 		std::unique_ptr<StoryMessageBox> mb(new StoryMessageBox(&game, coords, luaL_checkstring(L, 2),
 		                                                        luaL_checkstring(L, 3), posx, posy, w,

--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -487,9 +487,11 @@ void MapView::pan_by(Vector2i delta_pixels, const Transition& transition) {
 }
 
 void MapView::stop_dragging() {
-	WLApplication::get()->set_mouse_lock(false);
-	grab_mouse(false);
-	dragging_ = false;
+	if (dragging_) {
+		WLApplication::get()->set_mouse_lock(false);
+		grab_mouse(false);
+		dragging_ = false;
+	}
 }
 
 bool MapView::handle_mousepress(uint8_t const btn, int32_t const x, int32_t const y) {

--- a/src/wui/mapview.h
+++ b/src/wui/mapview.h
@@ -183,9 +183,9 @@ public:
 	bool handle_mousewheel(int32_t x, int32_t y, uint16_t modstate) override;
 	bool handle_key(bool down, SDL_Keysym code) override;
 	void think() override;
+	void stop_dragging();
 
 private:
-	void stop_dragging();
 
 	// Returns the target view of the last entry in 'view_plans_' or (now,
 	// 'view_') if we are not animating.


### PR DESCRIPTION
When a script dialog opens, stop dragging the map, so that the mouse cursor gets back and no crash occurs when closing the dialog.

Signed-off-by: ctxnop <ctxnop@gmail.com>

**Type of change**
Bugfix

**Issues(s) closed**
Fixes #5751
