### PR TITLE
Fix add-ons admin dialog Enter key handling

### DIFF
--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -576,7 +576,9 @@ bool AdminDialog::handle_key(bool down, SDL_Keysym code) {
 	if (down) {
 		switch (code.sym) {
 		case SDLK_RETURN:
-			ok();
+			if (ok_.enabled()) {
+				ok();
+			}
 			return true;
 		case SDLK_ESCAPE:
 			die();


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
When the OK button is disabled, <kbd>Enter</kbd> should not do anything.