### PR TITLE
Naval Warfare: Invasion Strategy

### DIFF
--- a/src/logic/map_objects/tribes/militarysite.cc
+++ b/src/logic/map_objects/tribes/militarysite.cc
@@ -840,7 +840,7 @@ bool MilitarySite::get_building_work(Game& game, Worker& worker, bool /*success*
 		bool stayhome;
 		if (MapObject* const enemy = pop_soldier_job(soldier, &stayhome)) {
 			if (upcast(Building, building, enemy)) {
-				soldier->start_task_attack(game, *building, true);
+				soldier->start_task_attack(game, *building, CF_RETREAT_WHEN_INJURED);
 				return true;
 			}
 			if (upcast(Soldier, opponent, enemy)) {

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1160,7 +1160,7 @@ void Ship::battle_update(Game& game) {
 				   game, suitable_coords.at(game.logic_rand() % suitable_coords.size()));
 
 				worker->reset_tasks(game);
-				dynamic_cast<Soldier&>(*worker).start_task_attack(game, warehouse, false);
+				dynamic_cast<Soldier&>(*worker).start_task_naval_invasion(game, warehouse.get_position());
 
 				items_.erase(it);
 			}

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1160,7 +1160,8 @@ void Ship::battle_update(Game& game) {
 				   game, suitable_coords.at(game.logic_rand() % suitable_coords.size()));
 
 				worker->reset_tasks(game);
-				dynamic_cast<Soldier&>(*worker).start_task_naval_invasion(game, warehouse.get_position());
+				dynamic_cast<Soldier&>(*worker).start_task_naval_invasion(
+				   game, warehouse.get_position());
 
 				items_.erase(it);
 			}

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -18,6 +18,7 @@
 
 #include "logic/map_objects/tribes/soldier.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "base/log.h"
@@ -1669,13 +1670,10 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 	for (const ImmovableFound& result : results) {
 		Building& bld = dynamic_cast<Building&>(*result.object);
 		if (!owner().is_hostile(bld.owner()) || bld.attack_target() == nullptr ||
-		    !bld.attack_target()->can_be_attacked()) {
+		    !bld.attack_target()->can_be_attacked() ||
+		    bld.descr().get_conquers() + state.ivar2 <
+		       map.calc_distance(bld.get_position(), state.coords)) {
 			continue;
-		}
-		if (bld.descr().get_conquers() + state.ivar2 <
-		    map.calc_distance(bld.get_position(), state.coords)) {
-			// This building and all buildings sorted after it do not conquer the port space.
-			break;
 		}
 
 		// Attack in next cycle

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1686,7 +1686,8 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 	FCoords fcoords = map.get_fcoords(state.coords);
 	if (fcoords.field->get_owned_by() != owner().player_number()) {
 		// The target should be unguarded now, conquer the port space.
-		game.conquer_area(PlayerArea<Area<FCoords>>(owner().player_number(), Area<FCoords>(fcoords, 2)));
+		game.conquer_area(
+		   PlayerArea<Area<FCoords>>(owner().player_number(), Area<FCoords>(fcoords, 2)));
 		return schedule_act(game, Duration(10));
 	}
 
@@ -1700,7 +1701,8 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 		return;
 	}
 
-	if (fcoords.field->get_immovable() != nullptr && !fcoords.field->get_immovable()->get_passable()) {
+	if (fcoords.field->get_immovable() != nullptr &&
+	    !fcoords.field->get_immovable()->get_passable()) {
 		// Wait until the fire burns out
 		return schedule_act(game, Duration(100));
 	}

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1030,7 +1030,11 @@ void Soldier::attack_update(Game& game, State& state) {
 				    ((location == nullptr) ||
 				     location->base_flag().get_position() != newsite->base_flag().get_position())) {
 					molog(game.get_gametime(), "[attack] enemy belongs to us now, move in\n");
-					pop_task(game);
+
+					// Remain at the conquered site.
+					reset_tasks(game);
+					start_task_buildingwork(game);
+
 					set_location(newsite);
 					newsite->update_soldier_request();
 					return schedule_act(game, Duration(10));
@@ -1692,6 +1696,10 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 	}
 
 	if (get_position() == state.coords) {
+		if (current_health_ < get_max_health()) {  // Stationed soldiers heal very slowly.
+			constexpr unsigned kStationaryHealPerSecond = 10;
+			heal(kStationaryHealPerSecond);
+		}
 		return start_task_idle(game, descr().get_animation("idle", this), 1000);
 	}
 

--- a/src/logic/map_objects/tribes/soldier.h
+++ b/src/logic/map_objects/tribes/soldier.h
@@ -199,6 +199,8 @@ enum CombatWalkingDir {
 };
 
 enum CombatFlags {
+	/// No special commands.
+	CF_NONE = 0,
 	/// Soldier will wait enemies at his building flag. Only for defenders.
 	CF_DEFEND_STAYHOME = 1,
 	/// When current health points drop below a fixed percentage, soldier will flee
@@ -317,11 +319,12 @@ public:
 
 	void set_battle(Game&, Battle*);
 
-	void start_task_attack(Game& game, Building&, bool allow_retreat);
+	void start_task_attack(Game& game, Building&, CombatFlags flags);
 	void start_task_defense(Game& game, bool stayhome);
 	void start_task_battle(Game&);
 	void start_task_move_in_battle(Game&, CombatWalkingDir);
 	void start_task_die(Game&);
+	void start_task_naval_invasion(Game& game, const Coords& coords);
 
 	std::pair<std::unique_ptr<SoldierLevelRange>, std::unique_ptr<DirAnimations>>&
 	get_walking_animations_cache() {
@@ -338,6 +341,7 @@ private:
 	void move_in_battle_update(Game&, State&);
 	void die_update(Game&, State&);
 	void die_pop(Game&, State&);
+	void naval_invasion_update(Game&, State&);
 
 	void send_space_signals(Game&);
 	bool stay_home();
@@ -352,6 +356,7 @@ protected:
 	static Task const taskMoveInBattle;
 	// May be this can be moved this to bob when finished
 	static Task const taskDie;
+	static Task const taskNavalInvasion;
 
 	bool is_evict_allowed() override;
 


### PR DESCRIPTION
This implements the basic invasion strategy of soldiers in a naval invasion.

After the soldiers land at a port space, they go around conquering or destroying all enemy buildings that currently have influence over that port space. They occupy and secure the port space indefinitely so we can later send an expedition ship to actually build a port of our own there. ~~That bit comes in a future branch.~~ Which already works.

For now we still need an enemy port to exist at the selected port space to be able to initiate the attack, but the port is then treated no different from any other hostile building that conquers land we want for ourselves. In the future it will be independent of whether the enemy actually has a port there or not. The promised attack GUI redesign can only come after that since it will change the way attack targets for naval invasions are defined.