### PR TITLE
Only create pre-release from master in main repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
   push:
-    # TODO remove branch again
-    branches: [ master, workflow_update ]
+    branches: [ master ]
 
 jobs:
   # This job runs multiple smaller checks where having several jobs would be overkill.
@@ -407,8 +406,7 @@ jobs:
 
   dev_release:
     name: Automated development pre-release
-    # TODO reenable if: ${{ github.repository == 'widelands/widelands' && github.ref == 'refs/heads/master' && always() }}
-    if: ${{ always() }}
+    if: ${{ github.repository == 'widelands/widelands' && github.ref == 'refs/heads/master' && always() }}
     needs: [windows, windows-msvc, macos, appimage]
     runs-on: "ubuntu-latest"
     steps:
@@ -462,7 +460,7 @@ jobs:
           if [ "$latest" != "$GITHUB_SHA" ]
           then
             echo "The master branch ($GITHUB_REF) was updated from '$GITHUB_SHA' to '$latest', cancel"
-            # TODO reenable: exit 1
+            exit 1
           fi
       - name: Updating latest pre-release
         # Creates a new pre-release with the "latest" tag and all gathered artifacts.


### PR DESCRIPTION

> Before merging, the TODOs should be addressed to restore the master configuration.

@hessenfarmer was a bit to fast with merging the workflow update #5759 , so I did not have the chance to reenable the checks  to only do this automatic release from master, which I had disabled.

