### PR TITLE
Workflow improvements

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -14,7 +14,6 @@ if [ "${GITHUB_JOB}" = "testsuite" ]; then
   ADD_PKG_LIST="
     ${CXX} \
     libwayland-egl1-mesa  \
-    linux-generic \
     mesa-utils  \
     xserver-xorg  \
     xserver-xorg-core \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
   push:
-    branches: [ master, workflow_improvements ]
+    branches: [ master ]
 
 jobs:
   # This job runs multiple smaller checks where having several jobs would be overkill.
@@ -509,7 +509,7 @@ jobs:
           git push --delete origin latest   || echo "No latest tag to delete"
           git tag --force latest HEAD
           git push --tags origin
-
+          
           echo "These builds are automatically generated from master. " >> release_notes
           echo "## Latest changes" >> release_notes
           # Print changelog from last 10 commits
@@ -517,7 +517,7 @@ jobs:
           echo "<details><summary>Original filenames</summary><pre>" >> release_notes
           cat artifacts.list >> release_notes
           echo "</pre></details>" >> release_notes
-
+          
           gh release create latest         \
             --prerelease                   \
             --notes-file release_notes     \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -278,7 +278,7 @@ jobs:
       run: |
         choco install innosetup
         # Cache should have been populated by vcpkg-packages job
-        ./install-dependencies.sh vcpkg --triplet=${{ env.VCPKG_TARGET_TRIPLET }} --only-binarycaching
+        ./install-dependencies.sh vcpkg --triplet=${{ env.VCPKG_TARGET_TRIPLET }}
       shell: bash
     - name: Configure MSVC development console
       uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
   push:
-    branches: [ master ]
+    branches: [ master, workflow_improvemnts ]
 
 jobs:
   # This job runs multiple smaller checks where having several jobs would be overkill.
@@ -207,9 +207,46 @@ jobs:
     - name: Testsuite
       run: ./regression_test.py -b build/src/widelands
 
+  vcpkg-packages:
+    # If the vcpkg cache is not present, build packages and populate the cache
+    # Then the windows-msvc jobs can install dependencies faster
+    strategy:
+      matrix:
+        arch: [x64, x86]
+    name: Build vcpkg packages for ${{ matrix.arch }}
+    runs-on: windows-2022
+    outputs:
+      vcpkg_key: ${{ steps.prepare.outputs.vcpkg_key }}
+    env:
+      VCPKG_ROOT: C:\vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
+      VCPKG_TARGET_TRIPLET: ${{ matrix.arch }}-windows-static
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Create cache directory
+      id: prepare
+      run: |
+        mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
+        cd ${{ env.VCPKG_ROOT }}
+        HEAD=$(git rev-parse --short HEAD)
+        echo "vcpkg_key=${{ hashFiles( './install-dependencies.sh' ) }}-${HEAD}" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Restore vcpkg and its artifacts.
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+        key: |
+          ${{ steps.prepare.outputs.vcpkg_key }}-${{ matrix.arch }}
+    - name: Building packages
+      run: ./install-dependencies.sh vcpkg --triplet=${{ env.VCPKG_TARGET_TRIPLET }}
+      shell: bash
+
   windows-msvc:
     # inspired by https://github.com/lukka/CppCMakeVcpkgTemplate/blob/main/.github/workflows/hosted-pure-workflow.yml
-    needs: [clang_tidy, documentation, codecheck, misc_sanity_checks, lua_style]
+    needs: [clang_tidy, documentation, codecheck, misc_sanity_checks, lua_style, vcpkg-packages]
     strategy:
       matrix:
         config: [Debug, Release]
@@ -230,19 +267,19 @@ jobs:
       id: prepare
       run: |
         mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-        cd ${{ env.VCPKG_ROOT }}
-        echo "head=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Restore vcpkg and its artifacts.
       uses: actions/cache@v3
       with:
         path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
         key: |
-          ${{ hashFiles( '.github/workflows/build.yaml' ) }}-${{ steps.prepare.outputs.head }}-${{ matrix.arch }}
+          ${{needs.vcpkg-packages.outputs.vcpkg_key}}-${{ matrix.arch }}
     - name: Installing dependencies
       run: |
         choco install innosetup
-        vcpkg install --disable-metrics --triplet=${{ env.VCPKG_TARGET_TRIPLET }} asio gettext libpng icu glbinding sdl2 sdl2-ttf sdl2-mixer[libvorbis,libflac,mpg123] sdl2-image[libjpeg-turbo,tiff] graphite2 harfbuzz opusfile libwebp
+        # Cache should have been populated by vcpkg-packages job
+        ./install-dependencies.sh vcpkg --triplet=${{ env.VCPKG_TARGET_TRIPLET }} --only-binarycaching
+      shell: bash
     - name: Configure MSVC development console
       uses: ilammy/msvc-dev-cmd@v1
       with:
@@ -472,7 +509,7 @@ jobs:
           git push --delete origin latest   || echo "No latest tag to delete"
           git tag --force latest HEAD
           git push --tags origin
-          
+
           echo "These builds are automatically generated from master. " >> release_notes
           echo "## Latest changes" >> release_notes
           # Print changelog from last 10 commits
@@ -480,7 +517,7 @@ jobs:
           echo "<details><summary>Original filenames</summary><pre>" >> release_notes
           cat artifacts.list >> release_notes
           echo "</pre></details>" >> release_notes
-          
+
           gh release create latest         \
             --prerelease                   \
             --notes-file release_notes     \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
   push:
-    branches: [ master, workflow_improvemnts ]
+    branches: [ master, workflow_improvements ]
 
 jobs:
   # This job runs multiple smaller checks where having several jobs would be overkill.

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Installing python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
     - name: Installing dependencies

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -39,6 +39,7 @@ echo " "
 echo "Windows:"
 echo "* msys32    MSys 32bit"
 echo "* msys64    MSys 64bit"
+echo "* vcpkg     MSVC"
 echo " "
 echo "Mac:"
 echo "*homebrew   Homebrew"
@@ -161,7 +162,7 @@ elif [ "$DISTRO" = "mageia" ]; then
 
 elif [ "$DISTRO" = "debian" ]; then
    echo "Installing dependencies for Debian/Ubuntu Linux, Linux Mint..."
-   sudo apt install $@ git cmake g++ gcc gettext libasio-dev libglew-dev libpng-dev libsdl2-dev \
+   sudo apt-get install $@ git cmake g++ gcc gettext libasio-dev libglew-dev libpng-dev libsdl2-dev \
     libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev python3 zlib1g-dev libminizip-dev
 
 elif [ "$DISTRO" = "freebsd" ]; then
@@ -199,6 +200,12 @@ elif [ "$DISTRO" = "void" ]; then
    echo "Installing dependencies for Void..."
    sudo xbps-install $@ asio git gcc make cmake gettext glew-devel icu-devel SDL2-devel \
      SDL2_ttf-devel SDL2_image-devel SDL2_mixer-devel minizip-devel pkg-config
+
+elif [ "$DISTRO" = "vcpkg" ]; then
+   echo "Installing dependencies for vcpkg..."
+   vcpkg install --disable-metrics $@ asio gettext libpng icu glbinding sdl2 sdl2-ttf \
+     sdl2-mixer[libvorbis,libflac,mpg123] sdl2-image[libjpeg-turbo,tiff] graphite2 \
+     harfbuzz opusfile libwebp
 
 elif [ -z "$DISTRO" ]; then
    echo "ERROR. Unable to detect your operating system."


### PR DESCRIPTION
**Type of change**
Maintenance

**Issue(s) closed**
Re https://github.com/widelands/widelands/pull/5794#issuecomment-1449085994

**New behavior**
- (Should) resolve workflow warning in i18n.yml
- Use apt-get instead of apt
- Remove unused `linux-generic` dependency
- Use `install-dependencies.sh` also for vcpkg packages
- Check / Build vcpkg cache before compilation to reduce overall time.

**How it works**
The vcpkg cache is built in a separate job. If it is already present, fine the job finishes in ~2 minutes. Otherwise the packages are built and stored in the cache, if the Widelands compilation then fails, the cache will still be valid for the next run.
When the main compilation jobs start, the packages are already available, reducing the msvc build time.
