### PR TITLE
Merge Add-On Dirnames in Map Select UIs

### DIFF
--- a/src/editor/ui_menus/main_menu_load_map.cc
+++ b/src/editor/ui_menus/main_menu_load_map.cc
@@ -50,27 +50,30 @@ void MainMenuLoadMap::clicked_ok() {
 		return;
 	}
 	const MapData& mapdata = maps_data_[table_.get_selected()];
-	if (g_fs->is_directory(mapdata.filename) &&
-	    !Widelands::WidelandsMapLoader::is_widelands_map(mapdata.filename)) {
-		set_current_directory(mapdata.filename);
+	assert(!mapdata.filenames.empty());
+	if (g_fs->is_directory(mapdata.filenames.at(0)) &&
+	    !Widelands::WidelandsMapLoader::is_widelands_map(mapdata.filenames.at(0))) {
+		set_current_directory(mapdata.filenames);
 		fill_table();
 	} else {
+		assert(mapdata.filenames.size() == 1);
 		// Prevent description notes from reaching a subscriber
 		// other than the one they're meant for
 		egbase_.delete_world_and_tribes();
 
 		EditorInteractive& eia = dynamic_cast<EditorInteractive&>(*get_parent());
 		eia.egbase().create_loader_ui({"editor"}, true, "", kEditorSplashImage, false);
-		eia.load(mapdata.filename);
+		eia.load(mapdata.filenames.at(0));
 		// load() will delete us.
 		eia.egbase().remove_loader_ui();
 	}
 }
 
-void MainMenuLoadMap::set_current_directory(const std::string& filename) {
-	curdir_ = filename;
+void MainMenuLoadMap::set_current_directory(const std::vector<std::string>& filenames) {
+	assert(!filenames.empty());
+	curdir_ = filenames;
 
-	std::string display_dir = curdir_.substr(basedir_.size());
+	std::string display_dir = curdir_.at(0).substr(basedir_.size());
 	if (starts_with(display_dir, "/")) {
 		display_dir = display_dir.substr(1);
 	}

--- a/src/editor/ui_menus/main_menu_load_map.h
+++ b/src/editor/ui_menus/main_menu_load_map.h
@@ -31,7 +31,7 @@ struct MainMenuLoadMap : public MainMenuLoadOrSaveMap {
 protected:
 	void clicked_ok() override;
 	// Sets the current dir and updates labels.
-	void set_current_directory(const std::string& filename) override;
+	void set_current_directory(const std::vector<std::string>& filenames) override;
 
 private:
 	void entry_selected();

--- a/src/editor/ui_menus/main_menu_load_or_save_map.cc
+++ b/src/editor/ui_menus/main_menu_load_or_save_map.cc
@@ -223,7 +223,8 @@ void MainMenuLoadOrSaveMap::fill_table() {
 			MapData new_md = MapData::create_directory(mapfilename);
 			bool found = false;
 			for (MapData& md : maps_data_) {
-				if (md.maptype == MapData::MapType::kDirectory && md.localized_name == new_md.localized_name) {
+				if (md.maptype == MapData::MapType::kDirectory &&
+				    md.localized_name == new_md.localized_name) {
 					found = true;
 					md.add(new_md);
 					break;

--- a/src/editor/ui_menus/main_menu_load_or_save_map.cc
+++ b/src/editor/ui_menus/main_menu_load_or_save_map.cc
@@ -81,7 +81,7 @@ MainMenuLoadOrSaveMap::MainMenuLoadOrSaveMap(EditorInteractive& parent,
      include_addon_maps_(addons) {
 
 	g_fs->ensure_directory_exists(basedir_);
-	curdir_ = basedir_;
+	curdir_ = {basedir_};
 
 	main_box_.add(&table_and_details_box_, UI::Box::Resizing::kExpandBoth);
 	main_box_.add_space(padding_);
@@ -148,20 +148,26 @@ void MainMenuLoadOrSaveMap::layout() {
 /**
  * fill the file list
  */
+// TODO(Nordfriese): Code duplication with FsMenu::MapSelect::fill_table
 void MainMenuLoadOrSaveMap::fill_table() {
 	table_.clear();
 	maps_data_.clear();
 
 	//  Fill it with all files we find.
-	FilenameSet files = g_fs->list_directory(curdir_);
+	assert(!curdir_.empty());
+	FilenameSet files;
+	for (const std::string& dir : curdir_) {
+		FilenameSet f = g_fs->list_directory(dir);
+		files.insert(f.begin(), f.end());
+	}
 
 	// If we are not at the top of the map directory hierarchy (we're not talking
 	// about the absolute filesystem top!) we manually add ".."
-	if (curdir_ != basedir_) {
-		maps_data_.push_back(MapData::create_parent_dir(curdir_));
+	if (curdir_.at(0) != basedir_) {
+		maps_data_.push_back(MapData::create_parent_dir(curdir_.at(0)));
 	} else {
 		if (files.empty()) {
-			maps_data_.push_back(MapData::create_empty_dir(curdir_));
+			maps_data_.push_back(MapData::create_empty_dir(curdir_.at(0)));
 		}
 		// In the toplevel directory we also need to include add-on maps –
 		// but only in the load screen, not in the save screen!
@@ -213,7 +219,19 @@ void MainMenuLoadOrSaveMap::fill_table() {
 			if ((strcmp(fs_filename, ".") == 0) || (strcmp(fs_filename, "..") == 0)) {
 				continue;
 			}
-			maps_data_.push_back(MapData::create_directory(mapfilename));
+
+			MapData new_md = MapData::create_directory(mapfilename);
+			bool found = false;
+			for (MapData& md : maps_data_) {
+				if (md.maptype == MapData::MapType::kDirectory && md.localized_name == new_md.localized_name) {
+					found = true;
+					md.add(new_md);
+					break;
+				}
+			}
+			if (!found) {
+				maps_data_.push_back(new_md);
+			}
 		}
 	}
 

--- a/src/editor/ui_menus/main_menu_load_or_save_map.h
+++ b/src/editor/ui_menus/main_menu_load_or_save_map.h
@@ -43,7 +43,7 @@ protected:
 	virtual void clicked_ok() = 0;
 	void toggle_mapnames();
 	// Sets the current dir and updates labels.
-	virtual void set_current_directory(const std::string& filename) = 0;
+	virtual void set_current_directory(const std::vector<std::string>& filenames) = 0;
 	void layout() override;
 	void fill_table();
 
@@ -89,7 +89,7 @@ protected:
 
 	// Settings data
 	const std::string basedir_;
-	std::string curdir_;
+	std::vector<std::string> curdir_;
 	bool include_addon_maps_;
 };
 

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -125,28 +125,28 @@ void MainMenuSaveMap::clicked_ok() {
 	if (!ok_.enabled()) {
 		return;
 	}
-	std::string filename = editbox_.text();
-	std::string complete_filename;
+	std::vector<std::string> filename = {editbox_.text()};
+	std::vector<std::string> complete_filename;
 
 	if (filename.empty() && table_.has_selection()) {  //  Maybe a directory is selected.
-		complete_filename = filename = maps_data_[table_.get_selected()].filename;
+		complete_filename = filename = maps_data_[table_.get_selected()].filenames;
 	} else {
-		complete_filename = curdir_ + FileSystem::file_separator() + filename;
+		complete_filename = {curdir_.at(0) + FileSystem::file_separator() + filename.at(0)};
 	}
 
-	if (g_fs->is_directory(complete_filename) &&
-	    !Widelands::WidelandsMapLoader::is_widelands_map(complete_filename)) {
+	if (g_fs->is_directory(complete_filename.at(0)) &&
+	    !Widelands::WidelandsMapLoader::is_widelands_map(complete_filename.at(0))) {
 		set_current_directory(complete_filename);
 		fill_table();
 	} else {  //  Ok, save this map
 		Widelands::Map* map = eia().egbase().mutable_map();
 		if (map->get_name() == _("No Name")) {
-			std::string::size_type const filename_size = filename.size();
-			map->set_name(4 <= filename_size && ends_with(filename, kWidelandsMapExtension, false) ?
-                          filename.substr(0, filename_size - 4) :
-                          filename);
+			std::string::size_type const filename_size = filename.at(0).size();
+			map->set_name(4 <= filename_size && ends_with(filename.at(0), kWidelandsMapExtension, false) ?
+                          filename.at(0).substr(0, filename_size - 4) :
+                          filename.at(0));
 		}
-		if (save_map(filename, !get_config_bool("nozip", false))) {
+		if (save_map(filename.at(0), !get_config_bool("nozip", false))) {
 			die();
 		} else {
 			table_.focus();
@@ -164,7 +164,7 @@ void MainMenuSaveMap::clicked_make_directory() {
 	while (open_dialogue) {
 		open_dialogue = false;
 		if (md.run<UI::Panel::Returncodes>() == UI::Panel::Returncodes::kOk) {
-			std::string fullname = curdir_ + FileSystem::file_separator() + md.get_dirname();
+			std::string fullname = curdir_.at(0) + FileSystem::file_separator() + md.get_dirname();
 			// Trim it for preceding/trailing whitespaces in user input
 			trim(fullname);
 			if (g_fs->file_exists(fullname)) {
@@ -175,9 +175,8 @@ void MainMenuSaveMap::clicked_make_directory() {
 				open_dialogue = true;
 			} else {
 				try {
-					g_fs->ensure_directory_exists(curdir_);
 					//  Create directory.
-					g_fs->make_directory(fullname);
+					g_fs->ensure_directory_exists(fullname);
 				} catch (const FileError& e) {
 					log_err("directory creation failed in MainMenuSaveMap::"
 					        "clicked_make_directory: %s\n",
@@ -232,7 +231,7 @@ void MainMenuSaveMap::clicked_item() {
 		const MapData& mapdata = maps_data_[table_.get_selected()];
 		if (mapdata.maptype != MapData::MapType::kDirectory) {
 			editbox_.set_text(
-			   FileSystem::fs_filename(maps_data_[table_.get_selected()].filename.c_str()));
+			   FileSystem::fs_filename(maps_data_[table_.get_selected()].filenames.at(0).c_str()));
 			edit_box_changed();
 		}
 	}
@@ -245,7 +244,7 @@ void MainMenuSaveMap::double_clicked_item() {
 	assert(table_.has_selection());
 	const MapData& mapdata = maps_data_[table_.get_selected()];
 	if (mapdata.maptype == MapData::MapType::kDirectory) {
-		set_current_directory(mapdata.filename);
+		set_current_directory(mapdata.filenames);
 		fill_table();
 	} else {
 		clicked_ok();
@@ -271,11 +270,12 @@ void MainMenuSaveMap::reset_editbox_or_die(const std::string& current_filename) 
 	}
 }
 
-void MainMenuSaveMap::set_current_directory(const std::string& filename) {
-	curdir_ = filename;
+void MainMenuSaveMap::set_current_directory(const std::vector<std::string>& filenames) {
+	assert(!filenames.empty());
+	curdir_ = filenames;
 	directory_info_.set_text(
 	   /** TRANSLATORS: The folder that a file will be saved to. */
-	   format(_("Current directory: %s"), (_("My Maps") + curdir_.substr(basedir_.size()))));
+	   format(_("Current directory: %s"), (_("My Maps") + curdir_.at(0).substr(basedir_.size()))));
 }
 
 void MainMenuSaveMap::layout() {
@@ -300,7 +300,7 @@ bool MainMenuSaveMap::save_map(std::string filename, bool binary) {
 	}
 
 	//  Append directory name.
-	const std::string complete_filename = curdir_ + FileSystem::file_separator() + filename;
+	const std::string complete_filename = curdir_.at(0) + FileSystem::file_separator() + filename;
 
 	//  Check if file exists. If so, show a warning.
 	if (g_fs->file_exists(complete_filename)) {

--- a/src/editor/ui_menus/main_menu_save_map.cc
+++ b/src/editor/ui_menus/main_menu_save_map.cc
@@ -142,7 +142,8 @@ void MainMenuSaveMap::clicked_ok() {
 		Widelands::Map* map = eia().egbase().mutable_map();
 		if (map->get_name() == _("No Name")) {
 			std::string::size_type const filename_size = filename.at(0).size();
-			map->set_name(4 <= filename_size && ends_with(filename.at(0), kWidelandsMapExtension, false) ?
+			map->set_name(4 <= filename_size &&
+			                    ends_with(filename.at(0), kWidelandsMapExtension, false) ?
                           filename.at(0).substr(0, filename_size - 4) :
                           filename.at(0));
 		}

--- a/src/editor/ui_menus/main_menu_save_map.h
+++ b/src/editor/ui_menus/main_menu_save_map.h
@@ -39,7 +39,7 @@ struct MainMenuSaveMap : public MainMenuLoadOrSaveMap {
 
 protected:
 	// Sets the current dir and updates labels.
-	void set_current_directory(const std::string& filename) override;
+	void set_current_directory(const std::vector<std::string>& filenames) override;
 	void layout() override;
 
 private:

--- a/src/ui_fsmenu/addons/packager_box.cc
+++ b/src/ui_fsmenu/addons/packager_box.cc
@@ -267,10 +267,10 @@ void MapsAddOnsPackagerBox::load_addon(AddOns::MutableAddOn* a) {
 				continue;
 			}
 			my_maps_.add(
-			   entry.first.localized_name, entry.first.filename, nullptr, false,
+			   entry.first.localized_name, entry.first.filenames.at(0), nullptr, false,
 			   format("%s<br>%s<br>%s<br>%s<br>%s",
 			          g_style_manager->font_style(UI::FontStyle::kFsTooltipHeader)
-			             .as_font_tag(entry.first.filename),
+			             .as_font_tag(entry.first.filenames.at(0)),
 			          format(_("Name: %s"),
 			                 g_style_manager->font_style(UI::FontStyle::kFsMenuInfoPanelParagraph)
 			                    .as_font_tag(entry.first.localized_name)),

--- a/src/ui_fsmenu/launch_mpg.cc
+++ b/src/ui_fsmenu/launch_mpg.cc
@@ -162,7 +162,7 @@ void LaunchMPG::clicked_select_map_callback(const MapData* map, const bool scena
 	}
 
 	settings_.set_scenario(scenario);
-	settings_.set_map(map->name, map->filename, map->theme, map->background, map->nrplayers);
+	settings_.set_map(map->name, map->filenames.at(0), map->theme, map->background, map->nrplayers);
 
 	map_changed();
 	update_win_conditions();

--- a/src/ui_fsmenu/launch_spg.cc
+++ b/src/ui_fsmenu/launch_spg.cc
@@ -51,7 +51,7 @@ LaunchSPG::LaunchSPG(MenuCapsule& fsmm,
 	if (!preconfigured_) {
 		assert(!settings_.settings().tribes.empty());
 		settings_.set_map(
-		   mapdata->name, mapdata->filename, mapdata->theme, mapdata->background, mapdata->nrplayers);
+		   mapdata->name, mapdata->filenames.at(0), mapdata->theme, mapdata->background, mapdata->nrplayers);
 	}
 	Notifications::publish(NoteGameSettings(NoteGameSettings::Action::kMap));
 

--- a/src/ui_fsmenu/launch_spg.cc
+++ b/src/ui_fsmenu/launch_spg.cc
@@ -50,8 +50,8 @@ LaunchSPG::LaunchSPG(MenuCapsule& fsmm,
 	settings_.set_scenario(scenario);
 	if (!preconfigured_) {
 		assert(!settings_.settings().tribes.empty());
-		settings_.set_map(
-		   mapdata->name, mapdata->filenames.at(0), mapdata->theme, mapdata->background, mapdata->nrplayers);
+		settings_.set_map(mapdata->name, mapdata->filenames.at(0), mapdata->theme,
+		                  mapdata->background, mapdata->nrplayers);
 	}
 	Notifications::publish(NoteGameSettings(NoteGameSettings::Action::kMap));
 

--- a/src/ui_fsmenu/main.cc
+++ b/src/ui_fsmenu/main.cc
@@ -431,7 +431,7 @@ void MainMenu::set_labels() {
 			}
 		}
 		if (last_edited != nullptr) {
-			filename_for_continue_editing_ = last_edited->first.filename;
+			filename_for_continue_editing_ = last_edited->first.filenames.at(0);
 			editor_.add(
 			   _("Continue Editing"), MenuTarget::kEditorContinue, nullptr, false,
 			   format("%s<br>%s<br>%s<br>%s<br>%s",

--- a/src/ui_fsmenu/mapselect.cc
+++ b/src/ui_fsmenu/mapselect.cc
@@ -59,7 +59,7 @@ MapSelect::MapSelect(MenuCapsule& m,
      basedir_(kMapsDir),
      settings_(settings),
      ctrl_(ctrl) {
-	curdir_ = basedir_;
+	curdir_ = {basedir_};
 	if (settings_->settings().multiplayer) {
 		back_.set_tooltip(_("Return to the multiplayer game setup"));
 	} else {
@@ -233,7 +233,7 @@ void MapSelect::clicked_ok() {
 	const MapData& mapdata = maps_data_[table_.get_selected()];
 
 	if (mapdata.width == 0u) {
-		curdir_ = mapdata.filename;
+		curdir_ = mapdata.filenames;
 		fill_table();
 	} else if (!ok_.enabled()) {
 		return;
@@ -296,12 +296,17 @@ void MapSelect::fill_table() {
 	// This is the normal case
 
 	//  Fill it with all files we find in all directories.
-	FilenameSet files = g_fs->list_directory(curdir_);
+	assert(!curdir_.empty());
+	FilenameSet files;
+	for (const std::string& dir : curdir_) {
+		FilenameSet f = g_fs->list_directory(dir);
+		files.insert(f.begin(), f.end());
+	}
 
 	// If we are not at the top of the map directory hierarchy (we're not talking
 	// about the absolute filesystem top!) we manually add ".."
-	if (curdir_ != basedir_) {
-		maps_data_.push_back(MapData::create_parent_dir(curdir_));
+	if (curdir_.at(0) != basedir_) {
+		maps_data_.push_back(MapData::create_parent_dir(curdir_.at(0)));
 	} else {
 		// In the toplevel directory we also need to include add-on maps
 		for (auto& addon : AddOns::g_addons) {
@@ -401,7 +406,19 @@ void MapSelect::fill_table() {
 			if ((strcmp(fs_filename, ".") == 0) || (strcmp(fs_filename, "..") == 0)) {
 				continue;
 			}
-			maps_data_.push_back(MapData::create_directory(mapfilename));
+
+			MapData new_md = MapData::create_directory(mapfilename);
+			bool found = false;
+			for (MapData& md : maps_data_) {
+				if (md.maptype == MapData::MapType::kDirectory && md.localized_name == new_md.localized_name) {
+					found = true;
+					md.add(new_md);
+					break;
+				}
+			}
+			if (!found) {
+				maps_data_.push_back(new_md);
+			}
 		}
 	}
 

--- a/src/ui_fsmenu/mapselect.cc
+++ b/src/ui_fsmenu/mapselect.cc
@@ -410,7 +410,8 @@ void MapSelect::fill_table() {
 			MapData new_md = MapData::create_directory(mapfilename);
 			bool found = false;
 			for (MapData& md : maps_data_) {
-				if (md.maptype == MapData::MapType::kDirectory && md.localized_name == new_md.localized_name) {
+				if (md.maptype == MapData::MapType::kDirectory &&
+				    md.localized_name == new_md.localized_name) {
 					found = true;
 					md.add(new_md);
 					break;

--- a/src/ui_fsmenu/mapselect.h
+++ b/src/ui_fsmenu/mapselect.h
@@ -80,7 +80,7 @@ private:
 	Widelands::Map::ScenarioTypes scenario_types_;
 
 	const std::string basedir_;
-	std::string curdir_;
+	std::vector<std::string> curdir_;
 
 	GameSettingsProvider* settings_;
 	GameController* ctrl_;

--- a/src/wui/mapdata.cc
+++ b/src/wui/mapdata.cc
@@ -30,7 +30,7 @@ MapData::MapData(const std::string& init_filename,
                  const std::string& init_author,
                  const MapData::MapType& init_maptype,
                  const MapData::DisplayType& init_displaytype)
-   : filename(init_filename),
+   : filenames({init_filename}),
      name(init_localized_name),
      localized_name(init_localized_name),
      authors(init_author),
@@ -39,13 +39,14 @@ MapData::MapData(const std::string& init_filename,
      height(0),
      maptype(init_maptype),
      displaytype(init_displaytype) {
+	assert(!filenames.empty());
 }
 
 MapData::MapData(const Widelands::Map& map,
                  const std::string& init_filename,
                  const MapData::MapType& init_maptype,
                  const MapData::DisplayType& init_displaytype)
-   : MapData(init_filename,
+   : MapData({init_filename},
              _("No Name"),
              map.get_author().empty() ? _("No Author") : map.get_author(),
              init_maptype,
@@ -93,8 +94,8 @@ bool MapData::compare_names(const MapData& other) const {
 	std::string other_name;
 	switch (displaytype) {
 	case MapData::DisplayType::kFilenames:
-		this_name = filename;
-		other_name = other.filename;
+		this_name = filenames.at(0);
+		other_name = other.filenames.at(0);
 		break;
 
 	case MapData::DisplayType::kMapnames:
@@ -139,6 +140,12 @@ bool MapData::compare_size(const MapData& other) const {
 	return height < other.height;
 }
 
+void MapData::add(const MapData& md) {
+	assert(maptype == MapType::kDirectory);
+	assert(md.maptype == MapType::kDirectory);
+	filenames.insert(filenames.end(), md.filenames.begin(), md.filenames.end());
+}
+
 // static
 MapData MapData::create_parent_dir(const std::string& current_dir) {
 	std::string filename = FileSystem::fs_dirname(current_dir);
@@ -157,7 +164,7 @@ MapData MapData::create_parent_dir(const std::string& current_dir) {
 			}
 		}
 	}
-	return MapData(filename, parent_name());
+	return MapData({filename}, parent_name());
 }
 
 // static
@@ -187,7 +194,7 @@ MapData MapData::create_directory(const std::string& directory) {
 	} else if (directory == kMapsDir + "/" + kDownloadedMapsDir) {
 		/** TRANSLATORS: Directory name for downloaded maps in map selection */
 		localized_name = _("Downloaded Maps");
-	} else if (directory.compare(0, kAddOnDir.size(), kAddOnDir) == 0) {
+	} else if (starts_with(directory, kAddOnDir)) {
 		std::string addon = directory.substr(kAddOnDir.size() + 1);
 		addon = addon.substr(0, addon.find('/'));
 		std::unique_ptr<i18n::GenericTextdomain> td(AddOns::create_textdomain_for_addon(addon));
@@ -204,5 +211,5 @@ MapData MapData::create_directory(const std::string& directory) {
 			}
 		}
 	}
-	return MapData(directory, localized_name);
+	return MapData({directory}, localized_name);
 }

--- a/src/wui/mapdata.h
+++ b/src/wui/mapdata.h
@@ -48,7 +48,10 @@ public:
 	        const MapData::DisplayType& init_displaytype);
 
 	/// For directories
-	MapData(const std::string& init_filename, const std::string& init_localized_name);
+	MapData(const std::string& init_filenames, const std::string& init_localized_name);
+
+	/// Add a second directory path to this directory entry.
+	void add(const MapData& md);
 
 	/// The localized name of the parent directory
 	static std::string parent_name();
@@ -67,7 +70,7 @@ public:
 	[[nodiscard]] bool compare_players(const MapData& other) const;
 	[[nodiscard]] bool compare_size(const MapData& other) const;
 
-	std::string filename;
+	std::vector<std::string> filenames;
 	std::string name;
 	std::string localized_name;
 	MapAuthorData authors;

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -122,7 +122,7 @@ void MapDetails::layout() {
 bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool render_minimap) {
 	clear();
 	name_ = mapdata.name;
-	last_map_ = mapdata.filename;
+	last_map_ = mapdata.filenames.at(0);
 	bool loadable = true;
 	// Show directory information
 	if (mapdata.maptype == MapData::MapType::kDirectory) {
@@ -201,7 +201,7 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
 			} else {
 				egbase_.cleanup_for_load();
 				std::unique_ptr<Widelands::MapLoader> ml(
-				   egbase_.mutable_map()->get_correct_loader(mapdata.filename));
+				   egbase_.mutable_map()->get_correct_loader(mapdata.filenames.at(0)));
 				try {
 					if (ml != nullptr &&
 					    0 == ml->load_map_for_render(egbase_, &egbase_.enabled_addons())) {

--- a/src/wui/maptable.cc
+++ b/src/wui/maptable.cc
@@ -58,7 +58,7 @@ void MapTable::fill(const std::vector<MapData>& entries, MapData::DisplayType ty
 			if (type == MapData::DisplayType::kFilenames) {
 				set_column_title(1, _("Filename"));
 				te.set_picture(1, g_image_cache->get(picture),
-				               FileSystem::filename_without_ext(mapdata.filename.c_str()));
+				               FileSystem::filename_without_ext(mapdata.filenames.at(0).c_str()));
 			} else {
 				set_column_title(1, _("Map Name"));
 				if (type == MapData::DisplayType::kMapnames) {


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
New feature

**Issue(s) closed**
Follow-up to #5635: Merge directories with the same name in the map select UI

**To reproduce**
1. Install add-ons "Artifacts Race", "Tiperary", and "Call of Death"
2. Switch language to English so all localized dirnames are the same
3. Open the map select UI
4. In master, you will see three directories called "Add-On Maps" containing one map each. In this branch, you will see one directory of this name containing three maps.

**How it works**
Applies to both main menu mapselect and editor. Only directories with the same localized name are merged; differently translated directories are not merged.

**Possible regressions**
Navigating around the main menu map select, editor load, and editor save windows.

**Screenshots**
![grafik](https://user-images.githubusercontent.com/48293446/215265977-f431c129-ef06-4a08-82da-36b6fa8873a0.png)
![grafik](https://user-images.githubusercontent.com/48293446/215265984-6804d75d-c0ef-4743-8a71-efa46cedfcec.png)
