### PR TITLE
Fix window Z ordering priorities

### DIFF
--- a/src/editor/ui_menus/main_menu_load_or_save_map.cc
+++ b/src/editor/ui_menus/main_menu_load_or_save_map.cc
@@ -121,7 +121,7 @@ MainMenuLoadOrSaveMap::MainMenuLoadOrSaveMap(EditorInteractive& parent,
 	display_mode_.selected.connect([this]() { fill_table(); });
 	table_.cancel.connect([this]() { die(); });
 
-	set_flag(UI::Panel::pf_always_on_top, true);
+	set_z(UI::Panel::ZOrder::kFullscreenWindow);
 }
 
 bool MainMenuLoadOrSaveMap::compare_players(uint32_t rowa, uint32_t rowb) {

--- a/src/ui_basic/dropdown.cc
+++ b/src/ui_basic/dropdown.cc
@@ -133,7 +133,7 @@ BaseDropdown::BaseDropdown(UI::Panel* parent,
 	list_->set_linked_dropdown(this);
 
 	list_->set_visible(false);
-	list_->set_flag(UI::Panel::pf_always_on_top, true);
+	list_->set_z(UI::Panel::ZOrder::kDropdown);
 	button_box_.add(&display_button_, UI::Box::Resizing::kExpandBoth);
 	display_button_.sigclicked.connect([this]() {
 		toggle_list();

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -608,14 +608,18 @@ int Panel::get_inner_h() const {
 /**
  * Make this panel the top-most panel in the parent's Z-order.
  */
-void Panel::move_to_top() {
+void Panel::move_to_top(const bool on_top_of_equal_z) {
 	if (parent_ == nullptr) {
 		return;
 	}
 	/* If all siblings above us are permanently on top, skip. */
 	bool all_on_top = true;
 	for (Panel* p = parent_->first_child_; p != this && all_on_top; p = p->next_) {
-		all_on_top &= p->get_flag(pf_always_on_top);
+		if (on_top_of_equal_z) {
+			all_on_top &= (static_cast<uint8_t>(p->get_z()) > static_cast<uint8_t>(get_z()));
+		} else {
+			all_on_top &= (static_cast<uint8_t>(p->get_z()) >= static_cast<uint8_t>(get_z()));
+		}
 	}
 	if (all_on_top) {
 		return;
@@ -768,9 +772,7 @@ void Panel::do_think() {
 		return;
 	}
 
-	if (get_flag(pf_always_on_top)) {
-		move_to_top();
-	}
+	move_to_top(false);
 
 	if (thinks()) {
 		think();

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -77,8 +77,6 @@ public:
 		pf_child_die = 1 << 4,     ///< a child needs to die
 		pf_visible = 1 << 5,       ///< render the panel
 		pf_can_focus = 1 << 6,     ///< can receive the keyboard focus
-		// This panel will always be displayed on top of other panels.
-		pf_always_on_top = 1 << 7,
 		/// children should snap to the edges of this panel
 		pf_dock_windows_to_edges = 1 << 8,
 		/// whether any change in the desired size should propagate to the actual size
@@ -93,6 +91,15 @@ public:
 		pf_hide_all_overlays = 1 << 13,
 		// Other panels will snap to this one.
 		pf_snap_target = 1 << 14,
+	};
+	/** The Z ordering of overlapping panels; highest value is always on top. */
+	enum class ZOrder : uint8_t {
+		kAlwaysInBackground = 0,  ///< Always in the background.
+		kDefault = 5,             ///< No special handling.
+		kPinned = 10,             ///< Pinned by the user.
+		kInfoPanel = 20,          ///< The info panel and toolbar.
+		kFullscreenWindow = 30,   ///< A fullscreen window.
+		kDropdown = 50,           ///< Dropdown lists.
 	};
 
 	Panel(Panel* nparent,
@@ -254,7 +261,13 @@ public:
 		return last_child_;
 	}
 
-	void move_to_top();
+	void move_to_top(bool on_top_of_equal_z = true);
+	[[nodiscard]] virtual ZOrder get_z() const {
+		return z_order_;
+	}
+	void set_z(ZOrder z) {
+		z_order_ = z;
+	}
 
 	// Drawing, visibility
 	bool is_visible() const {
@@ -565,6 +578,7 @@ private:
 	uint8_t panel_snap_distance_{0U};
 	int desired_w_;
 	int desired_h_;
+	ZOrder z_order_{ZOrder::kDefault};
 
 	friend struct ModalGuard;
 

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -98,6 +98,7 @@ public:
 		kAlwaysInBackground = 0,  ///< Always in the background.
 		kDefault = 8,             ///< No special handling.
 		kPinned = 16,             ///< Pinned by the user.
+		kConfirmation = 24,       ///< A confirmation prompt.
 		kInfoPanel = 32,          ///< The info panel and toolbar.
 		kFullscreenWindow = 64,   ///< A fullscreen window.
 		kDropdown = 128,          ///< Dropdown lists.

--- a/src/ui_basic/panel.h
+++ b/src/ui_basic/panel.h
@@ -92,14 +92,15 @@ public:
 		// Other panels will snap to this one.
 		pf_snap_target = 1 << 14,
 	};
+
 	/** The Z ordering of overlapping panels; highest value is always on top. */
 	enum class ZOrder : uint8_t {
 		kAlwaysInBackground = 0,  ///< Always in the background.
-		kDefault = 5,             ///< No special handling.
-		kPinned = 10,             ///< Pinned by the user.
-		kInfoPanel = 20,          ///< The info panel and toolbar.
-		kFullscreenWindow = 30,   ///< A fullscreen window.
-		kDropdown = 50,           ///< Dropdown lists.
+		kDefault = 8,             ///< No special handling.
+		kPinned = 16,             ///< Pinned by the user.
+		kInfoPanel = 32,          ///< The info panel and toolbar.
+		kFullscreenWindow = 64,   ///< A fullscreen window.
+		kDropdown = 128,          ///< Dropdown lists.
 	};
 
 	Panel(Panel* nparent,

--- a/src/ui_basic/window.h
+++ b/src/ui_basic/window.h
@@ -95,6 +95,13 @@ public:
 	virtual void restore();
 	virtual void minimize();
 
+	[[nodiscard]] ZOrder get_z() const override {
+		if (is_pinned()) {
+			return std::max(Panel::ZOrder::kPinned, NamedPanel::get_z());
+		}
+		return NamedPanel::get_z();
+	}
+
 	bool is_pinned() const {
 		return pinned_;
 	}

--- a/src/wui/actionconfirm.cc
+++ b/src/wui/actionconfirm.cc
@@ -179,6 +179,7 @@ ActionConfirm::ActionConfirm(InteractivePlayer& parent,
 	                         (checkbox_ != nullptr ? checkbox_->get_h() + padding : 0));
 	set_inner_size(main_box->get_w() + 2 * padding, main_box->get_h() + 2 * padding);
 
+	set_z(UI::Panel::ZOrder::kConfirmation);
 	center_to_parent();
 	cancelbtn->center_mouse();
 

--- a/src/wui/game_exit_confirm_box.cc
+++ b/src/wui/game_exit_confirm_box.cc
@@ -26,6 +26,7 @@ GameExitConfirmBox::GameExitConfirmBox(UI::Panel& p, InteractiveGameBase& i)
                         /** TRANSLATORS: Window label when "Exit game" has been pressed */
                         _("Exit Game Confirmation"),
                         _("Are you sure you wish to exit this game?")) {
+	set_z(UI::Panel::ZOrder::kConfirmation);
 }
 
 // TODO(GunChleoc): Arabic: Buttons need more height for Arabic
@@ -35,6 +36,7 @@ GameExitConfirmBox::GameExitConfirmBox(UI::Panel& parent,
                                        const std::string& message)
    : UI::WLMessageBox(&parent, UI::WindowStyle::kWui, title, message, MBoxType::kOkCancel),
      igb_(gb) {
+	set_z(UI::Panel::ZOrder::kConfirmation);
 }
 
 void GameExitConfirmBox::clicked_ok() {

--- a/src/wui/game_main_menu_save_game.cc
+++ b/src/wui/game_main_menu_save_game.cc
@@ -142,7 +142,7 @@ GameMainMenuSaveGame::GameMainMenuSaveGame(InteractiveGameBase& parent,
 	load_or_save_.select_by_name(parent.game().save_handler().get_cur_filename());
 
 	center_to_parent();
-	set_flag(UI::Panel::pf_always_on_top, true);
+	set_z(UI::Panel::ZOrder::kFullscreenWindow);
 
 	if (type_ == Type::kSave) {
 		filename_editbox_.focus();

--- a/src/wui/info_panel.cc
+++ b/src/wui/info_panel.cc
@@ -170,7 +170,7 @@ InfoPanel::InfoPanel(InteractiveBase& ib)
                   UI::Align::kRight),
 
      draw_real_time_(get_config_bool("game_clock", true)) {
-	set_flag(UI::Panel::pf_always_on_top, true);
+	set_z(UI::Panel::ZOrder::kInfoPanel);
 	text_fps_.set_handle_mouse(true);
 	snap_target_panel_.set_snap_target(true);
 	int mode = get_config_int("toolbar_pos", 0);
@@ -490,7 +490,8 @@ void InfoPanel::think() {
 	}
 
 	for (UI::Panel* p = ibase_.get_first_child(); p != nullptr; p = p->get_next_sibling()) {
-		if (!p->get_flag(UI::Panel::pf_always_on_top) && p->get_x() < snap_target_panel_.get_w() &&
+		if (static_cast<uint8_t>(p->get_z()) < static_cast<uint8_t>(UI::Panel::ZOrder::kInfoPanel) &&
+		    p->get_x() < snap_target_panel_.get_w() &&
 		    (on_top_ ? (p->get_y() < snap_target_panel_.get_y() + snap_target_panel_.get_h()) :
                      (p->get_y() + p->get_h() > snap_target_panel_.get_y()))) {
 			if (UI::Window* w = dynamic_cast<UI::Window*>(p); w != nullptr && !w->moved_by_user()) {


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5808

**New behavior**
Z ordering of panels now has a clear priority that is always enforced: 
Dropdowns > Fullscreen windows > Info Panel > Pinned windows > Other windows

**Possible regressions**
Incorrect or frozen Z ordering of panels