### PR TITLE
windows logging for testsuite

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,6 @@ shallow_clone: false
 branches:
   only:
     - master
-    - 5819_windows_logging
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ install:
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   # Installed required libs
   - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER:\\=/%/install-dependencies.sh msys%BITS% --noconfirm\""
+  - cmd: "bash --login -c \"pacman -S mingw-w64-%MINGWSUFFIX%-gdb --noconfirm\""
   # Downgrade incompatible packages to working version
   # - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/%MINGWSUFFIX%/mingw-w64-%MINGWSUFFIX%-libtiff-4.3.0-3-any.pkg.tar.zst\""
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ install:
   - cmd: "bash --login -c \"pacman -Suuyy --noconfirm\""
   # Installed required libs
   - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER:\\=/%/install-dependencies.sh msys%BITS% --noconfirm\""
-  - cmd: "bash --login -c \"pacman -S mingw-w64-%MINGWSUFFIX%-gdb --noconfirm\""
   # Downgrade incompatible packages to working version
   # - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/%MINGWSUFFIX%/mingw-w64-%MINGWSUFFIX%-libtiff-4.3.0-3-any.pkg.tar.zst\""
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ shallow_clone: false
 branches:
   only:
     - master
+    - 5819_windows_logging
 
 skip_tags: true
 

--- a/src/ai/test/CMakeLists.txt
+++ b/src/ai/test/CMakeLists.txt
@@ -7,3 +7,12 @@ wl_test(test_ai
     base_test
     ai
 )
+
+add_custom_target(notifications_test_gdb
+    COMMAND gdb -ex r -ex bt -ex q test_ai.exe
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS notifications_test
+    USES_TERMINAL
+  )
+# Run it before the normal testsuite
+add_dependencies(wl_tests notifications_test_gdb)

--- a/src/ai/test/CMakeLists.txt
+++ b/src/ai/test/CMakeLists.txt
@@ -1,11 +1,14 @@
-# add_custom_target(notifications_test_gdb
+# Uncomment the following to get a gdb backtrace in the CI environment
+# to use for other unit tests change the name of the test and the binary
+
+# add_custom_target(test_gdb_bt
     # COMMAND gdb -ex r -ex bt -ex q test_ai.exe
     # WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     # DEPENDS test_ai
     # USES_TERMINAL
   # )
 # # Run it before the normal testsuite
-# add_dependencies(wl_tests notifications_test_gdb)
+# add_dependencies(wl_tests test_gdb_bt)
 
 wl_test(test_ai
   SRCS

--- a/src/ai/test/CMakeLists.txt
+++ b/src/ai/test/CMakeLists.txt
@@ -1,11 +1,11 @@
-add_custom_target(notifications_test_gdb
-    COMMAND gdb -ex r -ex bt -ex q test_ai.exe
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS test_ai
-    USES_TERMINAL
-  )
-# Run it before the normal testsuite
-add_dependencies(wl_tests notifications_test_gdb)
+# add_custom_target(notifications_test_gdb
+    # COMMAND gdb -ex r -ex bt -ex q test_ai.exe
+    # WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    # DEPENDS test_ai
+    # USES_TERMINAL
+  # )
+# # Run it before the normal testsuite
+# add_dependencies(wl_tests notifications_test_gdb)
 
 wl_test(test_ai
   SRCS

--- a/src/ai/test/CMakeLists.txt
+++ b/src/ai/test/CMakeLists.txt
@@ -1,3 +1,12 @@
+add_custom_target(notifications_test_gdb
+    COMMAND gdb -ex r -ex bt -ex q test_ai.exe
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS test_ai
+    USES_TERMINAL
+  )
+# Run it before the normal testsuite
+add_dependencies(wl_tests notifications_test_gdb)
+
 wl_test(test_ai
   SRCS
     ai_test_main.cc
@@ -7,12 +16,3 @@ wl_test(test_ai
     base_test
     ai
 )
-
-add_custom_target(notifications_test_gdb
-    COMMAND gdb -ex r -ex bt -ex q test_ai.exe
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS notifications_test
-    USES_TERMINAL
-  )
-# Run it before the normal testsuite
-add_dependencies(wl_tests notifications_test_gdb)

--- a/src/ai/test/ai_test_main.cc
+++ b/src/ai/test/ai_test_main.cc
@@ -17,4 +17,4 @@
  */
 
 #include "base/test.h"
-TEST_EXECUTABLE(ai, true)
+TEST_EXECUTABLE(ai)

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -79,16 +79,16 @@ public:
 		std::cout << "Log output will be written to: " << stdout_filename_ << std::endl;
 
 		// Configure redirection
-		std::cout.rdbuf(stdout_.rdbuf());
-		std::cerr.rdbuf(stderr_.rdbuf());
+		// std::cout.rdbuf(stdout_.rdbuf());
+		// std::cerr.rdbuf(stderr_.rdbuf());
 		// Repeat version info so that we'll have it available in the log file too
-		std::cout << "This is Widelands version " << build_ver_details() << std::endl;
-		std::cout.flush();
+		stdout_ << "This is Widelands version " << build_ver_details();
+		stdout_.flush();
 	}
 
 	void log_cstring(const char* buffer) {
-		std::cout << buffer;
-		std::cout.flush();
+		stdout_ << buffer;
+		stdout_.flush();
 	}
 
 private:
@@ -151,7 +151,7 @@ bool set_logging_dir(const std::string& homedir) {
 
 // Set the logging dir to the program's dir. For running test cases where we don't have a homedir.
 void set_testcase_logging_dir() {
-	// logger.reset(new WindowsLogger(get_output_directory()));
+	logger.reset(new WindowsLogger(get_output_directory()));
 }
 
 #else

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -78,9 +78,7 @@ public:
 		SDL_LogSetOutputFunction(sdl_logging_func, this);
 		std::cout << "Log output will be written to: " << stdout_filename_ << std::endl;
 
-		// Configure redirection
-		// std::cout.rdbuf(stdout_.rdbuf());
-		// std::cerr.rdbuf(stderr_.rdbuf());
+
 		// Repeat version info so that we'll have it available in the log file too
 		stdout_ << "This is Widelands version " << build_ver_details() << std::endl;
 		stdout_.flush();
@@ -90,11 +88,11 @@ public:
 		stdout_ << buffer;
 		stdout_.flush();
 	}
-	void redirect_output() {
+/* 	void redirect_output() {
 		// Configure redirection
 		std::cout.rdbuf(stdout_.rdbuf());
 		std::cerr.rdbuf(stderr_.rdbuf());
-	}
+	} */
 
 private:
 	const std::string stdout_filename_, stderr_filename_;
@@ -157,7 +155,7 @@ bool set_logging_dir(const std::string& homedir) {
 // Set the logging dir to the program's dir. For running test cases where we don't have a homedir.
 void set_testcase_logging_dir() {
 	logger.reset(new WindowsLogger(get_output_directory()));
-	logger->redirect_output();
+	// logger->redirect_output();
 }
 
 #else

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -78,7 +78,6 @@ public:
 		SDL_LogSetOutputFunction(sdl_logging_func, this);
 		std::cout << "Log output will be written to: " << stdout_filename_ << std::endl;
 
-
 		// Repeat version info so that we'll have it available in the log file too
 		stdout_ << "This is Widelands version " << build_ver_details() << std::endl;
 		stdout_.flush();

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -151,7 +151,7 @@ bool set_logging_dir(const std::string& homedir) {
 
 // Set the logging dir to the program's dir. For running test cases where we don't have a homedir.
 void set_testcase_logging_dir() {
-	logger.reset(new WindowsLogger(get_output_directory()));
+	// logger.reset(new WindowsLogger(get_output_directory()));
 }
 
 #else

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -82,13 +82,18 @@ public:
 		// std::cout.rdbuf(stdout_.rdbuf());
 		// std::cerr.rdbuf(stderr_.rdbuf());
 		// Repeat version info so that we'll have it available in the log file too
-		stdout_ << "This is Widelands version " << build_ver_details();
+		stdout_ << "This is Widelands version " << build_ver_details() << std::endl;
 		stdout_.flush();
 	}
 
 	void log_cstring(const char* buffer) {
 		stdout_ << buffer;
 		stdout_.flush();
+	}
+	void redirect_output() {
+		// Configure redirection
+		std::cout.rdbuf(stdout_.rdbuf());
+		std::cerr.rdbuf(stderr_.rdbuf());
 	}
 
 private:
@@ -152,6 +157,7 @@ bool set_logging_dir(const std::string& homedir) {
 // Set the logging dir to the program's dir. For running test cases where we don't have a homedir.
 void set_testcase_logging_dir() {
 	logger.reset(new WindowsLogger(get_output_directory()));
+	logger->redirect_output();
 }
 
 #else

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -88,11 +88,6 @@ public:
 		stdout_ << buffer;
 		stdout_.flush();
 	}
-/* 	void redirect_output() {
-		// Configure redirection
-		std::cout.rdbuf(stdout_.rdbuf());
-		std::cerr.rdbuf(stderr_.rdbuf());
-	} */
 
 private:
 	const std::string stdout_filename_, stderr_filename_;
@@ -155,7 +150,6 @@ bool set_logging_dir(const std::string& homedir) {
 // Set the logging dir to the program's dir. For running test cases where we don't have a homedir.
 void set_testcase_logging_dir() {
 	logger.reset(new WindowsLogger(get_output_directory()));
-	// logger->redirect_output();
 }
 
 #else

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -83,12 +83,12 @@ public:
 		std::cerr.rdbuf(stderr_.rdbuf());
 		// Repeat version info so that we'll have it available in the log file too
 		std::cout << "This is Widelands version " << build_ver_details() << std::endl;
-		stdout_.flush();
+		std::cout.flush();
 	}
 
 	void log_cstring(const char* buffer) {
 		stdout_ << buffer;
-		stdout_.flush();
+		std::cout.flush();
 	}
 
 private:

--- a/src/base/log.cc
+++ b/src/base/log.cc
@@ -87,7 +87,7 @@ public:
 	}
 
 	void log_cstring(const char* buffer) {
-		stdout_ << buffer;
+		std::cout << buffer;
 		std::cout.flush();
 	}
 

--- a/src/base/test.h
+++ b/src/base/test.h
@@ -200,11 +200,11 @@ inline void do_check_error(const char* f,
 			for (const auto& suite : all_testsuites()) {                                              \
 				for (const auto& test : suite.second) {                                                \
 					try {                                                                               \
-						log_info("Running %s::%s\n", suite.first, test.first);                          \
+						log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());                          \
 						test.second();                                                                   \
 					} catch (const std::exception& e) {                                                 \
 						errors = true;                                                                   \
-						log_info("Error in %s::%s: %s\n", suite.first, test.first, e.what());          \
+						log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(), e.what());          \
 					}                                                                                   \
 				}                                                                                      \
 			}                                                                                         \

--- a/src/base/test.h
+++ b/src/base/test.h
@@ -189,7 +189,7 @@ inline void do_check_error(const char* f,
 }
 }  // namespace WLTestsuite
 
-#define TEST_EXECUTABLE(name, needs_logging)                                                       \
+#define TEST_EXECUTABLE(name)                                                       \
 	namespace WLTestsuite {                                                                         \
 	namespace WLTestsuite_##name {                                                                  \
 		static int main() {                                                                          \
@@ -198,16 +198,11 @@ inline void do_check_error(const char* f,
 			for (const auto& suite : all_testsuites()) {                                              \
 				for (const auto& test : suite.second) {                                                \
 					try {                                                                               \
-						if (needs_logging) {                                                             \
-							log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());        \
-						}                                                                                \
+						log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());        \
 						test.second();                                                                   \
 					} catch (const std::exception& e) {                                                 \
 						errors = true;                                                                   \
-						if (needs_logging) {                                                             \
-							log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(),    \
-							         e.what());                                                           \
-						}                                                                                \
+						log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(), e.what()); \
 					}                                                                                   \
 				}                                                                                      \
 			}                                                                                         \

--- a/src/base/test.h
+++ b/src/base/test.h
@@ -193,20 +193,21 @@ inline void do_check_error(const char* f,
 	namespace WLTestsuite {                                                                         \
 	namespace WLTestsuite_##name {                                                                  \
 		static int main() {                                                                          \
-			set_testcase_logging_dir();                                                            \
+			set_testcase_logging_dir();                                                               \
 			bool errors = false;                                                                      \
 			for (const auto& suite : all_testsuites()) {                                              \
 				for (const auto& test : suite.second) {                                                \
 					try {                                                                               \
-						if (needs_logging) {                                                            \
-							log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());       \
+						if (needs_logging) {                                                             \
+							log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());        \
 						}                                                                                \
 						test.second();                                                                   \
 					} catch (const std::exception& e) {                                                 \
 						errors = true;                                                                   \
-						if (needs_logging) {                                                            \
-							log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(), e.what());  \
-						}                                                                               \
+						if (needs_logging) {                                                             \
+							log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(),    \
+							         e.what());                                                           \
+						}                                                                                \
 					}                                                                                   \
 				}                                                                                      \
 			}                                                                                         \

--- a/src/base/test.h
+++ b/src/base/test.h
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <string>
 
+#include "base/log.h"
 #include "base/string.h"
 #include "base/wexception.h"
 
@@ -160,7 +161,7 @@ inline bool compare(const double a,
 #define check_equal(a, b) do_check_equal(__FILE__, __LINE__, a, b)
 template <typename T1, typename T2>
 inline void do_check_equal(const char* f, uint32_t l, const T1& a, const T2& b) {
-	std::cout << "Running testcase " << f << ':' << l << std::endl;
+	log_info("Running testcase %s:%d\n", f, l);
 	if (!compare(a, b)) {
 		std::ostringstream oss;
 		oss << "Check failed: (";
@@ -178,7 +179,7 @@ inline void do_check_error(const char* f,
                            uint32_t l,
                            const std::string& what,
                            const std::function<void()>& fn) {
-	std::cout << "Running testcase " << f << ':' << l << std::endl;
+	log_info("Running testcase %s:%d\n", f, l);
 	try {
 		fn();
 	} catch (...) {
@@ -199,12 +200,11 @@ inline void do_check_error(const char* f,
 			for (const auto& suite : all_testsuites()) {                                              \
 				for (const auto& test : suite.second) {                                                \
 					try {                                                                               \
-						std::cout << "Running " << suite.first << "::" << test.first << std::endl;       \
+						log_info("Running %s::%s\n", suite.first, test.first);                          \
 						test.second();                                                                   \
 					} catch (const std::exception& e) {                                                 \
 						errors = true;                                                                   \
-						std::cout << "Error in " << suite.first << "::" << test.first << ": "            \
-						          << e.what() << std::endl;                                              \
+						log_info("Error in %s::%s: %s\n", suite.first, test.first, e.what());          \
 					}                                                                                   \
 				}                                                                                      \
 			}                                                                                         \

--- a/src/base/test.h
+++ b/src/base/test.h
@@ -193,18 +193,20 @@ inline void do_check_error(const char* f,
 	namespace WLTestsuite {                                                                         \
 	namespace WLTestsuite_##name {                                                                  \
 		static int main() {                                                                          \
-			if (needs_logging) {                                                                      \
-				set_testcase_logging_dir();                                                            \
-			}                                                                                         \
+			set_testcase_logging_dir();                                                            \
 			bool errors = false;                                                                      \
 			for (const auto& suite : all_testsuites()) {                                              \
 				for (const auto& test : suite.second) {                                                \
 					try {                                                                               \
-						log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());                          \
+						if (needs_logging) {                                                            \
+							log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());       \
+						}                                                                                \
 						test.second();                                                                   \
 					} catch (const std::exception& e) {                                                 \
 						errors = true;                                                                   \
-						log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(), e.what());          \
+						if (needs_logging) {                                                            \
+							log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(), e.what());  \
+						}                                                                               \
 					}                                                                                   \
 				}                                                                                      \
 			}                                                                                         \

--- a/src/base/test.h
+++ b/src/base/test.h
@@ -189,7 +189,7 @@ inline void do_check_error(const char* f,
 }
 }  // namespace WLTestsuite
 
-#define TEST_EXECUTABLE(name)                                                       \
+#define TEST_EXECUTABLE(name)                                                                      \
 	namespace WLTestsuite {                                                                         \
 	namespace WLTestsuite_##name {                                                                  \
 		static int main() {                                                                          \
@@ -198,11 +198,12 @@ inline void do_check_error(const char* f,
 			for (const auto& suite : all_testsuites()) {                                              \
 				for (const auto& test : suite.second) {                                                \
 					try {                                                                               \
-						log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());        \
+						log_info("Running %s::%s\n", suite.first.c_str(), test.first.c_str());           \
 						test.second();                                                                   \
 					} catch (const std::exception& e) {                                                 \
 						errors = true;                                                                   \
-						log_info("Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(), e.what()); \
+						log_info(                                                                        \
+						   "Error in %s::%s: %s\n", suite.first.c_str(), test.first.c_str(), e.what());  \
 					}                                                                                   \
 				}                                                                                      \
 			}                                                                                         \

--- a/src/base/test/base_test_main.cc
+++ b/src/base/test/base_test_main.cc
@@ -17,4 +17,4 @@
  */
 
 #include "base/test.h"
-TEST_EXECUTABLE(base, true)
+TEST_EXECUTABLE(base)

--- a/src/economy/test/economy_test_main.cc
+++ b/src/economy/test/economy_test_main.cc
@@ -17,4 +17,4 @@
  */
 
 #include "base/test.h"
-TEST_EXECUTABLE(economy, true)
+TEST_EXECUTABLE(economy)

--- a/src/io/filesystem/test/filesystem_test_main.cc
+++ b/src/io/filesystem/test/filesystem_test_main.cc
@@ -17,4 +17,4 @@
  */
 
 #include "base/test.h"
-TEST_EXECUTABLE(filesystem, false)
+TEST_EXECUTABLE(filesystem)

--- a/src/notifications/test/notifications_test.cc
+++ b/src/notifications/test/notifications_test.cc
@@ -21,7 +21,7 @@
 #include "base/test.h"
 #include "notifications/notifications.h"
 
-TEST_EXECUTABLE(notifications, false)
+TEST_EXECUTABLE(notifications, true)
 
 struct SimpleNote {
 	CAN_BE_SENT_AS_NOTE(100)

--- a/src/notifications/test/notifications_test.cc
+++ b/src/notifications/test/notifications_test.cc
@@ -21,7 +21,7 @@
 #include "base/test.h"
 #include "notifications/notifications.h"
 
-TEST_EXECUTABLE(notifications, true)
+TEST_EXECUTABLE(notifications)
 
 struct SimpleNote {
 	CAN_BE_SENT_AS_NOTE(100)

--- a/src/scripting/test/scripting_test_main.cc
+++ b/src/scripting/test/scripting_test_main.cc
@@ -17,4 +17,4 @@
  */
 
 #include "base/test.h"
-TEST_EXECUTABLE(scripting, true)
+TEST_EXECUTABLE(scripting)


### PR DESCRIPTION
**Type of change**
Bugfix 

**Issue(s) closed**
Fixes #5819 

**New behavior**
testsuite uses normal logging commands now rather then using cout

**How it works**
Made the unittests use the log_info function. this avoids re4direction of cout as the output is directly written to file for windows.
works in appveyor
https://ci.appveyor.com/project/widelands-dev/widelands/builds/46901496

**Possible regressions**
Unit tests performance / logging in linux / macos

