### PR TITLE
consider team score for leaving team and some fixes and optimisations

### DIFF
--- a/src/ai/ai_help_structs.cc
+++ b/src/ai/ai_help_structs.cc
@@ -1130,12 +1130,12 @@ int32_t PlayersStrengths::get_team_average_score(const Widelands::TeamNumber tn,
 		return 0;
 	}
 
-	assert(exclude_pn == 0 || get_team_numer(exclude_pn) == tn);
+	assert(exclude_pn == 0 || get_team_number(exclude_pn) == tn);
 	assert(team_scores_sum_.count(tn) == 1);
 
 	const bool exclude = exclude_pn != 0;
-	const int32_t team_sc = team_scores_sum_[tn] - exclude ? get_diplo_score(exclude_pn) : 0;
-	const uint8_t n_included = members_in_team(tn) - exclude ? 1 : 0;
+	const int32_t team_sc = team_scores_sum_[tn] - (exclude ? get_diplo_score(exclude_pn) : 0);
+	const uint8_t n_included = members_in_team(tn) - (exclude ? 1 : 0);
 	return team_sc / n_included;
 }
 

--- a/src/ai/ai_help_structs.cc
+++ b/src/ai/ai_help_structs.cc
@@ -1074,8 +1074,8 @@ void PlayersStrengths::recalculate_team_power() {
 			}
 			++team_members_[item.second.team_number];
 
-			if(item.second.team_number == this_player_team &&
-			   item.second.players_diplomacy_score < worst_ally_score_) {
+			if (item.second.team_number == this_player_team &&
+			    item.second.players_diplomacy_score < worst_ally_score_) {
 				worst_ally_score_ = item.second.players_diplomacy_score;
 				worst_ally_ = item.first;
 			}

--- a/src/ai/ai_help_structs.cc
+++ b/src/ai/ai_help_structs.cc
@@ -1154,7 +1154,7 @@ void PlayersStrengths::join_or_invite(const Widelands::PlayerNumber pn,
 
 	bool invite = false;  // Only to check fall through case
 
-	if (my_team_sc < other_team_sc) {
+	if (my_team_sc < other_team_sc && can_join) {
 		if (other_alone && (me_alone || my_team_sc > static_cast<int>(RNG::static_rand(20)))) {
 			// If we're both alone, we try to be polite and invite.
 			// Or if we have a good enough team, we won't leave it for a lone player, but we try to
@@ -1170,15 +1170,6 @@ void PlayersStrengths::join_or_invite(const Widelands::PlayerNumber pn,
 				return;
 			}
 		} else {  // Other has team, or own team is less desirable than other player alone
-			if (!can_join) {
-				verb_log_dbg_time(gametime,
-				                  "AI Diplomacy: Player(%d)%s cannot request to join player (%d) with "
-				                  "diploscore %d%s\n",
-				                  static_cast<unsigned int>(this_player_number), myts_s.c_str(),
-				                  static_cast<unsigned int>(pn), get_diplo_score(pn), ots_s.c_str());
-				return;
-			}
-
 			verb_log_dbg_time(
 			   gametime,
 			   "AI Diplomacy: Player(%d)%s requests to join player (%d) with diploscore %d%s\n",
@@ -1188,7 +1179,7 @@ void PlayersStrengths::join_or_invite(const Widelands::PlayerNumber pn,
 			set_last_time_requested(gametime, pn);
 			return;
 		}
-	} else {  // Own team is more desirable
+	} else {  // Own team is more desirable, or everyone else is teamed up against us
 		if (other_alone) {
 			verb_log_dbg_time(gametime,
 			                  "AI Diplomacy: Player(%d)%s declines to invite player (%d) with "
@@ -1197,14 +1188,8 @@ void PlayersStrengths::join_or_invite(const Widelands::PlayerNumber pn,
 			                  static_cast<unsigned int>(pn), get_diplo_score(pn));
 			return;
 		}
-		if (!can_invite) {
-			verb_log_dbg_time(gametime,
-			                  "AI Diplomacy: Player(%d)%s cannot invite player (%d) with diploscore "
-			                  "%d%s\n",
-			                  static_cast<unsigned int>(this_player_number), myts_s.c_str(),
-			                  static_cast<unsigned int>(pn), get_diplo_score(pn), ots_s.c_str());
-			return;
-		}
+
+		// !other_alone means can_invite must be true
 		invite = true;  // Handle in fall through with above
 	}
 

--- a/src/ai/ai_help_structs.h
+++ b/src/ai/ai_help_structs.h
@@ -911,6 +911,8 @@ public:
 	                                             Widelands::PlayerNumber exclude_pn = 0);
 	[[nodiscard]] uint32_t team_power(Widelands::TeamNumber tn);
 	[[nodiscard]] uint8_t players_active() const;
+	[[nodiscard]] Widelands::PlayerNumber get_worst_ally() const;
+	[[nodiscard]] int32_t get_worst_ally_score() const;
 	[[nodiscard]] bool any_enemy_seen_lately(const Time&);
 	void set_update_time(const Time&);
 	const Time& get_update_time();
@@ -926,6 +928,8 @@ private:
 
 	// Number of team, sum of players' strength
 	std::map<Widelands::TeamNumber, uint32_t> team_powers_;
+	// Number of team, sum of players' diploscores
+	std::map<Widelands::TeamNumber, uint32_t> team_scores_sum_;
 	// Number of team, number of members
 	std::map<Widelands::TeamNumber, uint8_t> team_members_;
 	// number of active players (not defeated)
@@ -934,6 +938,11 @@ private:
 	Time update_time;
 	Widelands::PlayerNumber this_player_number;
 	Widelands::PlayerNumber this_player_team;
+
+	// Member of own team with lowest diploscore
+	Widelands::PlayerNumber worst_ally_;
+	// Lowest member diploscore in own team
+	int32_t worst_ally_score_;
 };
 
 // This is a wrapper around map of <Flag coords hash:distance from flag to nearest warehouse>

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3380,23 +3380,24 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 	if (!have_plan && player_statistics.get_worst_ally_score() < -15) {
 		const int32_t team_vs_worst = my_team_score + player_statistics.get_worst_ally_score();
 		if ((team_vs_worst > 0 && player_statistics.members_in_team(mytn) > 3) ||
-			    (team_vs_worst > -10 &&
-			     RNG::static_rand(player_statistics.members_in_team(mytn) * 2 - 2) > 0)) {
-				verb_log_dbg_time(gametime,
-				                  "AI Diplomacy: Player(%d) tolerates player (%d) with diploscore "
-				                  "%d in team (%d)%s\n",
-				                  static_cast<unsigned int>(mypn),
-		                        static_cast<unsigned int>(player_statistics.get_worst_ally()),
-				                  player_statistics.get_worst_ally_score(),
-				                  static_cast<unsigned int>(mytn), myts_s.c_str());
+		    (team_vs_worst > -10 &&
+		     RNG::static_rand(player_statistics.members_in_team(mytn) * 2 - 2) > 0)) {
+			verb_log_dbg_time(gametime,
+			                  "AI Diplomacy: Player(%d) tolerates player (%d) with diploscore "
+			                  "%d in team (%d)%s\n",
+			                  static_cast<unsigned int>(mypn),
+			                  static_cast<unsigned int>(player_statistics.get_worst_ally()),
+			                  player_statistics.get_worst_ally_score(),
+			                  static_cast<unsigned int>(mytn), myts_s.c_str());
 		} else {
 			planned_action = Widelands::DiplomacyAction::kLeaveTeam;
 			have_plan = true;
 			plan_priority = std::max(0, -team_vs_worst);
 			if (g_verbose) {
-				planned_log_append_text = format("%s because of player (%d) with diploscore %d",
-			                  myts_s, static_cast<unsigned int>(player_statistics.get_worst_ally()),
-			                  player_statistics.get_worst_ally());
+				planned_log_append_text =
+				   format("%s because of player (%d) with diploscore %d", myts_s,
+				          static_cast<unsigned int>(player_statistics.get_worst_ally()),
+				          player_statistics.get_worst_ally());
 			}
 		}
 	}
@@ -3452,33 +3453,33 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 
 	// Execute only one action that changes team line-ups
 	if (have_plan) {
-		assert (planned_action == Widelands::DiplomacyAction::kLeaveTeam ||
-		        planned_action == Widelands::DiplomacyAction::kAcceptInvite ||
-		        planned_action == Widelands::DiplomacyAction::kAcceptJoin);
+		assert(planned_action == Widelands::DiplomacyAction::kLeaveTeam ||
+		       planned_action == Widelands::DiplomacyAction::kAcceptInvite ||
+		       planned_action == Widelands::DiplomacyAction::kAcceptJoin);
 		if (g_verbose) {
 			std::string action_str = "join request";
 			switch (planned_action) {
-				case Widelands::DiplomacyAction::kLeaveTeam:
-					verb_log_dbg_time(gametime, "AI Diplomacy: Player(%d) leaves team (%d)%s.\n",
-					                  static_cast<unsigned int>(mypn), static_cast<unsigned int>(mytn),
-					                  planned_log_append_text.c_str());
-					break;
+			case Widelands::DiplomacyAction::kLeaveTeam:
+				verb_log_dbg_time(gametime, "AI Diplomacy: Player(%d) leaves team (%d)%s.\n",
+				                  static_cast<unsigned int>(mypn), static_cast<unsigned int>(mytn),
+				                  planned_log_append_text.c_str());
+				break;
 
-				case Widelands::DiplomacyAction::kAcceptInvite:
-					action_str = "invitation";
-					FALLS_THROUGH;
-				case Widelands::DiplomacyAction::kAcceptJoin:
-					verb_log_dbg_time(
-					   gametime,
-					   "AI Diplomacy: Player(%d)%s accepts the %s of player (%d) with diploscore %d%s.\n",
-					   static_cast<unsigned int>(mypn), myts_s.c_str(), action_str.c_str(),
-					   static_cast<unsigned int>(planned_opn), planned_other_score,
-					   planned_log_append_text.c_str());
-					break;
+			case Widelands::DiplomacyAction::kAcceptInvite:
+				action_str = "invitation";
+				FALLS_THROUGH;
+			case Widelands::DiplomacyAction::kAcceptJoin:
+				verb_log_dbg_time(
+				   gametime,
+				   "AI Diplomacy: Player(%d)%s accepts the %s of player (%d) with diploscore %d%s.\n",
+				   static_cast<unsigned int>(mypn), myts_s.c_str(), action_str.c_str(),
+				   static_cast<unsigned int>(planned_opn), planned_other_score,
+				   planned_log_append_text.c_str());
+				break;
 
-				default:
-					NEVER_HERE();
-					break;
+			default:
+				NEVER_HERE();
+				break;
 			}
 		}
 		game().send_player_diplomacy(mypn, planned_action, planned_opn);

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3389,10 +3389,11 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 
 	// Check for undesirable teammates
 	if (planned_action == kNoAction && player_statistics.get_worst_ally_score() < -15) {
-		const int32_t team_vs_worst = my_team_score + player_statistics.get_worst_ally_score();
-		if ((team_vs_worst > 0 && player_statistics.members_in_team(mytn) > 3) ||
-		    (team_vs_worst > -10 &&
-		     RNG::static_rand(player_statistics.members_in_team(mytn) * 2 - 2) > 0)) {
+		const uint8_t my_team_size = player_statistics.members_in_team(mytn);
+		const int32_t team_vs_worst =
+		   (my_team_size < 3 ? 0 : my_team_score) + player_statistics.get_worst_ally_score();
+		if ((team_vs_worst > 0 && my_team_size > 3) ||
+		    (team_vs_worst > -10 && RNG::static_rand(my_team_size * 2 - 2) > 0)) {
 			verb_log_dbg_time(gametime,
 			                  "AI Diplomacy: Player(%d) tolerates player (%d) with diploscore "
 			                  "%d in team (%d)%s\n",

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3426,7 +3426,9 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 		           other_player->team_number() == mytn && other_player->team_number() != 0) {
 			if (player_statistics.members_in_team(mytn) > 2) {
 				const int32_t team_vs_this = my_team_score + player_statistics.get_diplo_score(opn);
-				if (team_vs_this > 0 || (team_vs_this > -10 && RNG::static_rand(8) > 0)) {
+				if ((team_vs_this > 0 && player_statistics.members_in_team(mytn) > 3) ||
+				    (team_vs_this > -10 &&
+				     RNG::static_rand(player_statistics.members_in_team(mytn) * 2 - 2) > 0)) {
 					verb_log_dbg_time(
 					   gametime,
 					   "AI Diplomacy: Player(%d) tolerates player (%d) with diploscore %d in team (%d)%s\n",

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3483,18 +3483,21 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 					   "AI Diplomacy: Player(%d) replaces plan: old priority: %d, new priority: %d",
 					   static_cast<unsigned int>(mypn), plan_priority, priority);
 					if (planned_action != Widelands::DiplomacyAction::kLeaveTeam) {
-						verb_log_dbg_time(
-						   gametime,
-						   "AI Diplomacy: Player(%d)%s denies the %s of player (%d) with diploscore %d%s\n",
-						   static_cast<unsigned int>(mypn), myts_s.c_str(),
-						   planned_action == Widelands::DiplomacyAction::kAcceptInvite ? "invitation" : "join request",
-						   static_cast<unsigned int>(planned_opn), planned_other_score,
-							planned_log_append_text.c_str());
-						game().send_player_diplomacy(mypn,
-						                             (planned_action == Widelands::DiplomacyAction::kAcceptInvite ?
-                                                   Widelands::DiplomacyAction::kRefuseInvite :
-                                                   Widelands::DiplomacyAction::kRefuseJoin),
-						                             planned_opn);
+						verb_log_dbg_time(gametime,
+						                  "AI Diplomacy: Player(%d)%s denies the %s of player (%d) with "
+						                  "diploscore %d%s\n",
+						                  static_cast<unsigned int>(mypn), myts_s.c_str(),
+						                  planned_action == Widelands::DiplomacyAction::kAcceptInvite ?
+                                       "invitation" :
+                                       "join request",
+						                  static_cast<unsigned int>(planned_opn), planned_other_score,
+						                  planned_log_append_text.c_str());
+						game().send_player_diplomacy(
+						   mypn,
+						   (planned_action == Widelands::DiplomacyAction::kAcceptInvite ?
+                         Widelands::DiplomacyAction::kRefuseInvite :
+                         Widelands::DiplomacyAction::kRefuseJoin),
+						   planned_opn);
 					}
 				}
 				planned_action = pda.action == Widelands::DiplomacyAction::kInvite ?

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3368,9 +3368,8 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 
 			// consider only if we are not defeated and if not resulting in a team win
 			bool accept = !me_def &&
-			              std::max<uint8_t>(
-			                 1, player_statistics.members_in_team(
-			                       pda.action == Widelands::DiplomacyAction::kInvite ? other_tn : mytn)) <
+			              player_statistics.members_in_team(
+			                 pda.action == Widelands::DiplomacyAction::kInvite ? other_tn : mytn) <
 			                 player_statistics.players_active() - 1;
 
 			// accept if diploscore high, else accept only 50%

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3361,7 +3361,7 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 	// first.
 	// If alone, we may accept requests to join and cancel leaving.
 	// If defeated, just clean up by rejecting everything.
-	if (me->team_number() != 0 && (me_alone || me_def)) {
+	if (mytn != 0 && (me_alone || me_def)) {
 		planned_action = Widelands::DiplomacyAction::kLeaveTeam;
 		plan_priority = me_alone ? 0 : std::numeric_limits<int32_t>::max();
 		if (g_verbose) {

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3337,12 +3337,10 @@ void DefaultAI::check_flag_distances(const Time& gametime) {
 
 // Dealing with diplomacy actions
 void DefaultAI::diplomacy_actions(const Time& gametime) {
-	// Make sure we use reasonably up to date stats
-	update_player_stat(gametime);
 
 	const Widelands::PlayerNumber mypn = player_number();
 	const Widelands::Player* me = game().get_player(mypn);
-	const Widelands::TeamNumber mytn = player_statistics.get_team_number(mypn);
+	const Widelands::TeamNumber mytn = me->team_number();
 	const bool me_def = me->is_defeated();
 	const bool me_alone = player_statistics.get_is_alone(mypn);
 
@@ -3361,7 +3359,7 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 	// first.
 	// If alone, we may accept requests to join and cancel leaving.
 	// If defeated, just clean up by rejecting everything.
-	if (mytn != 0 && (me_alone || me_def)) {
+	if (me->team_number() != 0 && (me_alone || me_def)) {
 		planned_action = Widelands::DiplomacyAction::kLeaveTeam;
 		plan_priority = me_alone ? 0 : std::numeric_limits<int32_t>::max();
 		if (g_verbose) {

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -1155,7 +1155,7 @@ void DefaultAI::late_initialization() {
 		taskPool.push_back(std::make_shared<SchedulerTask>(
 		   std::max<Time>(
 		      gametime + kStatUpdateInterval * 4 + Duration(RNG::static_rand(5 * 60) * 1000),
-			   Time((10 + RNG::static_rand(10)) * 60 * 1000)),
+		      Time((10 + RNG::static_rand(10)) * 60 * 1000)),
 		   SchedulerTaskId::kDiplomacy, 7, "diplomacy actions"));
 	}
 
@@ -3345,8 +3345,8 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 	const bool me_alone = player_statistics.get_is_alone(mypn);
 
 	// TODO(tothxa): Check all uses whether it's safe to add an invalid value to the enum
-	constexpr Widelands::DiplomacyAction kNoAction = static_cast<Widelands::DiplomacyAction>(
-	                                                    std::numeric_limits<uint8_t>::max());
+	constexpr Widelands::DiplomacyAction kNoAction =
+	   static_cast<Widelands::DiplomacyAction>(std::numeric_limits<uint8_t>::max());
 	constexpr int32_t kNoScore = std::numeric_limits<int32_t>::min();
 
 	bool have_plan = false;

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3342,7 +3342,7 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 
 	const Widelands::PlayerNumber mypn = player_number();
 	const Widelands::Player* me = game().get_player(mypn);
-	const Widelands::TeamNumber mytn = me->team_number();
+	const Widelands::TeamNumber mytn = player_statistics.get_team_number(mypn);
 	const bool me_def = me->is_defeated();
 	const bool me_alone = player_statistics.get_is_alone(mypn);
 

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3358,9 +3358,9 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 		plan_priority = me_alone ? 0 : std::numeric_limits<int32_t>::max();
 		if (g_verbose) {
 			planned_log_append_text = me_alone ? " as last one" : " as defeated";
-			/* verb_ */ log_dbg_time(
-			  gametime, "AI Diplomacy: Player(%d) plans to leave team with priority %d",
-			  static_cast<unsigned int>(mypn), plan_priority);
+			/* verb_ */ log_dbg_time(gametime,
+			                         "AI Diplomacy: Player(%d) plans to leave team with priority %d",
+			                         static_cast<unsigned int>(mypn), plan_priority);
 		}
 	}
 
@@ -3376,9 +3376,9 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 		plan_priority = -my_team_score;
 		if (g_verbose) {
 			planned_log_append_text = myts_s;
-			/* verb_ */ log_dbg_time(
-			  gametime, "AI Diplomacy: Player(%d) plans to leave team with priority %d",
-			  static_cast<unsigned int>(mypn), plan_priority);
+			/* verb_ */ log_dbg_time(gametime,
+			                         "AI Diplomacy: Player(%d) plans to leave team with priority %d",
+			                         static_cast<unsigned int>(mypn), plan_priority);
 		}
 	}
 
@@ -3405,8 +3405,8 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 				          static_cast<unsigned int>(player_statistics.get_worst_ally()),
 				          player_statistics.get_worst_ally());
 				/* verb_ */ log_dbg_time(
-				  gametime, "AI Diplomacy: Player(%d) plans to leave team with priority %d",
-				  static_cast<unsigned int>(mypn), plan_priority);
+				   gametime, "AI Diplomacy: Player(%d) plans to leave team with priority %d",
+				   static_cast<unsigned int>(mypn), plan_priority);
 			}
 		}
 	}
@@ -3421,7 +3421,8 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 			int32_t priority = 0;
 
 			// We may still decide to stay if a strong enough player wants to join
-			const bool plan_to_leave = have_plan && planned_action == Widelands::DiplomacyAction::kLeaveTeam;
+			const bool plan_to_leave =
+			   have_plan && planned_action == Widelands::DiplomacyAction::kLeaveTeam;
 
 			// consider only if we are not defeated and if not resulting in a team win
 			bool accept =
@@ -3462,7 +3463,8 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 
 			if (!accept) {
 				verb_log_dbg_time(
-				   gametime, "AI Diplomacy: Player(%d)%s denies the %s of player (%d) with diploscore %d%s\n",
+				   gametime,
+				   "AI Diplomacy: Player(%d)%s denies the %s of player (%d) with diploscore %d%s\n",
 				   static_cast<unsigned int>(pda.other), myts_s.c_str(),
 				   pda.action == Widelands::DiplomacyAction::kInvite ? "invitation" : "join request",
 				   static_cast<unsigned int>(pda.sender), diploscore, other_team_score_str.c_str());
@@ -3474,7 +3476,8 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 			} else {
 				if (have_plan) {
 					verb_log_dbg_time(
-					   gametime, "AI Diplomacy: Player(%d) replaces plan: old priority: %d, new priority: %d",
+					   gametime,
+					   "AI Diplomacy: Player(%d) replaces plan: old priority: %d, new priority: %d",
 					   static_cast<unsigned int>(mypn), plan_priority, priority);
 				}
 				planned_action = pda.action == Widelands::DiplomacyAction::kInvite ?
@@ -3486,11 +3489,11 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 				plan_priority = priority;
 				if (g_verbose) {
 					planned_log_append_text = other_team_score_str;
-				   /* verb_ */ log_dbg_time(
-				      gametime,
+					/* verb_ */ log_dbg_time(
+					   gametime,
 					   "AI Diplomacy: Player(%d) plans to accept the %s of player (%d) with priority %d",
-				      static_cast<unsigned int>(mypn),
-				      pda.action == Widelands::DiplomacyAction::kInvite ? "invitation" : "join request",
+					   static_cast<unsigned int>(mypn),
+					   pda.action == Widelands::DiplomacyAction::kInvite ? "invitation" : "join request",
 					   pda.sender, plan_priority);
 				}
 			}

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3337,6 +3337,8 @@ void DefaultAI::check_flag_distances(const Time& gametime) {
 
 // Dealing with diplomacy actions
 void DefaultAI::diplomacy_actions(const Time& gametime) {
+	// Make sure we use reasonably up to date stats
+	update_player_stat(gametime);
 
 	const Widelands::PlayerNumber mypn = player_number();
 	const Widelands::Player* me = game().get_player(mypn);

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3367,15 +3367,15 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 			const Widelands::TeamNumber other_tn = player_statistics.get_team_number(pda.sender);
 
 			// consider only if we are not defeated and if not resulting in a team win
-			bool accept = !me_def &&
-			              player_statistics.members_in_team(
+			bool accept =
+			   !me_def && player_statistics.members_in_team(
 			                 pda.action == Widelands::DiplomacyAction::kInvite ? other_tn : mytn) <
 			                 player_statistics.players_active() - 1;
 
 			// accept if diploscore high, else accept only 50%
-			accept = accept && (diploscore >= std::max(my_team_score, 25) ||
-			                    (diploscore > std::max(my_team_score / 2, 15) &&
-                              RNG::static_rand(2) == 0));
+			accept =
+			   accept && (diploscore >= std::max(my_team_score, 25) ||
+			              (diploscore > std::max(my_team_score / 2, 15) && RNG::static_rand(2) == 0));
 
 			std::string other_team_score_str;
 			if (pda.action == Widelands::DiplomacyAction::kInvite && accept && !me_alone) {
@@ -3428,21 +3428,22 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 				if ((team_vs_this > 0 && player_statistics.members_in_team(mytn) > 3) ||
 				    (team_vs_this > -10 &&
 				     RNG::static_rand(player_statistics.members_in_team(mytn) * 2 - 2) > 0)) {
-					verb_log_dbg_time(
-					   gametime,
-					   "AI Diplomacy: Player(%d) tolerates player (%d) with diploscore %d in team (%d)%s\n",
-					   static_cast<unsigned int>(mypn), static_cast<unsigned int>(opn),
-					   player_statistics.get_diplo_score(opn), static_cast<unsigned int>(mytn),
-					   myts_s.c_str());
+					verb_log_dbg_time(gametime,
+					                  "AI Diplomacy: Player(%d) tolerates player (%d) with diploscore "
+					                  "%d in team (%d)%s\n",
+					                  static_cast<unsigned int>(mypn), static_cast<unsigned int>(opn),
+					                  player_statistics.get_diplo_score(opn),
+					                  static_cast<unsigned int>(mytn), myts_s.c_str());
 					continue;
 				}
 			}
 			game().send_player_diplomacy(mypn, Widelands::DiplomacyAction::kLeaveTeam, opn);
-			verb_log_dbg_time(
-			   gametime,
-			   "AI Diplomacy: Player(%d) leaves team (%d)%s because of player (%d) with diploscore %d\n",
-			   static_cast<unsigned int>(mypn), static_cast<unsigned int>(mytn), myts_s.c_str(),
-			   static_cast<unsigned int>(opn), player_statistics.get_diplo_score(opn));
+			verb_log_dbg_time(gametime,
+			                  "AI Diplomacy: Player(%d) leaves team (%d)%s because of player (%d) "
+			                  "with diploscore %d\n",
+			                  static_cast<unsigned int>(mypn), static_cast<unsigned int>(mytn),
+			                  myts_s.c_str(), static_cast<unsigned int>(opn),
+			                  player_statistics.get_diplo_score(opn));
 		}
 	}
 }

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3482,6 +3482,20 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 					   gametime,
 					   "AI Diplomacy: Player(%d) replaces plan: old priority: %d, new priority: %d",
 					   static_cast<unsigned int>(mypn), plan_priority, priority);
+					if (planned_action != Widelands::DiplomacyAction::kLeaveTeam) {
+						verb_log_dbg_time(
+						   gametime,
+						   "AI Diplomacy: Player(%d)%s denies the %s of player (%d) with diploscore %d%s\n",
+						   static_cast<unsigned int>(mypn), myts_s.c_str(),
+						   planned_action == Widelands::DiplomacyAction::kAcceptInvite ? "invitation" : "join request",
+						   static_cast<unsigned int>(planned_opn), planned_other_score,
+							planned_log_append_text.c_str());
+						game().send_player_diplomacy(mypn,
+						                             (planned_action == Widelands::DiplomacyAction::kAcceptInvite ?
+                                                   Widelands::DiplomacyAction::kRefuseInvite :
+                                                   Widelands::DiplomacyAction::kRefuseJoin),
+						                             planned_opn);
+					}
 				}
 				planned_action = pda.action == Widelands::DiplomacyAction::kInvite ?
                                 Widelands::DiplomacyAction::kAcceptInvite :

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3344,6 +3344,8 @@ void DefaultAI::diplomacy_actions(const Time& gametime) {
 	const bool me_def = me->is_defeated();
 	const bool me_alone = player_statistics.get_is_alone(mypn);
 
+	// TODO(tothxa): detect and handle team changes since last stats update
+
 	// TODO(tothxa): Check all uses whether it's safe to add an invalid value to the enum
 	constexpr Widelands::DiplomacyAction kNoAction =
 	   static_cast<Widelands::DiplomacyAction>(std::numeric_limits<uint8_t>::max());


### PR DESCRIPTION
@hessenfarmer Last part of team based decisions.
Also implements checking all pending requests before doing maximum one team change (and rejecting all others) in one run of diplomacy actions.

**Additional context**
I tested your last scoring fix with this, and it's now stable. I think this works very well now.

[outdated] ~Here's today's test game with this branch:
[dipl_test_0317.zip](https://github.com/widelands/widelands/files/10997108/dipl_test_0317.zip)
[dipl_test_0317_replay.zip](https://github.com/widelands/widelands/files/10997109/dipl_test_0317_replay.zip)~
