### PR TITLE
Editor Automatic Tree Placement Tool

### DIFF
--- a/data/scripting/editor/toolhistory_tooltip.lua
+++ b/data/scripting/editor/toolhistory_tooltip.lua
@@ -5,6 +5,7 @@
 -- This script returns a compact formatted entry for toolhistory list tooltips in the editor.
 -- Pass map object type ("terrain", "critter", or "immovable") followed by the internal names of
 -- the map objects to the coroutine.
+-- If the map object type is "image", the arguments are interpreted as image filepaths.
 
 include "scripting/richtext.lua"
 include "scripting/help.lua"
@@ -25,6 +26,9 @@ return {
 
          elseif mo_type == "immovable" then
             result = result .. img_object(name) .. space(gap)
+
+         elseif mo_type == "image" then
+            result = result .. img(name) .. space(gap)
 
          end
       end

--- a/src/editor/tools/place_immovable_tool.cc
+++ b/src/editor/tools/place_immovable_tool.cc
@@ -54,14 +54,20 @@ int32_t EditorPlaceImmovableTool::handle_click_impl(const Widelands::NodeAndTria
 		std::list<Widelands::DescriptionIndex>::iterator i = args->new_immovable_types.begin();
 		do {
 			if (*i == kAutoTreesIndex) {
-				const uint32_t attribute_id = Widelands::ImmovableDescr::get_attribute_id("normal_tree");
-				std::set<std::pair<unsigned /* probability_to_grow, for sorting */, Widelands::DescriptionIndex>> all_trees_sorted;
+				const uint32_t attribute_id =
+				   Widelands::ImmovableDescr::get_attribute_id("normal_tree");
+				std::set<std::pair<unsigned /* probability_to_grow, for sorting */,
+				                   Widelands::DescriptionIndex>>
+				   all_trees_sorted;
 
 				const Widelands::Descriptions& descriptions = egbase.descriptions();
 				for (Widelands::DescriptionIndex di = 0; di < descriptions.nr_immovables(); ++di) {
 					const Widelands::ImmovableDescr* descr = descriptions.get_immovable_descr(di);
 					if (descr->has_attribute(attribute_id) && descr->has_terrain_affinity()) {
-						all_trees_sorted.emplace(Widelands::probability_to_grow(descr->terrain_affinity(), mr.location(), *map, descriptions.terrains()), di);
+						all_trees_sorted.emplace(
+						   Widelands::probability_to_grow(
+						      descr->terrain_affinity(), mr.location(), *map, descriptions.terrains()),
+						   di);
 					}
 				}
 

--- a/src/editor/tools/place_immovable_tool.cc
+++ b/src/editor/tools/place_immovable_tool.cc
@@ -23,6 +23,7 @@
 #include "logic/editor_game_base.h"
 #include "logic/field.h"
 #include "logic/map_objects/immovable.h"
+#include "logic/map_objects/terrain_affinity.h"
 #include "logic/mapregion.h"
 
 /**
@@ -52,6 +53,23 @@ int32_t EditorPlaceImmovableTool::handle_click_impl(const Widelands::NodeAndTria
 		   *map, Widelands::Area<Widelands::FCoords>(map->get_fcoords(center.node), radius));
 		std::list<Widelands::DescriptionIndex>::iterator i = args->new_immovable_types.begin();
 		do {
+			if (*i == kAutoTreesIndex) {
+				const uint32_t attribute_id = Widelands::ImmovableDescr::get_attribute_id("normal_tree");
+				std::set<std::pair<unsigned /* probability_to_grow, for sorting */, Widelands::DescriptionIndex>> all_trees_sorted;
+
+				const Widelands::Descriptions& descriptions = egbase.descriptions();
+				for (Widelands::DescriptionIndex di = 0; di < descriptions.nr_immovables(); ++di) {
+					const Widelands::ImmovableDescr* descr = descriptions.get_immovable_descr(di);
+					if (descr->has_attribute(attribute_id) && descr->has_terrain_affinity()) {
+						all_trees_sorted.emplace(Widelands::probability_to_grow(descr->terrain_affinity(), mr.location(), *map, descriptions.terrains()), di);
+					}
+				}
+
+				auto it = all_trees_sorted.rbegin();
+				std::advance(it, RNG::static_rand(std::min<size_t>(all_trees_sorted.size(), 3)));
+				*i = it->second;
+			}
+
 			if ((mr.location().field->get_immovable() == nullptr) &&
 			    ((mr.location().field->nodecaps() & Widelands::MOVECAPS_WALK) != 0)) {
 				egbase.create_immovable(mr.location(), *i, nullptr /* owner */);
@@ -103,7 +121,11 @@ std::string EditorPlaceImmovableTool::format_conf_description_impl(const ToolCon
 		if (!mapobj_names.empty()) {
 			mapobj_names += " | ";
 		}
-		mapobj_names += immovable_descriptions.get(idx).descname();
+		if (idx == kAutoTreesIndex) {
+			mapobj_names += _("Automatic Trees");
+		} else {
+			mapobj_names += immovable_descriptions.get(idx).descname();
+		}
 	}
 
 	/** TRANSLATORS: An entry in the tool history list. */

--- a/src/editor/tools/place_immovable_tool.h
+++ b/src/editor/tools/place_immovable_tool.h
@@ -22,6 +22,8 @@
 #include "editor/tools/delete_immovable_tool.h"
 #include "editor/tools/multi_select.h"
 
+constexpr int32_t kAutoTreesIndex = std::numeric_limits<uint16_t>::max() - 4;
+
 /**
  * This places immovables on the map
  */

--- a/src/editor/tools/place_immovable_tool.h
+++ b/src/editor/tools/place_immovable_tool.h
@@ -22,8 +22,6 @@
 #include "editor/tools/delete_immovable_tool.h"
 #include "editor/tools/multi_select.h"
 
-constexpr int32_t kAutoTreesIndex = std::numeric_limits<uint16_t>::max() - 4;
-
 /**
  * This places immovables on the map
  */

--- a/src/editor/tools/tool.h
+++ b/src/editor/tools/tool.h
@@ -40,6 +40,8 @@ enum class WindowID {
 	ToolHistory,
 };
 
+constexpr int32_t kAutoTreesIndex = std::numeric_limits<uint16_t>::max() - 4;
+
 /**
  * An editor tool is a tool that can be selected in the editor. Examples are:
  * modify height, place immovable, place critter, place building. A Tool only

--- a/src/editor/ui_menus/categorized_item_selection_menu.h
+++ b/src/editor/ui_menus/categorized_item_selection_menu.h
@@ -46,7 +46,8 @@ public:
 	   const Widelands::DescriptionMaintainer<DescriptionType>& descriptions,
 	   std::function<UI::Checkbox*(UI::Panel* parent, const DescriptionType& descr)> create_checkbox,
 	   std::function<void()> select_correct_tool,
-	   ToolType* tool);
+	   ToolType* tool,
+	   std::map<int32_t, std::string> descname_overrides = {});
 
 	// Updates selection to match the tool settings
 	void update_selection();
@@ -66,12 +67,12 @@ private:
 	void selected(int32_t, bool);
 
 	const Widelands::DescriptionMaintainer<DescriptionType>& descriptions_;
+	std::map<int32_t, std::string> descname_overrides_;
 	std::function<void()> select_correct_tool_;
 	bool protect_against_recursive_select_{false};
 	UI::TabPanel tab_panel_;
 	UI::MultilineTextarea current_selection_names_;
 	std::map<int, UI::Checkbox*> checkboxes_;
-	std::map<int32_t, std::string> descname_overrides_;
 	ToolType* const tool_;  // not owned
 };
 
@@ -83,9 +84,11 @@ CategorizedItemSelectionMenu<DescriptionType, ToolType>::CategorizedItemSelectio
    const std::function<UI::Checkbox*(UI::Panel* parent, const DescriptionType& descr)>
       create_checkbox,
    const std::function<void()> select_correct_tool,
-   ToolType* const tool)
+   ToolType* const tool,
+   std::map<int32_t, std::string> descname_overrides)
    : UI::Box(parent, UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical),
      descriptions_(descriptions),
+     descname_overrides_(descname_overrides),
      select_correct_tool_(select_correct_tool),
 
      tab_panel_(this, UI::TabPanelStyle::kWuiLight),

--- a/src/editor/ui_menus/tool_options_menu.h
+++ b/src/editor/ui_menus/tool_options_menu.h
@@ -59,7 +59,7 @@ struct EditorToolOptionsMenu : public UI::UniqueWindow {
 	virtual void update_window() {
 	}
 
-private:
+protected:
 	EditorInteractive& parent_;
 	EditorTool& current_tool_;
 };

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -73,8 +73,7 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 		      tool.enable(kAutoTreesIndex, false);
 		      select_correct_tool();
 	      },
-	      &tool,
-	      {{kAutoTreesIndex, _("Automatic Trees")}}));
+	      &tool, {{kAutoTreesIndex, _("Automatic Trees")}}));
 
 	UI::Box* auto_immovables_box =
 	   new UI::Box(&multi_select_menu_->tabs(), UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical);

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -73,9 +73,9 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 		      tool.enable(kAutoTreesIndex, false);
 		      select_correct_tool();
 	      },
-	      &tool));
+	      &tool,
+	      {{kAutoTreesIndex, _("Automatic Trees")}}));
 
-	multi_select_menu_->set_descname_override(kAutoTreesIndex, _("Automatic Trees"));
 	UI::Box* auto_immovables_box =
 	   new UI::Box(&multi_select_menu_->tabs(), UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical);
 	auto_trees_button_ = new UI::Button(auto_immovables_box, "auto_trees", 0, 0, 0, 0,
@@ -90,10 +90,12 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 		}
 		multi_select_menu_->update_label();
 	});
+	auto_trees_button_->set_perm_pressed(tool.is_enabled(kAutoTreesIndex));
 	auto_immovables_box->add(auto_trees_button_, UI::Box::Resizing::kFullSize);
 	multi_select_menu_->tabs().add("auto",
 	                               g_image_cache->get("images/wui/editor/tools/immovables.png"),
 	                               auto_immovables_box, _("Automatic Immovable Placement"), 0);
+	multi_select_menu_->tabs().activate(0);
 
 	set_center_panel(multi_select_menu_.get());
 

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -68,7 +68,32 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 	      [lua](UI::Panel* cb_parent, const Widelands::ImmovableDescr& immovable_descr) {
 		      return create_immovable_checkbox(cb_parent, lua, immovable_descr);
 	      },
-	      [this] { select_correct_tool(); }, &tool));
+	      [this, &tool] {
+		      auto_trees_button_->set_perm_pressed(false);
+		      tool.enable(kAutoTreesIndex, false);
+		      select_correct_tool();
+	      }, &tool));
+
+	multi_select_menu_->set_descname_override(kAutoTreesIndex, _("Automatic Trees"));
+	UI::Box* auto_immovables_box = new UI::Box(&multi_select_menu_->tabs(), UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical);
+	auto_trees_button_ = new UI::Button(auto_immovables_box, "auto_trees", 0, 0, 0, 0, UI::ButtonStyle::kWuiSecondary, _("Automatic Trees"));
+	auto_trees_button_->sigclicked.connect([this, &tool]() {
+		auto_trees_button_->toggle();
+		if (auto_trees_button_->style() == UI::Button::VisualState::kPermpressed) {
+			tool.disable_all();
+			tool.enable(kAutoTreesIndex, true);
+		} else {
+			tool.enable(kAutoTreesIndex, false);
+		}
+		multi_select_menu_->update_label();
+	});
+	auto_immovables_box->add(auto_trees_button_, UI::Box::Resizing::kFullSize);
+	multi_select_menu_->tabs().add("auto",
+	             g_image_cache->get("images/wui/editor/tools/immovables.png"),
+	             auto_immovables_box,
+	             _("Automatic Immovable Placement"),
+	             0);
+
 	set_center_panel(multi_select_menu_.get());
 
 	initialization_complete();

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -83,13 +83,13 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 		auto_trees_button_->toggle();
 		if (auto_trees_button_->style() == UI::Button::VisualState::kPermpressed) {
 			tool.disable_all();
+			select_correct_tool();
 			tool.enable(kAutoTreesIndex, true);
 		} else {
 			tool.enable(kAutoTreesIndex, false);
 		}
 		multi_select_menu_->update_label();
 	});
-	auto_trees_button_->set_perm_pressed(tool.is_enabled(kAutoTreesIndex));
 	auto_immovables_box->add(auto_trees_button_, UI::Box::Resizing::kFullSize);
 	multi_select_menu_->tabs().add("auto",
 	                               g_image_cache->get("images/wui/editor/tools/immovables.png"),
@@ -103,4 +103,9 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 
 void EditorToolPlaceImmovableOptionsMenu::update_window() {
 	multi_select_menu_->update_selection();
+}
+
+void EditorToolPlaceImmovableOptionsMenu::think() {
+	EditorToolOptionsMenu::think();
+	auto_trees_button_->set_perm_pressed(parent_.tools()->current_pointer == &current_tool_ && dynamic_cast<EditorPlaceImmovableTool&>(current_tool_).is_enabled(kAutoTreesIndex));
 }

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -78,7 +78,9 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 	UI::Box* auto_immovables_box =
 	   new UI::Box(&multi_select_menu_->tabs(), UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical);
 	auto_trees_button_ = new UI::Button(auto_immovables_box, "auto_trees", 0, 0, 0, 0,
-	                                    UI::ButtonStyle::kWuiSecondary, _("Automatic Trees"));
+	                                    UI::ButtonStyle::kWuiSecondary, _("Automatic Trees"),
+	                                    _("Automatically place the trees which "
+	                                      "grow best on the terrain"));
 	auto_trees_button_->sigclicked.connect([this, &tool]() {
 		auto_trees_button_->toggle();
 		if (auto_trees_button_->style() == UI::Button::VisualState::kPermpressed) {

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -72,11 +72,14 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 		      auto_trees_button_->set_perm_pressed(false);
 		      tool.enable(kAutoTreesIndex, false);
 		      select_correct_tool();
-	      }, &tool));
+	      },
+	      &tool));
 
 	multi_select_menu_->set_descname_override(kAutoTreesIndex, _("Automatic Trees"));
-	UI::Box* auto_immovables_box = new UI::Box(&multi_select_menu_->tabs(), UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical);
-	auto_trees_button_ = new UI::Button(auto_immovables_box, "auto_trees", 0, 0, 0, 0, UI::ButtonStyle::kWuiSecondary, _("Automatic Trees"));
+	UI::Box* auto_immovables_box =
+	   new UI::Box(&multi_select_menu_->tabs(), UI::PanelStyle::kWui, 0, 0, UI::Box::Vertical);
+	auto_trees_button_ = new UI::Button(auto_immovables_box, "auto_trees", 0, 0, 0, 0,
+	                                    UI::ButtonStyle::kWuiSecondary, _("Automatic Trees"));
 	auto_trees_button_->sigclicked.connect([this, &tool]() {
 		auto_trees_button_->toggle();
 		if (auto_trees_button_->style() == UI::Button::VisualState::kPermpressed) {
@@ -89,10 +92,8 @@ EditorToolPlaceImmovableOptionsMenu::EditorToolPlaceImmovableOptionsMenu(
 	});
 	auto_immovables_box->add(auto_trees_button_, UI::Box::Resizing::kFullSize);
 	multi_select_menu_->tabs().add("auto",
-	             g_image_cache->get("images/wui/editor/tools/immovables.png"),
-	             auto_immovables_box,
-	             _("Automatic Immovable Placement"),
-	             0);
+	                               g_image_cache->get("images/wui/editor/tools/immovables.png"),
+	                               auto_immovables_box, _("Automatic Immovable Placement"), 0);
 
 	set_center_panel(multi_select_menu_.get());
 

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -107,5 +107,7 @@ void EditorToolPlaceImmovableOptionsMenu::update_window() {
 
 void EditorToolPlaceImmovableOptionsMenu::think() {
 	EditorToolOptionsMenu::think();
-	auto_trees_button_->set_perm_pressed(parent_.tools()->current_pointer == &current_tool_ && dynamic_cast<EditorPlaceImmovableTool&>(current_tool_).is_enabled(kAutoTreesIndex));
+	auto_trees_button_->set_perm_pressed(
+	   parent_.tools()->current_pointer == &current_tool_ &&
+	   dynamic_cast<EditorPlaceImmovableTool&>(current_tool_).is_enabled(kAutoTreesIndex));
 }

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.h
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.h
@@ -39,6 +39,7 @@ private:
 	std::unique_ptr<
 	   CategorizedItemSelectionMenu<Widelands::ImmovableDescr, EditorPlaceImmovableTool>>
 	   multi_select_menu_;
+	UI::Button* auto_trees_button_{nullptr};
 };
 
 #endif  // end of include guard: WL_EDITOR_UI_MENUS_TOOL_PLACE_IMMOVABLE_OPTIONS_MENU_H

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.h
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.h
@@ -34,6 +34,7 @@ struct EditorToolPlaceImmovableOptionsMenu : public EditorToolOptionsMenu {
 	~EditorToolPlaceImmovableOptionsMenu() override = default;
 
 	void update_window() override;
+	void think() override;
 
 private:
 	std::unique_ptr<

--- a/src/editor/ui_menus/tool_toolhistory_options_menu.cc
+++ b/src/editor/ui_menus/tool_toolhistory_options_menu.cc
@@ -94,10 +94,15 @@ std::string EditorToolhistoryOptionsMenu::make_tooltip(const ToolConf& conf,
 			cr->push_arg(descr->name());
 		}
 	} else if (conf.primary->get_window_id() == WindowID::Immovables) {
-		cr->push_arg("immovable");
-		for (Widelands::DescriptionIndex idx : conf.map_obj_types) {
-			const Widelands::ImmovableDescr* descr = descriptions.get_immovable_descr(idx);
-			cr->push_arg(descr->name());
+		if (conf.map_obj_types.count(kAutoTreesIndex) != 0) {
+			cr->push_arg("image");
+			cr->push_arg("images/wui/editor/tools/immovables.png");
+		} else {
+			cr->push_arg("immovable");
+			for (Widelands::DescriptionIndex idx : conf.map_obj_types) {
+				const Widelands::ImmovableDescr* descr = descriptions.get_immovable_descr(idx);
+				cr->push_arg(descr->name());
+			}
 		}
 	}
 

--- a/src/ui_basic/tabpanel.cc
+++ b/src/ui_basic/tabpanel.cc
@@ -312,7 +312,10 @@ uint32_t TabPanel::add_tab(const std::string& name,
 	assert(panel);
 	assert(panel->get_parent() == this);
 
-	size_t id = index < 0 ? tabs_.size() : index;
+	const size_t id = index < 0 ? tabs_.size() : index;
+	if (active_ >= id && !tabs_.empty()) {
+		++active_;
+	}
 	int32_t x = id > 0 ? tabs_[id - 1]->get_x() + tabs_[id - 1]->get_w() : 0;
 	tabs_.insert(
 	   tabs_.begin() + id,

--- a/src/ui_basic/tabpanel.cc
+++ b/src/ui_basic/tabpanel.cc
@@ -314,7 +314,8 @@ uint32_t TabPanel::add_tab(const std::string& name,
 
 	size_t id = index < 0 ? tabs_.size() : index;
 	int32_t x = id > 0 ? tabs_[id - 1]->get_x() + tabs_[id - 1]->get_w() : 0;
-	tabs_.insert(tabs_.begin() + id,
+	tabs_.insert(
+	   tabs_.begin() + id,
 	   new Tab(this, panel_style_, id, x,
 	           tab_style_ == TabPanelStyle::kFsMenu ? FontStyle::kFsMenuLabel : FontStyle::kWuiLabel,
 	           name, title, pic, tooltip_text, panel));

--- a/src/ui_basic/tabpanel.cc
+++ b/src/ui_basic/tabpanel.cc
@@ -286,8 +286,9 @@ void TabPanel::update_desired_size() {
 uint32_t TabPanel::add(const std::string& name,
                        const std::string& title,
                        Panel* const panel,
-                       const std::string& tooltip_text) {
-	return add_tab(name, title, nullptr, tooltip_text, panel);
+                       const std::string& tooltip_text,
+                       int index) {
+	return add_tab(name, title, nullptr, tooltip_text, panel, index);
 }
 
 /**
@@ -296,8 +297,9 @@ uint32_t TabPanel::add(const std::string& name,
 uint32_t TabPanel::add(const std::string& name,
                        const Image* pic,
                        Panel* const panel,
-                       const std::string& tooltip_text) {
-	return add_tab(name, "", pic, tooltip_text, panel);
+                       const std::string& tooltip_text,
+                       int index) {
+	return add_tab(name, "", pic, tooltip_text, panel, index);
 }
 
 /** Common adding function for textual and pictorial tabs. */
@@ -305,16 +307,22 @@ uint32_t TabPanel::add_tab(const std::string& name,
                            const std::string& title,
                            const Image* pic,
                            const std::string& tooltip_text,
-                           Panel* panel) {
+                           Panel* panel,
+                           int index) {
 	assert(panel);
 	assert(panel->get_parent() == this);
 
-	size_t id = tabs_.size();
+	size_t id = index < 0 ? tabs_.size() : index;
 	int32_t x = id > 0 ? tabs_[id - 1]->get_x() + tabs_[id - 1]->get_w() : 0;
-	tabs_.push_back(
+	tabs_.insert(tabs_.begin() + id,
 	   new Tab(this, panel_style_, id, x,
 	           tab_style_ == TabPanelStyle::kFsMenu ? FontStyle::kFsMenuLabel : FontStyle::kWuiLabel,
 	           name, title, pic, tooltip_text, panel));
+	const int tabw = tabs_.at(id)->get_w();
+	for (size_t i = id + 1; i < tabs_.size(); ++i) {
+		Tab* t = tabs_.at(i);
+		t->set_pos(Vector2i(t->get_x() + tabw, t->get_y()));
+	}
 
 	// Add a margin if there is a border
 	if (tab_style_ == UI::TabPanelStyle::kFsMenu) {

--- a/src/ui_basic/tabpanel.h
+++ b/src/ui_basic/tabpanel.h
@@ -105,7 +105,8 @@ struct TabPanel : public Panel {
 	uint32_t add(const std::string& name,
 	             const std::string& title,
 	             Panel* panel,
-	             const std::string& tooltip = std::string());
+	             const std::string& tooltip = std::string(),
+	             int index = -1);
 
 	/** Add pictorial tab
 	 * Text conventions: Sentence case for the 'tooltip'
@@ -113,7 +114,8 @@ struct TabPanel : public Panel {
 	uint32_t add(const std::string& name,
 	             const Image* pic,
 	             Panel* panel,
-	             const std::string& tooltip = std::string());
+	             const std::string& tooltip = std::string(),
+	             int index = -1);
 
 	using TabList = std::vector<Tab*>;
 
@@ -146,7 +148,8 @@ private:
 	                 const std::string& title,
 	                 const Image* pic,
 	                 const std::string& tooltip,
-	                 Panel* panel);
+	                 Panel* panel,
+	                 int index);
 
 	// Drawing and event handlers
 	void draw(RenderTarget&) override;


### PR DESCRIPTION
**Type of change**
New feature

**Issue(s) closed**
Fixes #5797

**How it works**
This adds a pseudo-immovable to the Immovable Placement menu to select a suitable tree type for each node.

**Possible regressions**
Editor multiselect tools; tabpanels

**Screenshots**
![shot0002](https://user-images.githubusercontent.com/48293446/230732114-b1f58a85-ad7d-43c4-bea7-046f6861d5a4.png)

