### PR TITLE
Fix player end status handling

### DIFF
--- a/src/game_io/game_player_info_packet.cc
+++ b/src/game_io/game_player_info_packet.cc
@@ -185,7 +185,7 @@ void GamePlayerInfoPacket::write(FileSystem& fs, Game& game, MapObjectSaver* /* 
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
 	   game.player_manager()->get_all_players_end_status();
 	fw.unsigned_8(end_status_map.size());
-	for (auto it : end_status_map) {
+	for (const auto it : end_status_map) {
 		const Widelands::PlayerEndStatus& status = it.second;
 		fw.unsigned_8(status.player);
 		fw.unsigned_8(static_cast<uint8_t>(status.result));

--- a/src/game_io/game_player_info_packet.cc
+++ b/src/game_io/game_player_info_packet.cc
@@ -185,7 +185,7 @@ void GamePlayerInfoPacket::write(FileSystem& fs, Game& game, MapObjectSaver* /* 
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
 	   game.player_manager()->get_all_players_end_status();
 	fw.unsigned_8(end_status_map.size());
-	for (const auto it : end_status_map) {
+	for (const auto& it : end_status_map) {
 		const Widelands::PlayerEndStatus& status = it.second;
 		fw.unsigned_8(status.player);
 		fw.unsigned_8(static_cast<uint8_t>(status.result));

--- a/src/game_io/game_player_info_packet.cc
+++ b/src/game_io/game_player_info_packet.cc
@@ -185,7 +185,7 @@ void GamePlayerInfoPacket::write(FileSystem& fs, Game& game, MapObjectSaver* /* 
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
 	   game.player_manager()->get_players_end_status();
 	fw.unsigned_8(end_status_map.size());
-	for (auto it: end_status_map) {
+	for (auto it : end_status_map) {
 		const Widelands::PlayerEndStatus& status = it.second;
 		fw.unsigned_8(status.player);
 		fw.unsigned_8(static_cast<uint8_t>(status.result));

--- a/src/game_io/game_player_info_packet.cc
+++ b/src/game_io/game_player_info_packet.cc
@@ -183,7 +183,7 @@ void GamePlayerInfoPacket::write(FileSystem& fs, Game& game, MapObjectSaver* /* 
 
 	// Result screen
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
-	   game.player_manager()->get_players_end_status();
+	   game.player_manager()->get_all_players_end_status();
 	fw.unsigned_8(end_status_map.size());
 	for (auto it : end_status_map) {
 		const Widelands::PlayerEndStatus& status = it.second;

--- a/src/game_io/game_player_info_packet.cc
+++ b/src/game_io/game_player_info_packet.cc
@@ -182,19 +182,15 @@ void GamePlayerInfoPacket::write(FileSystem& fs, Game& game, MapObjectSaver* /* 
 	}
 
 	// Result screen
-	std::vector<const Widelands::PlayerEndStatus*> end_status_list;
-	for (uint8_t pn = 1; pn <= game.player_manager()->get_number_of_players(); ++pn) {
-		const Widelands::PlayerEndStatus* pes = game.player_manager()->get_player_end_status(pn);
-		if (pes != nullptr) {
-			end_status_list.push_back(pes);
-		}
-	}
-	fw.unsigned_8(end_status_list.size());
-	for (const PlayerEndStatus* status : end_status_list) {
-		fw.unsigned_8(status->player);
-		fw.unsigned_8(static_cast<uint8_t>(status->result));
-		status->time.save(fw);
-		fw.c_string(status->info.c_str());
+	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
+	   game.player_manager()->get_players_end_status();
+	fw.unsigned_8(end_status_map.size());
+	for (auto it: end_status_map) {
+		const Widelands::PlayerEndStatus& status = it.second;
+		fw.unsigned_8(status.player);
+		fw.unsigned_8(static_cast<uint8_t>(status.result));
+		status.time.save(fw);
+		fw.c_string(status.info.c_str());
 	}
 
 	game.write_statistics(fw);

--- a/src/logic/playersmanager.cc
+++ b/src/logic/playersmanager.cc
@@ -100,7 +100,7 @@ void PlayersManager::add_player_end_status(const PlayerEndStatus& status, bool c
 	auto it = players_end_status_.find(pn);
 
 	if (it == players_end_status_.end()) {
-		players_end_status_.insert({pn, status});
+		players_end_status_.emplace(pn, status);
 	} else {
 		if (!change_existing) {
 			throw wexception("Player end status for player %d already reported", status.player);

--- a/src/logic/playersmanager.cc
+++ b/src/logic/playersmanager.cc
@@ -87,34 +87,33 @@ Player* PlayersManager::add_player(PlayerNumber const player_number,
 }
 
 const PlayerEndStatus* PlayersManager::get_player_end_status(PlayerNumber player) const {
-	return (player == 0 || player - 1u >= players_end_status_.size() ||
-	        players_end_status_.at(player - 1).player != player) ?
-             nullptr :
-             &players_end_status_.at(player - 1);
+	auto it = players_end_status_.find(player);
+	if (it == players_end_status_.end()) {
+		return nullptr;
+	}
+	return &(it->second);
 }
 
 void PlayersManager::add_player_end_status(const PlayerEndStatus& status, bool change_existing) {
-	assert(status.player > 0 && status.player <= number_of_players_);
-	if (players_end_status_.size() < number_of_players_) {
-		players_end_status_.resize(number_of_players_);
-	}
+	assert(status.player > 0);
+	const PlayerNumber& pn = status.player;
+	auto it = players_end_status_.find(pn);
 
-	{
-		PlayerEndStatus& s = players_end_status_.at(status.player - 1);
-		if (!change_existing && s.player != 0) {
+	if (it == players_end_status_.end()) {
+		players_end_status_.insert({pn, status});
+	} else {
+		if (!change_existing) {
 			throw wexception("Player end status for player %d already reported", status.player);
 		}
-		s = status;
+		it->second = status;
 	}
 
 	/* If all results have been gathered, show the summary screen. */
 	if (change_existing || egbase_.get_igbase() == nullptr) {
 		return;
 	}
-	for (const PlayerEndStatus& s : players_end_status_) {
-		if (s.player == 0) {
-			return;
-		}
+	if (players_end_status_.size() < number_of_players_) {
+		return;
 	}
 	egbase_.get_igbase()->show_game_summary();
 }

--- a/src/logic/playersmanager.h
+++ b/src/logic/playersmanager.h
@@ -20,6 +20,7 @@
 #define WL_LOGIC_PLAYERSMANAGER_H
 
 #include <cassert>
+#include <map>
 
 #include "base/times.h"
 #include "graphic/playercolor.h"
@@ -29,7 +30,6 @@
 namespace Widelands {
 
 class EditorGameBase;
-class Player;
 class Player;
 
 /**
@@ -97,7 +97,7 @@ private:
 	Player* players_[kMaxPlayers];
 	EditorGameBase& egbase_;
 	uint8_t number_of_players_{0U};
-	std::vector<PlayerEndStatus> players_end_status_;
+	std::map<PlayerNumber, PlayerEndStatus> players_end_status_;
 };
 }  // namespace Widelands
 

--- a/src/logic/playersmanager.h
+++ b/src/logic/playersmanager.h
@@ -92,6 +92,9 @@ public:
 	void add_player_end_status(const PlayerEndStatus& status, bool change_existing = false);
 
 	[[nodiscard]] const PlayerEndStatus* get_player_end_status(PlayerNumber player) const;
+	[[nodiscard]] const std::map<PlayerNumber, PlayerEndStatus>& get_players_end_status() {
+		return players_end_status_;
+	}
 
 private:
 	Player* players_[kMaxPlayers];

--- a/src/logic/playersmanager.h
+++ b/src/logic/playersmanager.h
@@ -92,7 +92,7 @@ public:
 	void add_player_end_status(const PlayerEndStatus& status, bool change_existing = false);
 
 	[[nodiscard]] const PlayerEndStatus* get_player_end_status(PlayerNumber player) const;
-	[[nodiscard]] const std::map<PlayerNumber, PlayerEndStatus>& get_players_end_status() {
+	[[nodiscard]] const std::map<PlayerNumber, PlayerEndStatus>& get_all_players_end_status() {
 		return players_end_status_;
 	}
 

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -147,8 +147,10 @@ bool GameSummaryScreen::compare_status(const uint32_t index1, const uint32_t ind
 	assert(index1 >= 0 && index1 < game_.player_manager()->get_number_of_players());
 	assert(index2 >= 0 && index2 < game_.player_manager()->get_number_of_players());
 
-	const Widelands::PlayerEndStatus* p1 = game_.player_manager()->get_player_end_status(playernumbers_[index1]);
-	const Widelands::PlayerEndStatus* p2 = game_.player_manager()->get_player_end_status(playernumbers_[index2]);
+	const Widelands::PlayerEndStatus* p1 =
+	   game_.player_manager()->get_player_end_status(playernumbers_[index1]);
+	const Widelands::PlayerEndStatus* p2 =
+	   game_.player_manager()->get_player_end_status(playernumbers_[index2]);
 
 	if (p1->result == p2->result) {
 		// We want to use the time as tie-breaker: The first player to lose sorts last

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -188,8 +188,8 @@ void GameSummaryScreen::fill_data() {
 
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
 	   game_.player_manager()->get_all_players_end_status();
-	for (auto it : end_status_map) {
-		const Widelands::PlayerNumber pn = it.first;
+	for (const auto it : end_status_map) {
+		const Widelands::PlayerNumber& pn = it.first;
 		const Widelands::PlayerEndStatus& pes = it.second;
 		assert(pn == pes.player);
 

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -184,16 +184,17 @@ void GameSummaryScreen::fill_data() {
 	// This defines a row to be selected, current player,
 	// if not then the first line
 	uint32_t current_player_position = 0;
+	uintptr_t i = 0;
 
-	for (uintptr_t i = 1; i <= game_.player_manager()->get_number_of_players(); ++i) {
-		const Widelands::PlayerEndStatus* pes = game_.player_manager()->get_player_end_status(i);
+	for (Widelands::PlayerNumber pn = 1; pn <= kMaxPlayers; ++pn) {
+		const Widelands::PlayerEndStatus* pes = game_.player_manager()->get_player_end_status(pn);
 		if (pes == nullptr) {
 			continue;
 		}
 		if ((ipl != nullptr) && pes->player == ipl->player_number()) {
 			local_in_game = true;
 			local_won = pes->result == Widelands::PlayerEndResult::kWon;
-			current_player_position = i - 1;
+			current_player_position = i;
 		}
 		Widelands::Player* p = game_.get_player(pes->player);
 		UI::Table<uintptr_t const>::EntryRecord& te = players_table_->add(i);
@@ -235,6 +236,10 @@ void GameSummaryScreen::fill_data() {
 		te.set_string(2, stat_str);
 		// Time
 		te.set_string(3, gametimestring(pes->time.get()));
+		++i;
+		if (i == game_.player_manager()->get_number_of_players()) {
+			break;
+		}
 	}
 
 	if (local_in_game) {

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -144,14 +144,11 @@ bool GameSummaryScreen::handle_mousepress(uint8_t btn, int32_t mx, int32_t my) {
 }
 
 bool GameSummaryScreen::compare_status(const uint32_t index1, const uint32_t index2) const {
-	const uintptr_t a = (*players_table_)[index1];
-	const uintptr_t b = (*players_table_)[index2];
+	assert(index1 >= 0 && index1 < game_.player_manager()->get_number_of_players());
+	assert(index2 >= 0 && index2 < game_.player_manager()->get_number_of_players());
 
-	assert(a > 0 && a <= game_.player_manager()->get_number_of_players());
-	assert(b > 0 && b <= game_.player_manager()->get_number_of_players());
-
-	const Widelands::PlayerEndStatus* p1 = game_.player_manager()->get_player_end_status(a);
-	const Widelands::PlayerEndStatus* p2 = game_.player_manager()->get_player_end_status(b);
+	const Widelands::PlayerEndStatus* p1 = game_.player_manager()->get_player_end_status(playernumbers_[index1]);
+	const Widelands::PlayerEndStatus* p2 = game_.player_manager()->get_player_end_status(playernumbers_[index2]);
 
 	if (p1->result == p2->result) {
 		// We want to use the time as tie-breaker: The first player to lose sorts last
@@ -184,13 +181,15 @@ void GameSummaryScreen::fill_data() {
 	// This defines a row to be selected, current player,
 	// if not then the first line
 	uint32_t current_player_position = 0;
-	uintptr_t i = 0;
+	uint32_t i = 0;
+	playernumbers_.clear();
 
 	for (Widelands::PlayerNumber pn = 1; pn <= kMaxPlayers; ++pn) {
 		const Widelands::PlayerEndStatus* pes = game_.player_manager()->get_player_end_status(pn);
 		if (pes == nullptr) {
 			continue;
 		}
+		playernumbers_.emplace_back(pn);
 		if ((ipl != nullptr) && pes->player == ipl->player_number()) {
 			local_in_game = true;
 			local_won = pes->result == Widelands::PlayerEndResult::kWon;
@@ -271,9 +270,8 @@ void GameSummaryScreen::stop_clicked() {
 }
 
 void GameSummaryScreen::player_selected(uint32_t entry_index) {
-	const uintptr_t selected_player_index = (*players_table_)[entry_index];
 	const Widelands::PlayerEndStatus* player_status =
-	   game_.player_manager()->get_player_end_status(selected_player_index);
+	   game_.player_manager()->get_player_end_status(playernumbers_[entry_index]);
 
 	std::string info_str = parse_player_info(player_status->info);
 	info_area_->set_text(info_str);

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -187,7 +187,7 @@ void GameSummaryScreen::fill_data() {
 	playernumbers_.clear();
 
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
-	   game_.player_manager()->get_players_end_status();
+	   game_.player_manager()->get_all_players_end_status();
 	for (auto it : end_status_map) {
 		const Widelands::PlayerNumber pn = it.first;
 		const Widelands::PlayerEndStatus& pes = it.second;

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -188,7 +188,7 @@ void GameSummaryScreen::fill_data() {
 
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
 	   game_.player_manager()->get_all_players_end_status();
-	for (const auto it : end_status_map) {
+	for (const auto& it : end_status_map) {
 		const Widelands::PlayerNumber& pn = it.first;
 		const Widelands::PlayerEndStatus& pes = it.second;
 		assert(pn == pes.player);

--- a/src/wui/game_summary.cc
+++ b/src/wui/game_summary.cc
@@ -188,7 +188,7 @@ void GameSummaryScreen::fill_data() {
 
 	const std::map<Widelands::PlayerNumber, Widelands::PlayerEndStatus>& end_status_map =
 	   game_.player_manager()->get_players_end_status();
-	for (auto it: end_status_map) {
+	for (auto it : end_status_map) {
 		const Widelands::PlayerNumber pn = it.first;
 		const Widelands::PlayerEndStatus& pes = it.second;
 		assert(pn == pes.player);

--- a/src/wui/game_summary.h
+++ b/src/wui/game_summary.h
@@ -19,6 +19,9 @@
 #ifndef WL_WUI_GAME_SUMMARY_H
 #define WL_WUI_GAME_SUMMARY_H
 
+#include <vector>
+
+#include "logic/widelands.h"
 #include "ui_basic/box.h"
 #include "ui_basic/button.h"
 #include "ui_basic/icon.h"
@@ -59,6 +62,7 @@ private:
 	UI::Button* continue_button_;
 	UI::Button* stop_button_;
 	UI::Table<uintptr_t const>* players_table_;
+	std::vector<Widelands::PlayerNumber> playernumbers_;
 };
 
 #endif  // end of include guard: WL_WUI_GAME_SUMMARY_H


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5667
Fixes #5809

**To reproduce**
Steps to reproduce the behavior which cause the bug in master but not in your branch:
1. Start a game with closed player slots (test both with single and multiplayer)
2. Resign all players
3. master crashes, with these changes it works

**Possible regressions**
Win conditions, game summary, game speed setting

**Additional context**
Alternative and extension of #5823