### PR TITLE
Turn unguaranteed add-on dependency check assert into a conditional

### DIFF
--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -1183,7 +1183,7 @@ void AddOnsCtrl::update_dependency_errors() {
 					if (too_late && AddOns::order_matters(prev->category, next->category)) {
 						warn_requirements.push_back(format(
 						   _("· ‘%1$s’ requires first ‘%2$s’ and then ‘%3$s’, but they are "
-							 "listed in the wrong order"),
+						     "listed in the wrong order"),
 						   addon->first->descname(), prev->descname(), search_result->first->descname()));
 					}
 				}

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -1178,13 +1178,14 @@ void AddOnsCtrl::update_dependency_errors() {
 						too_late = true;
 					}
 				}
-				assert(prev != nullptr);
-				assert(!too_late || next != nullptr);
-				if (too_late && AddOns::order_matters(prev->category, next->category)) {
-					warn_requirements.push_back(format(
-					   _("· ‘%1$s’ requires first ‘%2$s’ and then ‘%3$s’, but they are "
-					     "listed in the wrong order"),
-					   addon->first->descname(), prev->descname(), search_result->first->descname()));
+				if (prev != nullptr) {
+					assert(!too_late || next != nullptr);
+					if (too_late && AddOns::order_matters(prev->category, next->category)) {
+						warn_requirements.push_back(format(
+						   _("· ‘%1$s’ requires first ‘%2$s’ and then ‘%3$s’, but they are "
+							 "listed in the wrong order"),
+						   addon->first->descname(), prev->descname(), search_result->first->descname()));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5828

I'm planning to refactor the whole dependency check stuff anyway when I find time, but here's to fix the bug report. This specific case happens when some add-on X requires add-ons A and B and checks whether they are in the wrong order but A is not installed at all. In this case we already generate a separate warning elsewhere.

There may be more similar bugs in the existing code, we did not have a lot of testcases for dependencies until recently.