### PR TITLE
Disambiguate temporary savegame for multiple LAN games

### DIFF
--- a/src/io/filesystem/CMakeLists.txt
+++ b/src/io/filesystem/CMakeLists.txt
@@ -16,6 +16,7 @@ wl_library(io_filesystem
     base
     base_exceptions
     base_macros
+    base_time_string
     io_stream
   USES_MINIZIP
 )

--- a/src/io/filesystem/filesystem.cc
+++ b/src/io/filesystem/filesystem.cc
@@ -350,8 +350,8 @@ std::vector<std::string> FileSystem::get_xdgdatadirs() {
 }
 #endif
 
-std::string
-FileSystem::create_unique_temp_file_path(std::string prefix, const std::string& suffix) const {
+std::string FileSystem::create_unique_temp_file_path(std::string prefix,
+                                                     const std::string& suffix) const {
 	prefix += file_separator();
 	prefix += timestring();
 

--- a/src/io/filesystem/filesystem.cc
+++ b/src/io/filesystem/filesystem.cc
@@ -43,6 +43,7 @@
 #include "base/i18n.h"
 #include "base/log.h"
 #include "base/string.h"
+#include "base/time_string.h"
 #include "config.h"
 #include "io/filesystem/disk_filesystem.h"
 #include "io/filesystem/filesystem_exceptions.h"
@@ -348,6 +349,30 @@ std::vector<std::string> FileSystem::get_xdgdatadirs() {
 	return xdgdatadirs;
 }
 #endif
+
+std::string
+FileSystem::create_unique_temp_file_path(std::string prefix, const std::string& suffix) const {
+	prefix += file_separator();
+	prefix += timestring();
+
+	std::string complete_filename = prefix + suffix;
+	if (!file_exists(complete_filename)) {
+		log_dbg("NOCOM *** Disambiguatied filename: %s", complete_filename.c_str());
+		return complete_filename;
+	}
+
+	prefix += '-';
+	for (int i = 0; i <= 9; ++i) {
+		complete_filename = prefix + std::to_string(i) + suffix;
+		if (!file_exists(complete_filename)) {
+			log_dbg("NOCOM *** Disambiguatied filename: %s", complete_filename.c_str());
+			return complete_filename;
+		}
+	}
+
+	throw wexception(
+	   "Could not create a unique filename similar near %s", complete_filename.c_str());
+}
 
 // Returning a vector rather than a set because animations need the indices
 std::vector<std::string> FileSystem::get_sequential_files(const std::string& directory,

--- a/src/io/filesystem/filesystem.cc
+++ b/src/io/filesystem/filesystem.cc
@@ -357,15 +357,15 @@ std::string FileSystem::create_unique_temp_file_path(std::string prefix,
 
 	std::string complete_filename = prefix + suffix;
 	if (!file_exists(complete_filename)) {
-		log_dbg("NOCOM *** Disambiguatied filename: %s", complete_filename.c_str());
 		return complete_filename;
 	}
 
 	prefix += '-';
 	for (int i = 0; i <= 9; ++i) {
-		complete_filename = prefix + std::to_string(i) + suffix;
+		complete_filename = prefix;
+		complete_filename += std::to_string(i);
+		complete_filename += suffix;
 		if (!file_exists(complete_filename)) {
-			log_dbg("NOCOM *** Disambiguatied filename: %s", complete_filename.c_str());
 			return complete_filename;
 		}
 	}

--- a/src/io/filesystem/filesystem.h
+++ b/src/io/filesystem/filesystem.h
@@ -127,6 +127,8 @@ public:
 	static std::vector<std::string> get_xdgdatadirs();
 #endif
 
+	std::string create_unique_temp_file_path(std::string prefix, const std::string& suffix) const;
+
 	/// Return the files in the given 'directory' that match the condition in 'test', i.e. 'test'
 	/// returned 'true' for their filenames.
 	template <class UnaryPredicate>

--- a/src/io/filesystem/filesystem.h
+++ b/src/io/filesystem/filesystem.h
@@ -127,7 +127,8 @@ public:
 	static std::vector<std::string> get_xdgdatadirs();
 #endif
 
-	std::string create_unique_temp_file_path(std::string prefix, const std::string& suffix) const;
+	[[nodiscard]] std::string create_unique_temp_file_path(std::string prefix,
+	                                                       const std::string& suffix) const;
 
 	/// Return the files in the given 'directory' that match the condition in 'test', i.e. 'test'
 	/// returned 'true' for their filenames.

--- a/src/logic/editor_game_base.cc
+++ b/src/logic/editor_game_base.cc
@@ -24,7 +24,6 @@
 #include "base/log.h"
 #include "base/macros.h"
 #include "base/scoped_timer.h"
-#include "base/time_string.h"
 #include "base/wexception.h"
 #include "economy/flag.h"
 #include "economy/road.h"
@@ -138,26 +137,8 @@ void EditorGameBase::create_tempfile_and_save_mapdata(FileSystem::Type const typ
 	try {
 		g_fs->ensure_directory_exists(kTempFileDir);
 
-		std::string filename =
-		   kTempFileDir + FileSystem::file_separator() + timestring() + "_mapdata";
-		std::string complete_filename = filename + kTempFileExtension;
-
-		// if a file with that name already exists, then try a few name modifications
-		if (g_fs->file_exists(complete_filename)) {
-			int suffix;
-			for (suffix = 0; suffix <= 9; suffix++) {
-				complete_filename =
-				   filename.append("-").append(std::to_string(suffix)).append(kTempFileExtension);
-				if (!g_fs->file_exists(complete_filename)) {
-					break;
-				}
-			}
-			if (suffix > 9) {
-				throw wexception(
-				   "EditorGameBase::create_tempfile_and_save_mapdata(): for all considered "
-				   "filenames a file already existed");
-			}
-		}
+		std::string complete_filename = g_fs->create_unique_temp_file_path(
+		   kTempFileDir, std::string("_mapdata") + kTempFileExtension);
 
 		// create tmp_fs_
 		tmp_fs_.reset(g_fs->create_sub_file_system(complete_filename, type));

--- a/src/logic/replay.cc
+++ b/src/logic/replay.cc
@@ -274,7 +274,7 @@ ReplayWriter::ReplayWriter(Game& game, const std::string& filename)
 	SaveHandler& save_handler = game_.save_handler();
 
 	const std::string temp_savegame =
-	   kTempFileDir + FileSystem::file_separator() + timestring() + kSavegameExtension;
+	   g_fs->create_unique_temp_file_path(kTempFileDir, kSavegameExtension);
 	std::string error;
 	if (!save_handler.save_game(game_, temp_savegame, FileSystem::ZIP, &error)) {
 		throw wexception("Failed to save game for replay: %s", error.c_str());
@@ -370,7 +370,8 @@ ReplayfileSavegameExtractor::ReplayfileSavegameExtractor(const std::string& game
 	fr.data_complete(buffer.get(), bytes);
 	FileWrite fw;
 	fw.data(buffer.get(), bytes);
-	temp_file_ = kTempFileDir + FileSystem::file_separator() + timestring() + kSavegameExtension;
+	temp_file_ =
+	   g_fs->create_unique_temp_file_path(kTempFileDir, kSavegameExtension);
 	fw.write(*g_fs, temp_file_);
 }
 

--- a/src/logic/replay.cc
+++ b/src/logic/replay.cc
@@ -370,8 +370,7 @@ ReplayfileSavegameExtractor::ReplayfileSavegameExtractor(const std::string& game
 	fr.data_complete(buffer.get(), bytes);
 	FileWrite fw;
 	fw.data(buffer.get(), bytes);
-	temp_file_ =
-	   g_fs->create_unique_temp_file_path(kTempFileDir, kSavegameExtension);
+	temp_file_ = g_fs->create_unique_temp_file_path(kTempFileDir, kSavegameExtension);
 	fw.write(*g_fs, temp_file_);
 }
 


### PR DESCRIPTION
**Type of change**
Bugfix

**To reproduce**
1. Start a LAN games with multiple clients on the same machine, with the same homedir
2. Sometimes, the game fails to start on 2 of the clients because they both try to save the temporary files for the replay writer to the same temporary file.

**New behavior**
Disambiguate the filenames using an incremental suffix, like we already did for the temporary map filesystem.
