### PR TITLE
Make AI supplycheck non recursive and more efficient

### DIFF
--- a/src/ai/ai_help_structs.h
+++ b/src/ai/ai_help_structs.h
@@ -598,6 +598,8 @@ struct ShipObserver {
 struct WareObserver {
 	bool refined_build_material = false;
 	uint8_t preciousness;
+	// all buildings of the tribe which produce the given ware
+	std::vector<Widelands::DescriptionIndex> producers;
 };
 
 // Computer player does not get notification messages about enemy militarysites

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -6917,14 +6917,16 @@ bool DefaultAI::check_supply(const BuildingObserver& bo) {
 	for (const Widelands::DescriptionIndex& temp_input : bo.inputs) {
 		for (const Widelands::DescriptionIndex& bidx : wares.at(temp_input).producers) {
 			BuildingObserver& temp_building = get_building_observer(bidx);
-			verb_log_dbg("Checking producer %s of ware %s for building %s.", temp_building.name, tribe_->get_ware_descr(temp_input)->name().c_str(),bo.name);
+			verb_log_dbg("Checking producer %s of ware %s for building %s.", temp_building.name,
+			             tribe_->get_ware_descr(temp_input)->name().c_str(), bo.name);
 			if (temp_building.cnt_built != 0 && temp_building.current_stats > 10) {
 				++supplied;
 				break;
 			}
 		}
 	}
-	verb_log_dbg("Found supplies for %lld of %lld input wares for Building %s", supplied, bo.inputs.size(), bo.name);
+	verb_log_dbg("Found supplies for %lld of %lld input wares for Building %s", supplied,
+	             bo.inputs.size(), bo.name);
 
 	return supplied == bo.inputs.size();
 }

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -6910,7 +6910,7 @@ void DefaultAI::lose_building(const Widelands::Building& b) {
 // Verify that all inputs have a working producer (i.e. building statistics better then 10%).
 
 bool DefaultAI::check_supply(const BuildingObserver& bo) {
-	if (bo.inputs.size() == 0) {
+	if (bo.inputs.empty()) {
 		return true;
 	}
 	size_t supplied = 0;

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -6925,8 +6925,8 @@ bool DefaultAI::check_supply(const BuildingObserver& bo) {
 			}
 		}
 	}
-	verb_log_dbg("Found supplies for %lld of %lld input wares for Building %s", supplied,
-	             bo.inputs.size(), bo.name);
+	verb_log_dbg("Found supplies for %d of %d input wares for Building %s", static_cast<unsigned int>(supplied),
+	             static_cast<unsigned int>(bo.inputs.size()), bo.name);
 
 	return supplied == bo.inputs.size();
 }

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -6907,7 +6907,7 @@ void DefaultAI::lose_building(const Widelands::Building& b) {
 }
 
 // Checks that supply line exists for given building.
-// Verify that all inputs have a working producer (i.e. building statistics better then 10%).
+// Verify that all inputs have a working producer (i.e. building statistics better than 10%).
 
 bool DefaultAI::check_supply(const BuildingObserver& bo) {
 	if (bo.inputs.empty()) {

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -747,6 +747,8 @@ void DefaultAI::late_initialization() {
 			}
 			for (const Widelands::DescriptionIndex& temp_output : prod.output_ware_types()) {
 				bo.ware_outputs.push_back(temp_output);
+				// add the building id to the producers vector of this ware
+				wares.at(temp_output).producers.push_back(bo.id);
 				if (tribe_->is_construction_material(temp_output) && !bo.inputs.empty()) {
 					wares.at(temp_output).refined_build_material = true;
 				}
@@ -6905,22 +6907,24 @@ void DefaultAI::lose_building(const Widelands::Building& b) {
 }
 
 // Checks that supply line exists for given building.
-// Recursively verify that all inputs have a producer.
-// TODO(unknown): this function leads to periodic freezes of ~1 second on big games on my system.
-// TODO(unknown): It needs profiling and optimization.
+// Verify that all inputs have a working producer (i.e. building statistics better then 10%).
+
 bool DefaultAI::check_supply(const BuildingObserver& bo) {
+	if (bo.inputs.size() == 0) {
+		return true;
+	}
 	size_t supplied = 0;
-	for (const Widelands::DescriptionIndex& temp_inputs : bo.inputs) {
-		for (const BuildingObserver& temp_building : buildings_) {
-			if ((temp_building.cnt_built != 0) &&
-			    std::find(temp_building.ware_outputs.begin(), temp_building.ware_outputs.end(),
-			              temp_inputs) != temp_building.ware_outputs.end() &&
-			    check_supply(temp_building)) {
+	for (const Widelands::DescriptionIndex& temp_input : bo.inputs) {
+		for (const Widelands::DescriptionIndex& bidx : wares.at(temp_input).producers) {
+			BuildingObserver& temp_building = get_building_observer(bidx);
+			verb_log_dbg("Checking producer %s of ware %s for building %s.", temp_building.name, tribe_->get_ware_descr(temp_input)->name().c_str(),bo.name);
+			if (temp_building.cnt_built != 0 && temp_building.current_stats > 10) {
 				++supplied;
 				break;
 			}
 		}
 	}
+	verb_log_dbg("Found supplies for %lld of %lld input wares for Building %s", supplied, bo.inputs.size(), bo.name);
 
 	return supplied == bo.inputs.size();
 }

--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -6925,8 +6925,9 @@ bool DefaultAI::check_supply(const BuildingObserver& bo) {
 			}
 		}
 	}
-	verb_log_dbg("Found supplies for %d of %d input wares for Building %s", static_cast<unsigned int>(supplied),
-	             static_cast<unsigned int>(bo.inputs.size()), bo.name);
+	verb_log_dbg("Found supplies for %d of %d input wares for Building %s",
+	             static_cast<unsigned int>(supplied), static_cast<unsigned int>(bo.inputs.size()),
+	             bo.name);
 
 	return supplied == bo.inputs.size();
 }


### PR DESCRIPTION
**Type of change**
Bugfix / Refactoring 

**Issue(s) closed**
Fixes #5854 

**New behavior**
hopefully none. the Ai should behave like before

How it works**
Instead of checking the whole chain recursively we now only check whether the supplying building is working already. (this would mean it is fully supplied and is in fact more accurate as it checks real supply rather then theoretical supply)
Furthermore we only check the buildings that produce the input ware rather then checking all buildings outputs for the production. this should safe us a lot of cycles. 

**Possible regressions**
AI construction decisions