### PR TITLE
Validate that all tribes possess all special animations

### DIFF
--- a/src/logic/map_objects/tribes/tribe_descr.cc
+++ b/src/logic/map_objects/tribes/tribe_descr.cc
@@ -396,13 +396,13 @@ void TribeDescr::load_frontiers_flags_roads(const LuaTable& table) {
 	}
 
 	if (flag_animation_id_ == 0U) {
-			throw GameDataError("Tribe has no flag animation.");
+		throw GameDataError("Tribe has no flag animation.");
 	}
 	if (frontier_animation_id_ == 0U) {
-			throw GameDataError("Tribe has no frontier animation.");
+		throw GameDataError("Tribe has no frontier animation.");
 	}
 	if (pinned_note_animation_id_ == 0U) {
-			throw GameDataError("Tribe has no pinned note animation.");
+		throw GameDataError("Tribe has no pinned note animation.");
 	}
 }
 

--- a/src/logic/map_objects/tribes/tribe_descr.cc
+++ b/src/logic/map_objects/tribes/tribe_descr.cc
@@ -394,6 +394,16 @@ void TribeDescr::load_frontiers_flags_roads(const LuaTable& table) {
 		load_animations(
 		   *table.get_table("spritesheets"), animation_directory, Animation::Type::kSpritesheet);
 	}
+
+	if (flag_animation_id_ == 0U) {
+			throw GameDataError("Tribe has no flag animation.");
+	}
+	if (frontier_animation_id_ == 0U) {
+			throw GameDataError("Tribe has no frontier animation.");
+	}
+	if (pinned_note_animation_id_ == 0U) {
+			throw GameDataError("Tribe has no pinned note animation.");
+	}
 }
 
 void TribeDescr::load_ships(const LuaTable& table, Descriptions& descriptions) {

--- a/src/logic/map_objects/tribes/tribe_descr.h
+++ b/src/logic/map_objects/tribes/tribe_descr.h
@@ -241,9 +241,9 @@ private:
 	const std::string descname_;
 	const Descriptions& descriptions_;
 
-	uint32_t frontier_animation_id_;
-	uint32_t flag_animation_id_;
-	uint32_t pinned_note_animation_id_;
+	uint32_t frontier_animation_id_{0U};
+	uint32_t flag_animation_id_{0U};
+	uint32_t pinned_note_animation_id_{0U};
 	struct BridgeAnimationIDs {
 		uint32_t e;
 		uint32_t se;


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Closes #5860

**To reproduce**
Start a game with a tribe that does not have a pinned note animation (currently Europeans) and place a pinned note.

**New behavior**
During tribe loading, throw a well-behaved error if any of the tribe's global animations (flag, frontier, pinned note) are undefined.

**Screenshots**
![grafik](https://user-images.githubusercontent.com/48293446/233619672-459bcf3a-44dc-4344-bb1d-a3ac4f212226.png)

**Additional context**
@MarkMcWire Please add a pinned note anim to Europeans :) 