### PR TITLE
Naval Warfare: Coastal Invasion

### DIFF
--- a/src/logic/map.cc
+++ b/src/logic/map.cc
@@ -1793,18 +1793,19 @@ bool Map::is_cycle_connected(const FCoords& start, const std::vector<WalkingDir>
 	return true;
 }
 
+static constexpr WalkingDir kPortSpaceWalkingDirs[16] = {WALK_NE, WALK_NE, WALK_NE, WALK_NW, WALK_NW, WALK_W,
+                                         WALK_W,  WALK_W,  WALK_SW, WALK_SW, WALK_SW, WALK_SE,
+                                         WALK_SE, WALK_E,  WALK_E,  WALK_E};
+
 /**
  * Returns a list of portdock fields (if any) that a port built at \p c should have.
  */
 std::vector<Coords> Map::find_portdock(const Coords& c, bool force) const {
-	static const WalkingDir cycledirs[16] = {WALK_NE, WALK_NE, WALK_NE, WALK_NW, WALK_NW, WALK_W,
-	                                         WALK_W,  WALK_W,  WALK_SW, WALK_SW, WALK_SW, WALK_SE,
-	                                         WALK_SE, WALK_E,  WALK_E,  WALK_E};
 	const FCoords start = br_n(br_n(get_fcoords(c)));
 	const Widelands::PlayerNumber owner = start.field->get_owned_by();
 	FCoords f = start;
 	std::vector<Coords> portdock;
-	for (uint32_t i = 0; i < 16; ++i) {
+	for (WalkingDir next_direction : kPortSpaceWalkingDirs) {
 		if (force) {
 			if ((f.field->maxcaps() & MOVECAPS_SWIM) != 0) {
 				return {f};
@@ -1838,12 +1839,31 @@ std::vector<Coords> Map::find_portdock(const Coords& c, bool force) const {
 			}
 		}
 
-		if (i < 15) {
-			f = get_neighbour(f, cycledirs[i]);
-		}
+		f = get_neighbour(f, next_direction);
 	}
 
 	return portdock;
+}
+
+/**
+ * Finds a port space field where a port, if built, could have the provided coords in its portdock.
+ * Returns Coords::null() if no such port space exists.
+ */
+Coords Map::find_portspace_for_dockpoint(Coords dockpoint) const {
+	if (port_spaces_.empty()) {
+		return Coords::null();
+	}
+
+	dockpoint = tl_n(tl_n(dockpoint));
+	for (WalkingDir next_direction : kPortSpaceWalkingDirs) {
+		if (is_port_space(dockpoint)) {
+			return dockpoint;
+		}
+
+		dockpoint = get_neighbour(dockpoint, get_backward_dir(next_direction));
+	}
+
+	return Coords::null();
 }
 
 bool Map::is_port_space_allowed(const EditorGameBase& egbase, const FCoords& fc) const {

--- a/src/logic/map.cc
+++ b/src/logic/map.cc
@@ -1793,9 +1793,9 @@ bool Map::is_cycle_connected(const FCoords& start, const std::vector<WalkingDir>
 	return true;
 }
 
-static constexpr WalkingDir kPortSpaceWalkingDirs[16] = {WALK_NE, WALK_NE, WALK_NE, WALK_NW, WALK_NW, WALK_W,
-                                         WALK_W,  WALK_W,  WALK_SW, WALK_SW, WALK_SW, WALK_SE,
-                                         WALK_SE, WALK_E,  WALK_E,  WALK_E};
+static constexpr WalkingDir kPortSpaceWalkingDirs[16] = {
+   WALK_NE, WALK_NE, WALK_NE, WALK_NW, WALK_NW, WALK_W, WALK_W, WALK_W,
+   WALK_SW, WALK_SW, WALK_SW, WALK_SE, WALK_SE, WALK_E, WALK_E, WALK_E};
 
 /**
  * Returns a list of portdock fields (if any) that a port built at \p c should have.

--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -461,6 +461,7 @@ public:
 
 	void get_neighbour(const Coords&, Direction dir, Coords*) const;
 	void get_neighbour(const FCoords&, Direction dir, FCoords*) const;
+	[[nodiscard]] Coords get_neighbour(const Coords&, Direction dir) const;
 	[[nodiscard]] FCoords get_neighbour(const FCoords&, Direction dir) const;
 
 	[[nodiscard]] std::set<Coords> to_set(Area<Coords> area) const;
@@ -580,6 +581,7 @@ public:
 		return port_spaces_;
 	}
 	[[nodiscard]] std::vector<Coords> find_portdock(const Widelands::Coords& c, bool force) const;
+	[[nodiscard]] Coords find_portspace_for_dockpoint(Coords dockpoint) const;
 
 	/// Return true if there are at least 2 port spaces that can be reached from each other by water
 	[[nodiscard]] bool allows_seafaring() const;
@@ -1307,6 +1309,24 @@ inline FCoords Map::br_n(const FCoords& f) const {
 }
 
 inline FCoords Map::get_neighbour(const FCoords& f, const Direction dir) const {
+	switch (dir) {
+	case WALK_NW:
+		return tl_n(f);
+	case WALK_NE:
+		return tr_n(f);
+	case WALK_E:
+		return r_n(f);
+	case WALK_SE:
+		return br_n(f);
+	case WALK_SW:
+		return bl_n(f);
+	case WALK_W:
+		return l_n(f);
+	default:
+		NEVER_HERE();
+	}
+}
+inline Coords Map::get_neighbour(const Coords& f, const Direction dir) const {
 	switch (dir) {
 	case WALK_NW:
 		return tl_n(f);

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -626,7 +626,8 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 						   ShipStates::kExpeditionWaiting, NoteShip::Action::kWaitingForCommand);
 
 						send_message(game, _("Port Space"), _("Port Space Found"),
-							         _("A warship found a new port build space."), descr().icon_filename());
+						             _("A warship found a new port build space."),
+						             descr().icon_filename());
 					}
 				}
 			}
@@ -1118,11 +1119,11 @@ void Ship::battle_update(Game& game) {
 			if (target_ship != nullptr) {
 				molog(game.get_gametime(),
 				      "Could not find a path to opponent ship %u %s from %dx%d to %dx%d",
-					  target_ship->serial(), target_ship->get_shipname().c_str(), get_position().x,
-					  get_position().y, dest.x, dest.y);
+				      target_ship->serial(), target_ship->get_shipname().c_str(), get_position().x,
+				      get_position().y, dest.x, dest.y);
 			} else {
 				molog(game.get_gametime(), "Could not find a path to attack coords from %dx%d to %dx%d",
-					  get_position().x, get_position().y, dest.x, dest.y);
+				      get_position().x, get_position().y, dest.x, dest.y);
 			}
 
 			battles_.pop_back();

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -597,7 +597,7 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 					}
 				}
 
-				assert(map->is_port_space(f));
+				assert(map->is_port_space(c));
 				new_coords = c;
 				distance = d;
 			}

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1029,6 +1029,7 @@ void Ship::battle_update(Game& game) {
 	};
 	auto damage = [this, &game, set_phase, &current_battle, other_battle,
 	               target_ship](Battle::Phase next) {
+		assert(target_ship != nullptr);
 		if (target_ship->hitpoints_ > current_battle.pending_damage) {
 			target_ship->hitpoints_ -= current_battle.pending_damage;
 			set_phase(next);

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1119,7 +1119,10 @@ void Ship::battle_update(Game& game) {
 			// The naval assault was successful. Now unload the soldiers.
 			// From the ship's perspective, the attack was a success.
 
-			const PlayerNumber enemy_pn = map[current_battle.attack_coords].get_owned_by();
+			Coords portspace = map.find_portspace_for_dockpoint(current_battle.attack_coords);
+			assert(portspace != Coords::null());
+
+			const PlayerNumber enemy_pn = map[portspace].get_owned_by();
 			if (enemy_pn != 0) {
 				game.get_player(enemy_pn)->add_message_with_timeout(game, std::unique_ptr<Message>(new Message(
 					                          Message::Type::kSeafaring, game.get_gametime(), _("Naval Attack"), "images/wui/ship/ship_attack.png",
@@ -1148,7 +1151,7 @@ void Ship::battle_update(Game& game) {
 				// Distribute the soldiers on walkable fields around the point of invasion.
 				// Do not drop them off directly on a flag as that would interfere with battle code.
 				for (;;) {
-					Coords coords = game.random_location(current_battle.attack_coords, 3);
+					Coords coords = game.random_location(current_battle.attack_coords, 4);
 					const Field& field = map[coords];
 					if ((field.nodecaps() & MOVECAPS_WALK) != 0U && (field.get_immovable() == nullptr || field.get_immovable()->descr().type() != MapObjectType::FLAG)) {
 						worker->set_position(game, coords);
@@ -1157,7 +1160,7 @@ void Ship::battle_update(Game& game) {
 				}
 
 				worker->reset_tasks(game);
-				dynamic_cast<Soldier&>(*worker).start_task_naval_invasion(game, current_battle.attack_coords);
+				dynamic_cast<Soldier&>(*worker).start_task_naval_invasion(game, portspace);
 
 				items_.erase(it);
 			}

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -143,11 +143,12 @@ struct Ship : Bob {
 			kDefenderAttacking = 5,
 		};
 
-		Battle(MapObject* o, const std::vector<uint32_t>& a, bool f)
-		   : opponent(o), attack_soldier_serials(a), is_first(f) {
+		Battle(Ship* o, Coords ac, const std::vector<uint32_t>& a, bool f)
+		   : opponent(o), attack_coords(ac), attack_soldier_serials(a), is_first(f) {
 		}
 
-		OPtr<MapObject> opponent;
+		OPtr<Ship> opponent;
+		Coords attack_coords;
 		std::vector<uint32_t> attack_soldier_serials;
 		Time time_of_last_action;
 		uint32_t pending_damage{0U};
@@ -251,8 +252,11 @@ struct Ship : Bob {
 		capacity_ = c;
 	}
 
-	[[nodiscard]] MapObject* get_attack_target(const EditorGameBase& e) const {
+	[[nodiscard]] Ship* get_attack_target(const EditorGameBase& e) const {
 		return expedition_ != nullptr ? expedition_->attack_target.get(e) : nullptr;
+	}
+	[[nodiscard]] Coords get_attack_coords() const {
+		return expedition_ != nullptr ? expedition_->attack_coords : Coords::null();
 	}
 	[[nodiscard]] bool has_battle() const {
 		return !battles_.empty();
@@ -362,7 +366,8 @@ private:
 		WalkingDir scouting_direction;
 		Coords exploration_start;
 		IslandExploreDirection island_explore_direction;
-		OPtr<MapObject> attack_target;
+		OPtr<Ship> attack_target;
+		Coords attack_coords;
 		Economy* ware_economy;  // Owned by Player
 		Economy* worker_economy;
 	};

--- a/src/wui/shipwindow.cc
+++ b/src/wui/shipwindow.cc
@@ -444,8 +444,7 @@ void ShipWindow::think() {
                               _("Refit to transport ship") :
                               _("Refit to warship"));
 	btn_warship_attack_->set_enabled(can_act && ship->can_attack() &&
-	                                 (ship->get_attack_target(ibase_.egbase())->descr().type() !=
-	                                     Widelands::MapObjectType::PORTDOCK ||
+	                                 (ship->get_attack_target(ibase_.egbase()) != nullptr ||
 	                                  warship_soldiers_display_->count_soldiers() > 0U));
 	btn_warship_stay_->set_enabled(can_act);
 


### PR DESCRIPTION
**Type of change**
Feature Enhancement

**Issue(s) closed**
Continues naval warfare

**How it works**
Instead of being able to attack only enemy ports to launch a sea-to-land invasion, you can now invade any port space not owned by you, even if no port exists there.

**Possible regressions**
Naval warfare

**Additional context**
The last major mechanical change. After this there are additional tasks remaining like a better attack UI, graphics, and a tutorial, but the mechanics are mostly done at this point.