### PR TITLE
Pin docformatter version in formatting workflow

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -62,7 +62,7 @@ jobs:
         sudo apt-get update
         sudo apt-get purge -y clang-11 clang-format-11 clang-10 clang-format-10
         sudo apt-get install clang-format-12
-        pip install pyformat
+        pip install autoflake autopep8 unify docformatter==1.5.1
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100
         sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-12 100

--- a/utils/fix_formatting.py
+++ b/utils/fix_formatting.py
@@ -18,7 +18,7 @@ import argparse
 import os
 import re
 import sys
-from subprocess import check_call
+from subprocess import check_call, CalledProcessError
 from file_utils import read_text_file, write_text_file, find_files
 
 import autoflake
@@ -140,7 +140,13 @@ def main():
             sys.stdout.write(
                 '\nFormatting Python scripts in directory: ' + directory + ' ')
             python_files = find_files(directory, ['.py'])
-            check_call(['docformatter', '-i', *python_files])
+            try:
+                check_call(['docformatter', '-i', *python_files])
+            except CalledProcessError as e:
+                # Return code 3 means there are changes. That's OK for us, next
+                # step will pick them up
+                if e.returncode != 3 :
+                    raise
             for filename in find_files(directory, ['.py']):
                 sys.stdout.write('.')
                 sys.stdout.flush()


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5843

**Additional context**
This is a reboot of #5844. It still updates `fix_formatting.py` for docformatter-1.6.0, but for now pins docformatter version to 1.5.1 as suggested by @matthiakl to avoid undesired changes by the new rules.