### PR TITLE
Refactor Game Configuration Flags

### DIFF
--- a/src/editor/ui_menus/main_menu_random_map.cc
+++ b/src/editor/ui_menus/main_menu_random_map.cc
@@ -693,9 +693,6 @@ bool MainMenuNewRandomMapPanel::do_generate_map(Widelands::EditorGameBase& egbas
 			sp->set_map("", "", map_info.world_name, "", nr_players, false);
 			sp->set_scenario(false);
 			sp->set_player_number(plnum);
-			sp->set_peaceful_mode(false);
-			sp->set_fogless(false);
-			sp->set_custom_starting_positions(false);
 
 			for (unsigned p = 0; p < nr_players; ++p) {
 				sp->set_player_name(

--- a/src/logic/game.cc
+++ b/src/logic/game.cc
@@ -371,7 +371,7 @@ void Game::init_newgame(const GameSettings& settings) {
 	// Check for win_conditions
 	if (!settings.scenario) {
 		Notifications::publish(UI::NoteLoadingMessage(_("Initializing game…")));
-		if (settings.peaceful) {
+		if ((settings.flags & GameSettings::Flags::kPeaceful) != 0) {
 			for (uint32_t i = 1; i < settings.players.size(); ++i) {
 				if (Player* p1 = get_player(i)) {
 					for (uint32_t j = i + 1; j <= settings.players.size(); ++j) {
@@ -383,7 +383,7 @@ void Game::init_newgame(const GameSettings& settings) {
 				}
 			}
 		}
-		if (settings.custom_starting_positions) {
+		if ((settings.flags & GameSettings::Flags::kCustomStartingPositions) != 0) {
 			iterate_players_existing(p, map().get_nrplayers(), *this, pl) {
 				if (settings.get_tribeinfo(pl->tribe().name())
 				       .initializations[pl->initialization_index()]
@@ -393,7 +393,7 @@ void Game::init_newgame(const GameSettings& settings) {
 			}
 		}
 
-		if (settings.fogless) {
+		if ((settings.flags & GameSettings::Flags::kFogless) != 0) {
 			Coords c;
 			iterate_players_existing(p, map().get_nrplayers(), *this, pl) {
 				c.x = 0;
@@ -406,6 +406,7 @@ void Game::init_newgame(const GameSettings& settings) {
 			}
 		}
 
+		diplomacy_allowed_ &= ((settings.flags & GameSettings::Flags::kForbidDiplomacy) == 0);
 		win_condition_duration_ = settings.win_condition_duration;
 		std::unique_ptr<LuaTable> table(lua().run_script(settings.win_condition_script));
 		table->do_not_warn_about_unaccessed_keys();

--- a/src/logic/game_settings.h
+++ b/src/logic/game_settings.h
@@ -109,13 +109,16 @@ struct NoteGameSettings {
 	}
 };
 
-/**
- * Holds all settings about a game that can be configured before the
- * game actually starts.
- *
- * Think of it as the Model in MVC.
- */
+/** Holds all settings about a game that can be configured before the game actually starts. */
 struct GameSettings {
+	enum Flags : uint16_t {
+		kNone = 0,                          ///< No special options (the default).
+		kPeaceful = 1 << 0,                 ///< No fighting between players.
+		kCustomStartingPositions = 1 << 1,  ///< Players may choose their own starting positions.
+		kFogless = 1 << 2,                  ///< The entire map is always visible.
+		kForbidDiplomacy = 1 << 3,          ///< Players may not change their alliances.
+	};
+
 	GameSettings() {
 		std::unique_ptr<LuaInterface> lua(new LuaInterface);
 		std::unique_ptr<LuaTable> win_conditions(
@@ -181,14 +184,8 @@ struct GameSettings {
 	/// Is a savegame selected for loading?
 	bool savegame{false};
 
-	/// Is all fighting forbidden?
-	bool peaceful{false};
-
-	/// Is fog of war disabled?
-	bool fogless{false};
-
-	// Whether players may pick their own starting positions
-	bool custom_starting_positions{false};
+	/// Additional flags to control game behaviour.
+	uint16_t flags{Flags::kNone};
 
 	std::string map_theme;
 	std::string map_background;
@@ -251,14 +248,8 @@ struct GameSettingsProvider {
 	virtual void set_win_condition_duration(int32_t duration) = 0;
 	virtual int32_t get_win_condition_duration() = 0;
 
-	virtual void set_peaceful_mode(bool peace) = 0;
-	virtual bool is_peaceful_mode() = 0;
-
-	virtual void set_fogless(bool fogless) = 0;
-	virtual bool is_fogless() = 0;
-
-	virtual void set_custom_starting_positions(bool) = 0;
-	virtual bool get_custom_starting_positions() = 0;
+	virtual void set_flag(GameSettings::Flags flag, bool state) = 0;
+	virtual bool get_flag(GameSettings::Flags flag) = 0;
 
 	bool has_players_tribe() {
 		return UserSettings::highest_playernum() >= settings().playernum;

--- a/src/logic/game_settings.h
+++ b/src/logic/game_settings.h
@@ -112,7 +112,7 @@ struct NoteGameSettings {
 /** Holds all settings about a game that can be configured before the game actually starts. */
 struct GameSettings {
 	enum Flags : uint16_t {
-		kNone = 0,                          ///< No special options (the default).
+		kDefaultSettings = 0,               ///< No special options; the default.
 		kPeaceful = 1 << 0,                 ///< No fighting between players.
 		kCustomStartingPositions = 1 << 1,  ///< Players may choose their own starting positions.
 		kFogless = 1 << 2,                  ///< The entire map is always visible.
@@ -185,7 +185,7 @@ struct GameSettings {
 	bool savegame{false};
 
 	/// Additional flags to control game behaviour.
-	uint16_t flags{Flags::kNone};
+	uint16_t flags{Flags::kDefaultSettings};
 
 	std::string map_theme;
 	std::string map_background;

--- a/src/logic/single_player_game_settings_provider.cc
+++ b/src/logic/single_player_game_settings_provider.cc
@@ -70,28 +70,16 @@ std::string SinglePlayerGameSettingsProvider::get_map() {
 	return s.mapfilename;
 }
 
-bool SinglePlayerGameSettingsProvider::is_peaceful_mode() {
-	return s.peaceful;
+void SinglePlayerGameSettingsProvider::set_flag(GameSettings::Flags flag, bool state) {
+	if (state) {
+		s.flags |= flag;
+	} else {
+		s.flags &= ~flag;
+	}
 }
 
-void SinglePlayerGameSettingsProvider::set_peaceful_mode(bool peace) {
-	s.peaceful = peace;
-}
-
-bool SinglePlayerGameSettingsProvider::is_fogless() {
-	return s.fogless;
-}
-
-void SinglePlayerGameSettingsProvider::set_fogless(bool fogless) {
-	s.fogless = fogless;
-}
-
-bool SinglePlayerGameSettingsProvider::get_custom_starting_positions() {
-	return s.custom_starting_positions;
-}
-
-void SinglePlayerGameSettingsProvider::set_custom_starting_positions(bool c) {
-	s.custom_starting_positions = c;
+bool SinglePlayerGameSettingsProvider::get_flag(GameSettings::Flags flag) {
+	return (s.flags & flag) != 0;
 }
 
 void SinglePlayerGameSettingsProvider::set_map(const std::string& mapname,

--- a/src/logic/single_player_game_settings_provider.h
+++ b/src/logic/single_player_game_settings_provider.h
@@ -65,14 +65,8 @@ struct SinglePlayerGameSettingsProvider : public GameSettingsProvider {
 	int32_t get_win_condition_duration() override;
 	void set_win_condition_duration(int32_t duration) override;
 
-	void set_peaceful_mode(bool peace) override;
-	bool is_peaceful_mode() override;
-
-	void set_fogless(bool fogless) override;
-	bool is_fogless() override;
-
-	void set_custom_starting_positions(bool) override;
-	bool get_custom_starting_positions() override;
+	void set_flag(GameSettings::Flags flag, bool state) override;
+	bool get_flag(GameSettings::Flags flag) override;
 
 private:
 	GameSettings s;

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -548,28 +548,16 @@ void GameClient::set_player(uint8_t /*number*/, const PlayerSettings& /* setting
 	// set_player_number(uint8_t) to the host.
 }
 
-void GameClient::set_peaceful_mode(bool peace) {
-	d->settings.peaceful = peace;
+void GameClient::set_flag(GameSettings::Flags flag, bool state) {
+	if (state) {
+		d->settings.flags |= flag;
+	} else {
+		d->settings.flags &= ~flag;
+	}
 }
 
-bool GameClient::is_peaceful_mode() {
-	return d->settings.peaceful;
-}
-
-void GameClient::set_fogless(bool fogless) {
-	d->settings.fogless = fogless;
-}
-
-bool GameClient::is_fogless() {
-	return d->settings.fogless;
-}
-
-void GameClient::set_custom_starting_positions(bool c) {
-	d->settings.custom_starting_positions = c;
-}
-
-bool GameClient::get_custom_starting_positions() {
-	return d->settings.custom_starting_positions;
+bool GameClient::get_flag(GameSettings::Flags flag) {
+	return (d->settings.flags & flag) != 0;
 }
 
 std::string GameClient::get_win_condition_script() {
@@ -1191,14 +1179,8 @@ void GameClient::handle_packet(RecvPacket& packet) {
 	case NETCMD_WIN_CONDITION_DURATION:
 		d->settings.win_condition_duration = packet.signed_32();
 		break;
-	case NETCMD_PEACEFUL_MODE:
-		d->settings.peaceful = (packet.unsigned_8() != 0u);
-		break;
-	case NETCMD_FOGLESS:
-		d->settings.fogless = (packet.unsigned_8() != 0u);
-		break;
-	case NETCMD_CUSTOM_STARTING_POSITIONS:
-		d->settings.custom_starting_positions = (packet.unsigned_8() != 0u);
+	case NETCMD_GAMEFLAGS:
+		d->settings.flags = packet.unsigned_16();
 		break;
 	case NETCMD_LAUNCH:
 		if ((d->game != nullptr) || ((d->modal != nullptr) && d->modal->is_modal())) {

--- a/src/network/gameclient.h
+++ b/src/network/gameclient.h
@@ -108,14 +108,8 @@ struct GameClient : public GameController, public GameSettingsProvider, public C
 	int32_t get_win_condition_duration() override;
 	void set_win_condition_duration(int32_t duration) override;
 
-	void set_peaceful_mode(bool peace) override;
-	bool is_peaceful_mode() override;
-
-	void set_fogless(bool fogless) override;
-	bool is_fogless() override;
-
-	void set_custom_starting_positions(bool) override;
-	bool get_custom_starting_positions() override;
+	void set_flag(GameSettings::Flags flag, bool state) override;
+	bool get_flag(GameSettings::Flags flag) override;
 
 	// ChatProvider interface
 	void send(const std::string& msg) override;

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -1390,33 +1390,17 @@ void GameHost::set_win_condition_duration(const int32_t duration) {
 	broadcast(packet);
 }
 
-void GameHost::set_peaceful_mode(bool peace) {
-	d->settings.peaceful = peace;
+void GameHost::set_flag(GameSettings::Flags flag, bool state) {
+	if (state) {
+		d->settings.flags |= flag;
+	} else {
+		d->settings.flags &= ~flag;
+	}
 
 	// Broadcast changes
 	SendPacket packet;
-	packet.unsigned_8(NETCMD_PEACEFUL_MODE);
-	packet.unsigned_8(peace ? 1 : 0);
-	broadcast(packet);
-}
-
-void GameHost::set_fogless(bool fogless) {
-	d->settings.fogless = fogless;
-
-	// Broadcast changes
-	SendPacket packet;
-	packet.unsigned_8(NETCMD_FOGLESS);
-	packet.unsigned_8(fogless ? 1 : 0);
-	broadcast(packet);
-}
-
-void GameHost::set_custom_starting_positions(bool c) {
-	d->settings.custom_starting_positions = c;
-
-	// Broadcast changes
-	SendPacket packet;
-	packet.unsigned_8(NETCMD_CUSTOM_STARTING_POSITIONS);
-	packet.unsigned_8(c ? 1 : 0);
+	packet.unsigned_8(NETCMD_GAMEFLAGS);
+	packet.unsigned_16(d->settings.flags);
 	broadcast(packet);
 }
 
@@ -1786,18 +1770,8 @@ void GameHost::welcome_client(uint32_t const number, std::string& playername) {
 	d->net->send(client.sock_id, packet);
 
 	packet.reset();
-	packet.unsigned_8(NETCMD_PEACEFUL_MODE);
-	packet.unsigned_8(d->settings.peaceful ? 1 : 0);
-	d->net->send(client.sock_id, packet);
-
-	packet.reset();
-	packet.unsigned_8(NETCMD_FOGLESS);
-	packet.unsigned_8(d->settings.fogless ? 1 : 0);
-	d->net->send(client.sock_id, packet);
-
-	packet.reset();
-	packet.unsigned_8(NETCMD_CUSTOM_STARTING_POSITIONS);
-	packet.unsigned_8(d->settings.custom_starting_positions ? 1 : 0);
+	packet.unsigned_8(NETCMD_GAMEFLAGS);
+	packet.unsigned_16(d->settings.flags);
 	d->net->send(client.sock_id, packet);
 
 	// Broadcast new information about the player to everybody
@@ -2416,9 +2390,7 @@ void GameHost::handle_packet(uint32_t const client_num, RecvPacket& r) {
 	case NETCMD_SETTING_PLAYER:
 	case NETCMD_WIN_CONDITION:
 	case NETCMD_WIN_CONDITION_DURATION:
-	case NETCMD_PEACEFUL_MODE:
-	case NETCMD_FOGLESS:
-	case NETCMD_CUSTOM_STARTING_POSITIONS:
+	case NETCMD_GAMEFLAGS:
 	case NETCMD_LAUNCH:
 		if (d->game ==
 		    nullptr) {  // not expected while game is in progress -> something is wrong here

--- a/src/network/gamehost.h
+++ b/src/network/gamehost.h
@@ -99,9 +99,7 @@ public:
 	void switch_to_player(uint32_t user, uint8_t number);
 	void set_win_condition_script(const std::string& wc);
 	void set_win_condition_duration(int32_t duration);
-	void set_peaceful_mode(bool peace);
-	void set_fogless(bool fogless);
-	void set_custom_starting_positions(bool);
+	void set_flag(GameSettings::Flags flag, bool state);
 	void replace_client_with_ai(uint8_t playernumber, const std::string& ai);
 
 	void set_script_to_run(const std::string& s) {

--- a/src/network/host_game_settings_provider.cc
+++ b/src/network/host_game_settings_provider.cc
@@ -192,26 +192,10 @@ void HostGameSettingsProvider::set_win_condition_duration(const int32_t duration
 	host_->set_win_condition_duration(duration);
 }
 
-void HostGameSettingsProvider::set_peaceful_mode(bool peace) {
-	host_->set_peaceful_mode(peace);
+void HostGameSettingsProvider::set_flag(GameSettings::Flags flag, bool state) {
+	host_->set_flag(flag, state);
 }
 
-bool HostGameSettingsProvider::is_peaceful_mode() {
-	return HostGameSettingsProvider::settings().peaceful;
-}
-
-void HostGameSettingsProvider::set_fogless(bool fogless) {
-	host_->set_fogless(fogless);
-}
-
-bool HostGameSettingsProvider::is_fogless() {
-	return HostGameSettingsProvider::settings().fogless;
-}
-
-void HostGameSettingsProvider::set_custom_starting_positions(bool c) {
-	host_->set_custom_starting_positions(c);
-}
-
-bool HostGameSettingsProvider::get_custom_starting_positions() {
-	return HostGameSettingsProvider::settings().custom_starting_positions;
+bool HostGameSettingsProvider::get_flag(GameSettings::Flags flag) {
+	return (host_->settings().flags & flag) != 0;
 }

--- a/src/network/host_game_settings_provider.h
+++ b/src/network/host_game_settings_provider.h
@@ -63,14 +63,8 @@ public:
 	int32_t get_win_condition_duration() override;
 	void set_win_condition_duration(int32_t duration) override;
 
-	void set_peaceful_mode(bool peace) override;
-	bool is_peaceful_mode() override;
-
-	void set_fogless(bool fogless) override;
-	bool is_fogless() override;
-
-	void set_custom_starting_positions(bool) override;
-	bool get_custom_starting_positions() override;
+	void set_flag(GameSettings::Flags flag, bool state) override;
+	bool get_flag(GameSettings::Flags flag) override;
 
 private:
 	GameHost* host_;

--- a/src/network/network_protocol.h
+++ b/src/network/network_protocol.h
@@ -27,7 +27,7 @@ enum {
 	 * The current version of the in-game network protocol. Client and host
 	 * protocol versions must match.
 	 */
-	NETWORK_PROTOCOL_VERSION = 30,
+	NETWORK_PROTOCOL_VERSION = 31,
 
 	/**
 	 * The default interval (in milliseconds) in which the host issues
@@ -435,20 +435,12 @@ enum : uint8_t {
 	NETCMD_SYSTEM_MESSAGE_CODE = 32,
 
 	/**
-	 * Sent by the host to toggle peaceful mode.
+	 * Sent by the host to set game flags.
 	 *
 	 * Attached data is:
-	 * \li uint8_t: 1 if peaceful mode is enabled, 0 otherwise
+	 * \li uint16_t: Bitset of all enabled game flags.
 	 */
-	NETCMD_PEACEFUL_MODE = 33,
-
-	/**
-	 * Sent by the host to toggle custom_starting_positions mode.
-	 *
-	 * Attached data is:
-	 * \li uint8_t: 1 if custom_starting_positions mode is enabled, 0 otherwise
-	 */
-	NETCMD_CUSTOM_STARTING_POSITIONS = 34,
+	NETCMD_GAMEFLAGS = 33,
 
 	/**
 	 * During game setup, this is sent by the client to indicate that the
@@ -468,14 +460,6 @@ enum : uint8_t {
 	 * \li signed_32: win condition duration in minutes
 	 */
 	NETCMD_WIN_CONDITION_DURATION = 36,
-
-	/**
-	 * Sent by the host to toggle fogless mode.
-	 *
-	 * Attached data is:
-	 * \li uint8_t: 1 if fogless mode is enabled, 0 otherwise
-	 */
-	NETCMD_FOGLESS = 37,
 
 	/**
 	 * Sent by the metaserver to a freshly opened game to check connectability

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -246,8 +246,7 @@ bool LaunchGame::should_write_replay() const {
 void LaunchGame::update_advanced_options() {
 	const bool show = toggle_advanced_options_.style() == UI::Button::VisualState::kPermpressed;
 	advanced_options_box_.set_visible(show);
-	toggle_advanced_options_.set_title(show ? _("Show fewer options") :
-                                             _("Show more options"));
+	toggle_advanced_options_.set_title(show ? _("Show fewer options") : _("Show more options"));
 	layout();
 }
 

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -92,41 +92,44 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
                              5,
                              60),
 
-toggle_advanced_options_(&right_column_content_box_,
-                                   "toggle_advanced",
-                                   0,
-                                   0,
-                                   0,
-                                   ok_.get_h(),
-                                   UI::ButtonStyle::kFsMenuSecondary,
-                                   "" /* set later */,
-                                   _("Show or hide the advanced game configuration options")),
-advanced_options_box_(&right_column_content_box_, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Vertical),
+     toggle_advanced_options_(&right_column_content_box_,
+                              "toggle_advanced",
+                              0,
+                              0,
+                              0,
+                              ok_.get_h(),
+                              UI::ButtonStyle::kFsMenuSecondary,
+                              "" /* set later */,
+                              _("Show or hide the advanced game configuration options")),
+     advanced_options_box_(
+        &right_column_content_box_, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Vertical),
 
-game_flag_checkboxes_({
-{GameSettings::Flags::kPeaceful, {
-     new UI::Checkbox(
-        &advanced_options_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("Peaceful mode")),
-&LaunchGame::update_peaceful_mode}},
+     game_flag_checkboxes_({
+        {GameSettings::Flags::kPeaceful,
+         {new UI::Checkbox(
+             &advanced_options_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("Peaceful mode")),
+          &LaunchGame::update_peaceful_mode}},
 
-{GameSettings::Flags::kFogless, {
-     new UI::Checkbox(
-        &advanced_options_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("No fog of war")),
-&LaunchGame::update_fogless}},
+        {GameSettings::Flags::kFogless,
+         {new UI::Checkbox(
+             &advanced_options_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("No fog of war")),
+          &LaunchGame::update_fogless}},
 
-{GameSettings::Flags::kForbidDiplomacy, {
-     new UI::Checkbox(
-        &advanced_options_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("Forbid diplomacy")),
-&LaunchGame::update_forbid_diplomacy}},
+        {GameSettings::Flags::kForbidDiplomacy,
+         {new UI::Checkbox(&advanced_options_box_,
+                           UI::PanelStyle::kFsMenu,
+                           Vector2i::zero(),
+                           _("Forbid diplomacy")),
+          &LaunchGame::update_forbid_diplomacy}},
 
-{GameSettings::Flags::kCustomStartingPositions, {
-     new UI::Checkbox(&advanced_options_box_,
-                                UI::PanelStyle::kFsMenu,
-                                Vector2i::zero(),
-                                _("Custom starting positions")),
-&LaunchGame::update_custom_starting_positions}},
+        {GameSettings::Flags::kCustomStartingPositions,
+         {new UI::Checkbox(&advanced_options_box_,
+                           UI::PanelStyle::kFsMenu,
+                           Vector2i::zero(),
+                           _("Custom starting positions")),
+          &LaunchGame::update_custom_starting_positions}},
 
-}),
+     }),
      choose_map_(mpg && settings.can_change_map() && !preconfigured ?
                     new UI::Button(&right_column_content_box_,
                                    "choose_map",
@@ -157,7 +160,8 @@ game_flag_checkboxes_({
 	win_condition_dropdown_.selected.connect([this]() { win_condition_selected(); });
 	win_condition_duration_.changed.connect([this]() { win_condition_duration_changed(); });
 	for (auto& pair : game_flag_checkboxes_) {
-		pair.second.first->changed.connect([this, pair]() { settings_.set_flag(pair.first, pair.second.first->get_state()); });
+		pair.second.first->changed.connect(
+		   [this, pair]() { settings_.set_flag(pair.first, pair.second.first->get_state()); });
 	}
 	toggle_advanced_options_.sigclicked.connect([this]() {
 		toggle_advanced_options_.toggle();
@@ -242,7 +246,8 @@ bool LaunchGame::should_write_replay() const {
 void LaunchGame::update_advanced_options() {
 	const bool show = toggle_advanced_options_.style() == UI::Button::VisualState::kPermpressed;
 	advanced_options_box_.set_visible(show);
-	toggle_advanced_options_.set_title(show ? _("Hide advanced options") : _("Show advanced options"));
+	toggle_advanced_options_.set_title(show ? _("Hide advanced options") :
+                                             _("Show advanced options"));
 	layout();
 }
 
@@ -268,7 +273,8 @@ void LaunchGame::update_peaceful_mode() {
 }
 
 void LaunchGame::update_custom_starting_positions() {
-	UI::Checkbox* checkbox = game_flag_checkboxes_.at(GameSettings::Flags::kCustomStartingPositions).first;
+	UI::Checkbox* checkbox =
+	   game_flag_checkboxes_.at(GameSettings::Flags::kCustomStartingPositions).first;
 	const GameSettings& settings = settings_.settings();
 	const bool forbidden = settings.scenario || settings.savegame;
 

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -51,8 +51,6 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
                      0,
                      _("Configure this game"),
                      UI::Align::kCenter),
-     write_replay_(
-        &right_column_content_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("Write Replay")),
      warn_desyncing_addon_(
         &right_column_content_box_,
         0,
@@ -100,10 +98,9 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
                               ok_.get_h(),
                               UI::ButtonStyle::kFsMenuSecondary,
                               "" /* set later */,
-                              _("Show or hide the advanced game configuration options")),
+                              _("Show or hide additional game configuration options")),
      advanced_options_box_(
         &right_column_content_box_, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Vertical),
-
      game_flag_checkboxes_({
         {GameSettings::Flags::kPeaceful,
          {new UI::Checkbox(
@@ -130,6 +127,9 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
           &LaunchGame::update_custom_starting_positions}},
 
      }),
+     write_replay_(
+        &advanced_options_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("Write Replay")),
+
      choose_map_(mpg && settings.can_change_map() && !preconfigured ?
                     new UI::Button(&right_column_content_box_,
                                    "choose_map",
@@ -194,7 +194,6 @@ LaunchGame::~LaunchGame() {
 void LaunchGame::add_all_widgets() {
 	right_column_content_box_.add(&map_details_, UI::Box::Resizing::kExpandBoth);
 	right_column_content_box_.add_space(1 * kPadding);
-	right_column_content_box_.add(&write_replay_, UI::Box::Resizing::kFullSize);
 	right_column_content_box_.add(&warn_desyncing_addon_, UI::Box::Resizing::kFullSize);
 	right_column_content_box_.add_space(4 * kPadding);
 	right_column_content_box_.add(&configure_game_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
@@ -204,13 +203,14 @@ void LaunchGame::add_all_widgets() {
 	right_column_content_box_.add(&win_condition_duration_, UI::Box::Resizing::kFullSize);
 	right_column_content_box_.add_space(3 * kPadding);
 	right_column_content_box_.add(&toggle_advanced_options_, UI::Box::Resizing::kFullSize);
+	right_column_content_box_.add_space(1 * kPadding);
 	right_column_content_box_.add(&advanced_options_box_, UI::Box::Resizing::kFullSize);
 
-	advanced_options_box_.set_scrolling(true);
 	for (auto& pair : game_flag_checkboxes_) {
-		advanced_options_box_.add_space(1 * kPadding);
 		advanced_options_box_.add(pair.second.first, UI::Box::Resizing::kFullSize);
+		advanced_options_box_.add_space(1 * kPadding);
 	}
+	advanced_options_box_.add(&write_replay_, UI::Box::Resizing::kFullSize);
 
 	if (choose_map_ != nullptr) {
 		right_column_content_box_.add_space(3 * kPadding);
@@ -246,8 +246,8 @@ bool LaunchGame::should_write_replay() const {
 void LaunchGame::update_advanced_options() {
 	const bool show = toggle_advanced_options_.style() == UI::Button::VisualState::kPermpressed;
 	advanced_options_box_.set_visible(show);
-	toggle_advanced_options_.set_title(show ? _("Hide advanced options") :
-                                             _("Show advanced options"));
+	toggle_advanced_options_.set_title(show ? _("Show fewer options") :
+                                             _("Show more options"));
 	layout();
 }
 

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -236,7 +236,9 @@ void LaunchGame::update_warn_desyncing_addon() {
 	   [](const AddOns::AddOnState& addon) { return addon.second && !addon.first->sync_safe; });
 
 	warn_desyncing_addon_.set_visible(has_desyncing_addon);
-	write_replay_.set_visible(!has_desyncing_addon);
+	// TODO(Nordfriese): The scenario check is a quickfix for #5745 and related #4531,
+	// remove when scenario replays are functional
+	write_replay_.set_visible(!has_desyncing_addon && !settings_.settings().scenario);
 }
 
 bool LaunchGame::should_write_replay() const {

--- a/src/ui_fsmenu/launch_game.cc
+++ b/src/ui_fsmenu/launch_game.cc
@@ -91,14 +91,31 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
                              UI::SpinBox::Type::kBig,
                              5,
                              60),
-     peaceful_(
+
+game_flag_checkboxes_({
+{GameSettings::Flags::kPeaceful, {
+     new UI::Checkbox(
         &right_column_content_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("Peaceful mode")),
-     fogless_(
+&LaunchGame::update_peaceful_mode}},
+
+{GameSettings::Flags::kFogless, {
+     new UI::Checkbox(
         &right_column_content_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("No fog of war")),
-     custom_starting_positions_(&right_column_content_box_,
+&LaunchGame::update_fogless}},
+
+{GameSettings::Flags::kForbidDiplomacy, {
+     new UI::Checkbox(
+        &right_column_content_box_, UI::PanelStyle::kFsMenu, Vector2i::zero(), _("Forbid diplomacy")),
+&LaunchGame::update_forbid_diplomacy}},
+
+{GameSettings::Flags::kCustomStartingPositions, {
+     new UI::Checkbox(&right_column_content_box_,
                                 UI::PanelStyle::kFsMenu,
                                 Vector2i::zero(),
                                 _("Custom starting positions")),
+&LaunchGame::update_custom_starting_positions}},
+
+}),
      choose_map_(mpg && settings.can_change_map() && !preconfigured ?
                     new UI::Button(&right_column_content_box_,
                                    "choose_map",
@@ -125,11 +142,13 @@ LaunchGame::LaunchGame(MenuCapsule& fsmm,
      ctrl_(ctrl) {
 	warn_desyncing_addon_.set_visible(false);
 	write_replay_.set_state(true);
+
 	win_condition_dropdown_.selected.connect([this]() { win_condition_selected(); });
 	win_condition_duration_.changed.connect([this]() { win_condition_duration_changed(); });
-	peaceful_.changed.connect([this]() { toggle_peaceful(); });
-	fogless_.changed.connect([this]() { toggle_fogless(); });
-	custom_starting_positions_.changed.connect([this]() { toggle_custom_starting_positions(); });
+	for (auto& pair : game_flag_checkboxes_) {
+		pair.second.first->changed.connect([this, pair]() { settings_.set_flag(pair.first, pair.second.first->get_state()); });
+	}
+
 	if (choose_map_ != nullptr) {
 		choose_map_->sigclicked.connect([this]() { clicked_select_map(); });
 	}
@@ -163,12 +182,12 @@ void LaunchGame::add_all_widgets() {
 	right_column_content_box_.add(&win_condition_dropdown_, UI::Box::Resizing::kFullSize);
 	right_column_content_box_.add_space(1 * kPadding);
 	right_column_content_box_.add(&win_condition_duration_, UI::Box::Resizing::kFullSize);
-	right_column_content_box_.add_space(3 * kPadding);
-	right_column_content_box_.add(&peaceful_, UI::Box::Resizing::kFullSize);
-	right_column_content_box_.add_space(3 * kPadding);
-	right_column_content_box_.add(&fogless_, UI::Box::Resizing::kFullSize);
-	right_column_content_box_.add_space(3 * kPadding);
-	right_column_content_box_.add(&custom_starting_positions_, UI::Box::Resizing::kFullSize);
+
+	for (auto& pair : game_flag_checkboxes_) {
+		right_column_content_box_.add_space(3 * kPadding);
+		right_column_content_box_.add(pair.second.first, UI::Box::Resizing::kFullSize);
+	}
+
 	if (choose_map_ != nullptr) {
 		right_column_content_box_.add_space(3 * kPadding);
 		right_column_content_box_.add(choose_map_, UI::Box::Resizing::kFullSize);
@@ -201,30 +220,35 @@ bool LaunchGame::should_write_replay() const {
 }
 
 void LaunchGame::update_peaceful_mode() {
+	UI::Checkbox* checkbox = game_flag_checkboxes_.at(GameSettings::Flags::kPeaceful).first;
 	bool forbidden =
 	   peaceful_mode_forbidden_ || settings_.settings().scenario || settings_.settings().savegame;
-	peaceful_.set_enabled(!forbidden && settings_.can_change_map());
+
+	checkbox->set_enabled(!forbidden && settings_.can_change_map());
 	if (forbidden) {
-		peaceful_.set_state(false);
+		checkbox->set_state(false);
 	}
+
 	if (settings_.settings().scenario) {
-		peaceful_.set_tooltip(_("The relations between players are set by the scenario"));
+		checkbox->set_tooltip(_("The relations between players are set by the scenario"));
 	} else if (settings_.settings().savegame) {
-		peaceful_.set_tooltip(_("The relations between players are set by the saved game"));
+		checkbox->set_tooltip(_("The relations between players are set by the saved game"));
 	} else if (peaceful_mode_forbidden_) {
-		peaceful_.set_tooltip(_("The selected win condition does not allow peaceful matches"));
+		checkbox->set_tooltip(_("The selected win condition does not allow peaceful matches"));
 	} else {
-		peaceful_.set_tooltip(_("Forbid fighting between players"));
+		checkbox->set_tooltip(_("Forbid fighting between players"));
 	}
 }
 
 void LaunchGame::update_custom_starting_positions() {
+	UI::Checkbox* checkbox = game_flag_checkboxes_.at(GameSettings::Flags::kCustomStartingPositions).first;
 	const GameSettings& settings = settings_.settings();
 	const bool forbidden = settings.scenario || settings.savegame;
+
 	if (forbidden || !settings_.can_change_map()) {
-		custom_starting_positions_.set_enabled(false);
+		checkbox->set_enabled(false);
 		if (forbidden) {
-			custom_starting_positions_.set_state(false);
+			checkbox->set_state(false);
 		}
 	} else {
 		bool allowed = false;
@@ -237,41 +261,68 @@ void LaunchGame::update_custom_starting_positions() {
 				break;
 			}
 		}
-		custom_starting_positions_.set_enabled(allowed);
+		checkbox->set_enabled(allowed);
 		if (!allowed) {
-			custom_starting_positions_.set_state(false);
-			custom_starting_positions_.set_tooltip(
+			checkbox->set_state(false);
+			checkbox->set_tooltip(
 			   _("All selected starting conditions ignore the map’s starting positions"));
 			return;
 		}
 	}
+
 	if (settings_.settings().scenario) {
-		custom_starting_positions_.set_tooltip(_("The starting positions are set by the scenario"));
+		checkbox->set_tooltip(_("The starting positions are set by the scenario"));
 	} else if (settings_.settings().savegame) {
-		custom_starting_positions_.set_tooltip(_("The starting positions are set by the saved game"));
+		checkbox->set_tooltip(_("The starting positions are set by the saved game"));
 	} else {
-		custom_starting_positions_.set_tooltip(_(
+		checkbox->set_tooltip(_(
 		   "Allow the players to choose their own starting positions at the beginning of the game"));
 	}
 }
 
 void LaunchGame::update_fogless() {
+	UI::Checkbox* checkbox = game_flag_checkboxes_.at(GameSettings::Flags::kFogless).first;
 	const GameSettings& settings = settings_.settings();
 	const bool forbidden = settings.scenario || settings.savegame;
+
 	if (forbidden || !settings_.can_change_map()) {
-		fogless_.set_enabled(false);
+		checkbox->set_enabled(false);
 		if (forbidden) {
-			fogless_.set_state(false);
+			checkbox->set_state(false);
 		}
 	} else {
-		fogless_.set_enabled(true);
+		checkbox->set_enabled(true);
 	}
+
 	if (settings_.settings().scenario) {
-		fogless_.set_tooltip(_("Player vision is set by the scenario"));
+		checkbox->set_tooltip(_("Player vision is set by the scenario"));
 	} else if (settings_.settings().savegame) {
-		fogless_.set_tooltip(_("Player vision is set by the saved game"));
+		checkbox->set_tooltip(_("Player vision is set by the saved game"));
 	} else {
-		fogless_.set_tooltip(_("Give all players permanent vision of the entire map"));
+		checkbox->set_tooltip(_("Give all players permanent vision of the entire map"));
+	}
+}
+
+void LaunchGame::update_forbid_diplomacy() {
+	UI::Checkbox* checkbox = game_flag_checkboxes_.at(GameSettings::Flags::kForbidDiplomacy).first;
+	const GameSettings& settings = settings_.settings();
+	const bool forbidden = settings.scenario || settings.savegame;
+
+	if (forbidden || !settings_.can_change_map()) {
+		checkbox->set_enabled(false);
+		if (forbidden) {
+			checkbox->set_state(false);
+		}
+	} else {
+		checkbox->set_enabled(true);
+	}
+
+	if (settings_.settings().scenario) {
+		checkbox->set_tooltip(_("Player relations are set by the scenario"));
+	} else if (settings_.settings().savegame) {
+		checkbox->set_tooltip(_("Player relations are set by the saved game"));
+	} else {
+		checkbox->set_tooltip(_("Disallow players to change their alliances during the game"));
 	}
 }
 
@@ -399,17 +450,5 @@ LaunchGame::win_condition_if_valid(const std::string& win_condition_script,
 
 void LaunchGame::win_condition_duration_changed() {
 	settings_.set_win_condition_duration(win_condition_duration_.get_value());
-}
-
-void LaunchGame::toggle_peaceful() {
-	settings_.set_peaceful_mode(peaceful_.get_state());
-}
-
-void LaunchGame::toggle_fogless() {
-	settings_.set_fogless(fogless_.get_state());
-}
-
-void LaunchGame::toggle_custom_starting_positions() {
-	settings_.set_custom_starting_positions(custom_starting_positions_.get_state());
 }
 }  // namespace FsMenu

--- a/src/ui_fsmenu/launch_game.h
+++ b/src/ui_fsmenu/launch_game.h
@@ -46,9 +46,11 @@ public:
 		return settings_;
 	}
 
-	/// Enables or disables the custom_starting_positions checkbox.
+	/// Enables or disables the respective game flags checkbox.
+	void update_peaceful_mode();
 	void update_custom_starting_positions();
 	void update_fogless();
+	void update_forbid_diplomacy();
 
 protected:
 	std::unique_ptr<LuaInterface> lua_;
@@ -61,8 +63,6 @@ protected:
 	/// Creates a blank label/tooltip and returns 'false' otherwise.
 	bool init_win_condition_label();
 
-	/// Enables or disables the peaceful mode checkbox.
-	void update_peaceful_mode();
 	/// Hides or shows the desync warning.
 	void update_warn_desyncing_addon();
 
@@ -83,9 +83,6 @@ protected:
 	std::unique_ptr<LuaTable> win_condition_if_valid(const std::string& win_condition_script,
 	                                                 const std::set<std::string>& tags) const;
 
-	void toggle_peaceful();
-	void toggle_fogless();
-	void toggle_custom_starting_positions();
 	bool should_write_replay() const;
 
 	void layout() override;
@@ -96,7 +93,7 @@ protected:
 	UI::MultilineTextarea warn_desyncing_addon_;
 	UI::Dropdown<std::string> win_condition_dropdown_;
 	UI::SpinBox win_condition_duration_;
-	UI::Checkbox peaceful_, fogless_, custom_starting_positions_;
+	std::map<GameSettings::Flags, std::pair<UI::Checkbox*, void (LaunchGame::*)() /* update function */>> game_flag_checkboxes_;
 	UI::Button* choose_map_;
 	UI::Button* choose_savegame_;
 	std::string last_win_condition_;

--- a/src/ui_fsmenu/launch_game.h
+++ b/src/ui_fsmenu/launch_game.h
@@ -91,7 +91,6 @@ protected:
 
 	MapDetailsBox map_details_;
 	UI::Textarea configure_game_;
-	UI::Checkbox write_replay_;
 	UI::MultilineTextarea warn_desyncing_addon_;
 	UI::Dropdown<std::string> win_condition_dropdown_;
 	UI::SpinBox win_condition_duration_;
@@ -100,6 +99,7 @@ protected:
 	std::map<GameSettings::Flags,
 	         std::pair<UI::Checkbox*, void (LaunchGame::*)() /* update function */>>
 	   game_flag_checkboxes_;
+	UI::Checkbox write_replay_;
 	UI::Button* choose_map_;
 	UI::Button* choose_savegame_;
 	std::string last_win_condition_;

--- a/src/ui_fsmenu/launch_game.h
+++ b/src/ui_fsmenu/launch_game.h
@@ -63,6 +63,8 @@ protected:
 	/// Creates a blank label/tooltip and returns 'false' otherwise.
 	bool init_win_condition_label();
 
+	void update_advanced_options();
+
 	/// Hides or shows the desync warning.
 	void update_warn_desyncing_addon();
 
@@ -93,6 +95,8 @@ protected:
 	UI::MultilineTextarea warn_desyncing_addon_;
 	UI::Dropdown<std::string> win_condition_dropdown_;
 	UI::SpinBox win_condition_duration_;
+	UI::Button toggle_advanced_options_;
+	UI::Box advanced_options_box_;
 	std::map<GameSettings::Flags, std::pair<UI::Checkbox*, void (LaunchGame::*)() /* update function */>> game_flag_checkboxes_;
 	UI::Button* choose_map_;
 	UI::Button* choose_savegame_;

--- a/src/ui_fsmenu/launch_game.h
+++ b/src/ui_fsmenu/launch_game.h
@@ -97,7 +97,9 @@ protected:
 	UI::SpinBox win_condition_duration_;
 	UI::Button toggle_advanced_options_;
 	UI::Box advanced_options_box_;
-	std::map<GameSettings::Flags, std::pair<UI::Checkbox*, void (LaunchGame::*)() /* update function */>> game_flag_checkboxes_;
+	std::map<GameSettings::Flags,
+	         std::pair<UI::Checkbox*, void (LaunchGame::*)() /* update function */>>
+	   game_flag_checkboxes_;
 	UI::Button* choose_map_;
 	UI::Button* choose_savegame_;
 	std::string last_win_condition_;

--- a/src/ui_fsmenu/launch_mpg.cc
+++ b/src/ui_fsmenu/launch_mpg.cc
@@ -289,12 +289,10 @@ void LaunchMPG::refresh() {
 
 	ok_.set_enabled(settings_.can_launch());
 
-	update_peaceful_mode();
-	update_fogless();
-	update_custom_starting_positions();
-	custom_starting_positions_.set_state(settings_.get_custom_starting_positions());
-	peaceful_.set_state(settings_.is_peaceful_mode());
-	fogless_.set_state(settings_.is_fogless());
+	for (auto& pair : game_flag_checkboxes_) {
+		(this->*pair.second.second)();
+		pair.second.first->set_state(settings_.get_flag(pair.first));
+	}
 
 	if (!settings_.can_change_map() && !init_win_condition_label()) {
 		try {

--- a/src/ui_fsmenu/launch_spg.cc
+++ b/src/ui_fsmenu/launch_spg.cc
@@ -56,18 +56,21 @@ LaunchSPG::LaunchSPG(MenuCapsule& fsmm,
 	Notifications::publish(NoteGameSettings(NoteGameSettings::Action::kMap));
 
 	update_win_conditions();
-	update_peaceful_mode();
-	update_fogless();
-	update_custom_starting_positions();
+	for (auto& pair : game_flag_checkboxes_) {
+		(this->*pair.second.second)();
+	}
 	update_warn_desyncing_addon();
+
 	update();
 	layout();
 	initialization_complete();
 }
 
 void LaunchSPG::update() {
-	peaceful_.set_state(settings_.is_peaceful_mode());
-	fogless_.set_state(settings_.is_fogless());
+	for (auto& pair : game_flag_checkboxes_) {
+		pair.second.first->set_state(settings_.get_flag(pair.first));
+	}
+
 	if (preconfigured_) {
 		map_details_.update(&settings_, *game_->mutable_map());
 		ok_.set_enabled(true);

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -680,9 +680,10 @@ void WLApplication::init_and_run_game_from_template() {
 		settings.reset(new SinglePlayerGameSettingsProvider());
 	}
 
-	settings->set_peaceful_mode(section.get_bool("peaceful", false));
-	settings->set_fogless(section.get_bool("fogless", false));
-	settings->set_custom_starting_positions(section.get_bool("custom_starting_positions", false));
+	settings->set_flag(GameSettings::Flags::kPeaceful, section.get_bool("peaceful", false));
+	settings->set_flag(GameSettings::Flags::kFogless, section.get_bool("fogless", false));
+	settings->set_flag(GameSettings::Flags::kCustomStartingPositions, section.get_bool("custom_starting_positions", false));
+	settings->set_flag(GameSettings::Flags::kForbidDiplomacy, section.get_bool("forbid_diplomacy", false));
 
 	{
 		std::string wc_name = section.get_string("win_condition", "endless_game.lua");

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -682,8 +682,10 @@ void WLApplication::init_and_run_game_from_template() {
 
 	settings->set_flag(GameSettings::Flags::kPeaceful, section.get_bool("peaceful", false));
 	settings->set_flag(GameSettings::Flags::kFogless, section.get_bool("fogless", false));
-	settings->set_flag(GameSettings::Flags::kCustomStartingPositions, section.get_bool("custom_starting_positions", false));
-	settings->set_flag(GameSettings::Flags::kForbidDiplomacy, section.get_bool("forbid_diplomacy", false));
+	settings->set_flag(GameSettings::Flags::kCustomStartingPositions,
+	                   section.get_bool("custom_starting_positions", false));
+	settings->set_flag(
+	   GameSettings::Flags::kForbidDiplomacy, section.get_bool("forbid_diplomacy", false));
 
 	{
 		std::string wc_name = section.get_string("win_condition", "endless_game.lua");


### PR DESCRIPTION
**Type of change**
New feature & Refactoring

**Issue(s) closed**
Fixes #5816

**How it works**
Exposed the option to disallow diplomacy to the game setup UI.

I refactored all those boolean switches for game setup into a bitset of flags, which greatly simplifies handling.

The UI now has a toggle button to view or hide the advanced options, hidden by default.

**Possible regressions**
All things game flags handling

**Screenshots**
![grafik](https://user-images.githubusercontent.com/48293446/233782723-60ded6ed-217d-4a98-a57f-937aa02c435c.png)
![grafik](https://user-images.githubusercontent.com/48293446/233782711-65ed375d-92e8-46d7-bd3c-be853e58ca00.png)
