### PR TITLE
added size to tooltip

### DIFF
--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -33,17 +33,9 @@ namespace {
 UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
                                         LuaInterface* lua,
                                         const Widelands::ImmovableDescr& immovable_descr) {
-	const Image* pic = immovable_descr.representative_image();
+      const Image* pic = immovable_descr.representative_image();
 
-	std::string tooltip = immovable_descr.descname();
-	std::string size = Widelands::BaseImmovable::size_to_string(immovable_descr.get_size());
-	std::string size_str;
-	if (size == "none") {
-		size_str = _(" (removable by e.g. placing roads)");
-		} else {
-		size_str = format(_(" (needs a %1$s building plot)"), size);
-	}
-	tooltip.append(size_str);
+   std::string tooltip;
 
 	// Get information about preferred terrains
 	if (immovable_descr.has_terrain_affinity()) {
@@ -51,7 +43,14 @@ UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
 		std::unique_ptr<LuaCoroutine> cr(table->get_coroutine("func"));
 		cr->push_arg(immovable_descr.name());
 		cr->resume();
-		tooltip.append(cr->pop_table()->get_string("text"));
+		tooltip = format(_("%1$s %2$s"), immovable_descr.descname(), cr->pop_table()->get_string("text"));
+	} else {
+		std::string size = Widelands::BaseImmovable::size_to_string(immovable_descr.get_size());
+		if (size == "none") {
+			tooltip = format(_("%1$s (%2$s)"), immovable_descr.descname(), _("removable by e.g. placing roads"));
+		} else {
+			tooltip = format(_("%1$s (%2$s %3$s %4$s)"), immovable_descr.descname(), _("needs a"), size, _("building plot"));
+		}
 	}
 
 	UI::Checkbox* cb =

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -37,12 +37,12 @@ UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
 
 	std::string tooltip = immovable_descr.descname();
 	std::string size = Widelands::BaseImmovable::size_to_string(immovable_descr.get_size());
-	std::string size_str = "";
+	std::string size_str;
 	if (size == "none") {
 		size_str = _(" (removable by e.g. placing roads)");
 		} else {
 		size_str = format(_(" (needs a %1$s building plot)"), size);
-	};
+	}
 	tooltip.append(size_str);
 
 	// Get information about preferred terrains

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -36,6 +36,12 @@ UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
 	const Image* pic = immovable_descr.representative_image();
 
 	std::string tooltip = immovable_descr.descname();
+	std::string size = Widelands::BaseImmovable::size_to_string(immovable_descr.get_size());
+	if (size == "none") {
+		tooltip.append(_(" (removable by e.g. placing roads)"));
+		} else {
+		tooltip.append(_(" (needs a " + size + " building plot)"));
+	};
 
 	// Get information about preferred terrains
 	if (immovable_descr.has_terrain_affinity()) {

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -59,13 +59,6 @@ UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
 				tooltip = format(_("%1$s (needs a big building plot)"), immovable_descr.descname());
 				break;
 		}
-
-		std::string size = Widelands::BaseImmovable::size_to_string(immovable_descr.get_size());
-		if (size == "none") {
-			tooltip = format(_("%1$s (%2$s)"), immovable_descr.descname(), _("removable by e.g. placing roads"));
-		} else {
-			tooltip = format(_("%1$s (needs a %2$s building plot)"), immovable_descr.descname(), size);
-		}
 	}
 
 	UI::Checkbox* cb =

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -37,11 +37,13 @@ UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
 
 	std::string tooltip = immovable_descr.descname();
 	std::string size = Widelands::BaseImmovable::size_to_string(immovable_descr.get_size());
+	std::string size_str = "";
 	if (size == "none") {
-		tooltip.append(_(" (removable by e.g. placing roads)"));
+		size_str = _(" (removable by e.g. placing roads)");
 		} else {
-		tooltip.append(_(" (needs a " + size + " building plot)"));
+		size_str = format(_(" (needs a %1$s building plot)"), size);
 	};
+	tooltip.append(size_str);
 
 	// Get information about preferred terrains
 	if (immovable_descr.has_terrain_affinity()) {

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -45,6 +45,21 @@ UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
 		cr->resume();
 		tooltip = format(_("%1$s %2$s"), immovable_descr.descname(), cr->pop_table()->get_string("text"));
 	} else {
+		switch (immovable_descr.get_size()) {
+		case Widelands::BaseImmovable::NONE:
+				tooltip = format(_("%1$s (removable by e.g. placing roads)"), immovable_descr.descname());
+				break;
+		case Widelands::BaseImmovable::SMALL:
+				tooltip = format(_("%1$s (needs a small building plot)"), immovable_descr.descname());
+				break;
+		case Widelands::BaseImmovable::MEDIUM:
+				tooltip = format(_("%1$s (needs a medium building plot)"), immovable_descr.descname());
+				break;
+		case Widelands::BaseImmovable::BIG:
+				tooltip = format(_("%1$s (needs a big building plot)"), immovable_descr.descname());
+				break;
+		}
+
 		std::string size = Widelands::BaseImmovable::size_to_string(immovable_descr.get_size());
 		if (size == "none") {
 			tooltip = format(_("%1$s (%2$s)"), immovable_descr.descname(), _("removable by e.g. placing roads"));

--- a/src/editor/ui_menus/tool_place_immovable_options_menu.cc
+++ b/src/editor/ui_menus/tool_place_immovable_options_menu.cc
@@ -49,7 +49,7 @@ UI::Checkbox* create_immovable_checkbox(UI::Panel* parent,
 		if (size == "none") {
 			tooltip = format(_("%1$s (%2$s)"), immovable_descr.descname(), _("removable by e.g. placing roads"));
 		} else {
-			tooltip = format(_("%1$s (%2$s %3$s %4$s)"), immovable_descr.descname(), _("needs a"), size, _("building plot"));
+			tooltip = format(_("%1$s (needs a %2$s building plot)"), immovable_descr.descname(), size);
 		}
 	}
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #2099 

*If it's a bugfix:*
Steps to reproduce the behavior which cause the bug in master but not in your branch:
1. In editor open the immovables 
2. Tooltip has no representation of "size"

**New behavior**
The representation of size is now in the tooltip

**How it works**
*For features and functional changes:*
Adds some string to the tooltip of immovables

**Possible regressions**
I guess no

**Screenshots**
![immovablesize_01](https://user-images.githubusercontent.com/6730556/230853103-06cdf0aa-dd64-43e7-b29f-7677a5f5888a.jpg)
![immovablesize_02](https://user-images.githubusercontent.com/6730556/230853126-2de2ade4-3b72-4dfb-96f1-5b47396fce66.jpg)

For trees this may have to be changed:
![immovablesize_03](https://user-images.githubusercontent.com/6730556/230853408-14fc05f5-aa49-4708-9ab9-fbb3ee3a58e2.jpg)


**Additional context**
Don't know if the texts needs some changes for translation
