### PR TITLE
Add timeout support to regression_test.py and improve output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,7 +168,6 @@ jobs:
       ASAN_OPTIONS: 'detect_leaks=0'
       LSAN_OPTIONS: 'suppressions=${{ github.workspace }}/asan_3rd_party_leaks'
       CXX: '${{ matrix.compiler }}'
-      CONF: '${{ matrix.config }}'
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -208,7 +207,7 @@ jobs:
     - name: Testsuite
       run: |
         TIMEOUT=""
-        if [ "$CONF" = "Debug" ]
+        if [ "${{ matrix.config }}" = "Debug" ]
         then
           TIMEOUT="-t 20"
         fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,6 +168,7 @@ jobs:
       ASAN_OPTIONS: 'detect_leaks=0'
       LSAN_OPTIONS: 'suppressions=${{ github.workspace }}/asan_3rd_party_leaks'
       CXX: '${{ matrix.compiler }}'
+      CONF: '${{ matrix.config }}'
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -205,7 +206,13 @@ jobs:
         build/src/website/wl_map_object_info temp_web || [ $? -eq 2 ]
         build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf || [ $? -eq 2 ]
     - name: Testsuite
-      run: ./regression_test.py -b build/src/widelands
+      run: |
+        TIMEOUT=""
+        if [ "$CONF" = "Debug" ]
+        then
+          TIMEOUT="-t 20"
+        fi
+        ./regression_test.py -b build/src/widelands $TIMEOUT
 
   vcpkg-packages:
     # If the vcpkg cache is not present, build packages and populate the cache

--- a/regression_test.py
+++ b/regression_test.py
@@ -229,13 +229,19 @@ def parse_args():
 
     if args.binary is None:
         potential_binaries = (
-            glob("widelands") +
-            glob("src/widelands") +
-            glob("../*/src/widelands")
+            glob(os.path.join(os.curdir, "widelands")) +
+            glob(os.path.join(os.path.dirname(__file__), "widelands")) +
+            glob(os.path.join("src", "widelands")) +
+            glob(os.path.join("..", "*", "src", "widelands"))
         )
-        if not potential_binaries:
+        if potential_binaries:
+            args.binary = potential_binaries[0]
+        elif "which" in dir(shutil):
+            args.binary = shutil.which("widelands")
+
+        if args.binary is None:
             p.error("No widelands binary found. Please specify with -b.")
-        args.binary = potential_binaries[0]
+
     return args
 
 


### PR DESCRIPTION
**Type of change**
Bugfix / New feature

**Issue(s) closed**
Fixes #1996
Fixes #5805

**New behavior**
 - Test cases are stopped and marked as failed if they don't finish within the set timeout. Default is 10 minutes.
 - Debug builds in workflow runs use 20 minutes timeout, as was found necessary.
 - Elapsed time is reported for each test case.
 - The name of the test case is flushed to stdout before the Widelands binary is started to make it easier to identify which test is running.
 - Tests are run in a deterministic order. (all `glob()`s are now `sorted()`)
 - Finding the Widelands binary in the top level of the source tree actually works.

**Possible regressions**
Test suite problems