### PR TITLE
Map Required WL Version Check

### DIFF
--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -1479,6 +1479,7 @@ void EditorInteractive::publish_map() {
 	info.unlocalized_author = egbase().map().get_author();
 	info.version = version;
 	info.category = AddOns::AddOnCategory::kMaps;
+	info.min_wl_version = egbase().map().version().minimum_required_widelands_version;
 
 	AddOns::NetAddons::CallbackFn fnn = [this](const std::string& /* f */, int64_t /* l */) {
 		do_redraw_now();

--- a/src/logic/addons.cc
+++ b/src/logic/addons.cc
@@ -415,7 +415,8 @@ bool AddOnInfo::matches_widelands_version() const {
 	return AddOns::matches_widelands_version(min_wl_version, max_wl_version);
 }
 
-bool matches_widelands_version(const std::string& min_wl_version, const std::string& max_wl_version) {
+bool matches_widelands_version(const std::string& min_wl_version,
+                               const std::string& max_wl_version) {
 	if (min_wl_version.empty() && max_wl_version.empty()) {
 		return true;
 	}

--- a/src/logic/addons.h
+++ b/src/logic/addons.h
@@ -65,7 +65,8 @@ std::string version_to_string(const AddOnVersion&, bool localize = true);
 AddOnVersion string_to_version(std::string);
 // Returns true if and only if version `compare` is newer than version `base`
 bool is_newer_version(const AddOnVersion& base, const AddOnVersion& compare);
-bool matches_widelands_version(const std::string& min_wl_version, const std::string& max_wl_version);
+bool matches_widelands_version(const std::string& min_wl_version,
+                               const std::string& max_wl_version);
 
 // Required add-ons for an add-on, map, or savegame with the recommended version
 using AddOnRequirements = std::vector<std::pair<std::string, AddOnVersion>>;

--- a/src/logic/addons.h
+++ b/src/logic/addons.h
@@ -65,6 +65,7 @@ std::string version_to_string(const AddOnVersion&, bool localize = true);
 AddOnVersion string_to_version(std::string);
 // Returns true if and only if version `compare` is newer than version `base`
 bool is_newer_version(const AddOnVersion& base, const AddOnVersion& compare);
+bool matches_widelands_version(const std::string& min_wl_version, const std::string& max_wl_version);
 
 // Required add-ons for an add-on, map, or savegame with the recommended version
 using AddOnRequirements = std::vector<std::pair<std::string, AddOnVersion>>;

--- a/src/logic/map_revision.h
+++ b/src/logic/map_revision.h
@@ -32,7 +32,7 @@ struct MapVersion {
 	int32_t map_version_major{0};
 	int32_t map_version_minor{0};
 	uint32_t map_version_timestamp;
-	// Map compatibility information for the website
+	// Map compatibility information for the website, the add-ons packager, and the map select UI.
 	std::string minimum_required_widelands_version;
 
 	MapVersion();

--- a/src/logic/mutable_addon.cc
+++ b/src/logic/mutable_addon.cc
@@ -124,11 +124,15 @@ std::string MutableAddOn::profile_path() {
 void MutableAddOn::update_info(const std::string& descname,
                                const std::string& author,
                                const std::string& description,
-                               const std::string& version) {
+                               const std::string& version,
+                               const std::string& min_wl_version,
+                               const std::string& max_wl_version) {
 	descname_ = descname;
 	author_ = author;
 	description_ = description;
 	version_ = version;
+	min_wl_version_ = min_wl_version;
+	max_wl_version_ = max_wl_version;
 }
 
 void MutableAddOn::setup_temp_dir() {

--- a/src/logic/mutable_addon.h
+++ b/src/logic/mutable_addon.h
@@ -36,7 +36,9 @@ public:
 	void update_info(const std::string& descname,
 	                 const std::string& author,
 	                 const std::string& description,
-	                 const std::string& version);
+	                 const std::string& version,
+	                 const std::string& min_wl_version,
+	                 const std::string& max_wl_version);
 	using ProgressFunction = std::function<void(size_t)>;
 	void set_callbacks(const ProgressFunction& init, const ProgressFunction& progress) {
 		callback_init_ = init;
@@ -69,6 +71,12 @@ public:
 	void set_version(const std::string& version) {
 		version_ = version;
 	}
+	void set_min_wl_version(const std::string& min_wl_version) {
+		min_wl_version_ = min_wl_version;
+	}
+	void set_max_wl_version(const std::string& max_wl_version) {
+		max_wl_version_ = max_wl_version;
+	}
 	void set_force_sync_safe(bool fss) {
 		force_sync_safe_ = fss;
 	}
@@ -85,8 +93,13 @@ protected:
 	                                             const std::string& dest,
 	                                             bool dry_run);
 
-	std::string internal_name_, descname_, description_, author_, version_, min_wl_version_,
-	   max_wl_version_;
+	std::string internal_name_;
+	std::string descname_;
+	std::string description_;
+	std::string author_;
+	std::string version_;
+	std::string min_wl_version_;
+	std::string max_wl_version_;
 	AddOnCategory category_;
 	/*
 	 * The `sync_safe` property is not stored here because all new or updated add-ons

--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -126,11 +126,11 @@ AddOnsPackager::AddOnsPackager(FsMenu::MainMenu& parent, AddOnsCtrl& ctrl)
 	box_right_subbox_header_box_right_.add_space(kSpacing);
 	box_right_subbox_header_box_right_.add(&version_, UI::Box::Resizing::kFullSize);
 	box_right_subbox_header_box_right_.add_space(kSpacing);
-	box_right_subbox_header_box_right_.add(&descr_, UI::Box::Resizing::kFullSize);
-	box_right_subbox_header_box_right_.add_space(kSpacing);
 	box_right_subbox_header_box_right_.add(&min_wl_version_, UI::Box::Resizing::kFullSize);
 	box_right_subbox_header_box_right_.add_space(kSpacing);
 	box_right_subbox_header_box_right_.add(&max_wl_version_, UI::Box::Resizing::kFullSize);
+	box_right_subbox_header_box_right_.add_space(kSpacing);
+	box_right_subbox_header_box_right_.add(&descr_, UI::Box::Resizing::kFullSize);
 
 	box_right_subbox_header_box_left_.add_space(kSpacing);
 	box_right_subbox_header_box_left_.add(
@@ -150,18 +150,18 @@ AddOnsPackager::AddOnsPackager(FsMenu::MainMenu& parent, AddOnsCtrl& ctrl)
 	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
 	box_right_subbox_header_box_left_.add(
 	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
-	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Description:"),
-	                    UI::Align::kRight),
-	   UI::Box::Resizing::kFullSize);
-	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
-	box_right_subbox_header_box_left_.add(
-	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
 	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Minimum Widelands Version:"), UI::Align::kRight),
 	   UI::Box::Resizing::kFullSize);
 	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
 	box_right_subbox_header_box_left_.add(
 	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
 	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Maximum Widelands Version:"), UI::Align::kRight),
+	   UI::Box::Resizing::kFullSize);
+	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
+	box_right_subbox_header_box_left_.add(
+	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
+	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Description:"),
+	                    UI::Align::kRight),
 	   UI::Box::Resizing::kFullSize);
 
 	box_right_subbox_header_hbox_.add(

--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -63,6 +63,8 @@ AddOnsPackager::AddOnsPackager(FsMenu::MainMenu& parent, AddOnsCtrl& ctrl)
      name_(&box_right_subbox_header_box_right_, 0, 0, 100, UI::PanelStyle::kFsMenu),
      author_(&box_right_subbox_header_box_right_, 0, 0, 100, UI::PanelStyle::kFsMenu),
      version_(&box_right_subbox_header_box_right_, 0, 0, 100, UI::PanelStyle::kFsMenu),
+     min_wl_version_(&box_right_subbox_header_box_right_, 0, 0, 100, UI::PanelStyle::kFsMenu),
+     max_wl_version_(&box_right_subbox_header_box_right_, 0, 0, 100, UI::PanelStyle::kFsMenu),
      descr_(*new UI::MultilineEditbox(
         &box_right_subbox_header_box_right_, 0, 0, 100, 100, UI::PanelStyle::kFsMenu)),
      addon_new_(&box_left_buttons_,
@@ -125,6 +127,10 @@ AddOnsPackager::AddOnsPackager(FsMenu::MainMenu& parent, AddOnsCtrl& ctrl)
 	box_right_subbox_header_box_right_.add(&version_, UI::Box::Resizing::kFullSize);
 	box_right_subbox_header_box_right_.add_space(kSpacing);
 	box_right_subbox_header_box_right_.add(&descr_, UI::Box::Resizing::kFullSize);
+	box_right_subbox_header_box_right_.add_space(kSpacing);
+	box_right_subbox_header_box_right_.add(&min_wl_version_, UI::Box::Resizing::kFullSize);
+	box_right_subbox_header_box_right_.add_space(kSpacing);
+	box_right_subbox_header_box_right_.add(&max_wl_version_, UI::Box::Resizing::kFullSize);
 
 	box_right_subbox_header_box_left_.add_space(kSpacing);
 	box_right_subbox_header_box_left_.add(
@@ -146,6 +152,16 @@ AddOnsPackager::AddOnsPackager(FsMenu::MainMenu& parent, AddOnsCtrl& ctrl)
 	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
 	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Description:"),
 	                    UI::Align::kRight),
+	   UI::Box::Resizing::kFullSize);
+	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
+	box_right_subbox_header_box_left_.add(
+	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
+	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Minimum Widelands Version:"), UI::Align::kRight),
+	   UI::Box::Resizing::kFullSize);
+	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
+	box_right_subbox_header_box_left_.add(
+	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
+	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Maximum Widelands Version:"), UI::Align::kRight),
 	   UI::Box::Resizing::kFullSize);
 
 	box_right_subbox_header_hbox_.add(
@@ -193,6 +209,8 @@ AddOnsPackager::AddOnsPackager(FsMenu::MainMenu& parent, AddOnsCtrl& ctrl)
 	name_.changed.connect([this]() { current_addon_edited(); });
 	author_.changed.connect([this]() { current_addon_edited(); });
 	version_.changed.connect([this]() { current_addon_edited(); });
+	min_wl_version_.changed.connect([this]() { current_addon_edited(); });
+	max_wl_version_.changed.connect([this]() { current_addon_edited(); });
 	descr_.changed.connect([this]() { current_addon_edited(); });
 
 	initialize_mutable_addons();
@@ -280,6 +298,8 @@ void AddOnsPackager::addon_selected() {
 	descr_.set_text(selected->get_description());
 	author_.set_text(selected->get_author());
 	version_.set_text(selected->get_version());
+	min_wl_version_.set_text(selected->get_min_wl_version());
+	max_wl_version_.set_text(selected->get_min_wl_version());
 	update_in_progress_ = false;
 
 	if (addon_boxes_.count(selected->get_category()) == 0) {
@@ -301,7 +321,7 @@ void AddOnsPackager::current_addon_edited() {
 	const std::string& sel = addons_.get_selected();
 	AddOns::MutableAddOn* m = mutable_addons_.at(sel).get();
 
-	m->update_info(name_.text(), author_.text(), descr_.get_text(), version_.text());
+	m->update_info(name_.text(), author_.text(), descr_.get_text(), version_.text(), min_wl_version_.text(), max_wl_version_.text());
 
 	addons_with_changes_[sel] = false;
 	check_for_unsaved_changes();
@@ -522,6 +542,18 @@ bool AddOnsPackager::do_write_addon_to_disk(const std::string& addon) {
 		m->set_version(AddOns::version_to_string(v, false));
 		if (addons_.has_selection() && addons_.get_selected() == addon) {
 			version_.set_text(m->get_version());
+		}
+
+		v = AddOns::string_to_version(m->get_min_wl_version());
+		m->set_min_wl_version(AddOns::version_to_string(v, false));
+		if (addons_.has_selection() && addons_.get_selected() == addon) {
+			min_wl_version_.set_text(m->get_min_wl_version());
+		}
+
+		v = AddOns::string_to_version(m->get_max_wl_version());
+		m->set_max_wl_version(AddOns::version_to_string(v, false));
+		if (addons_.has_selection() && addons_.get_selected() == addon) {
+			max_wl_version_.set_text(m->get_max_wl_version());
 		}
 	} catch (...) {
 		main_menu_.show_messagebox(

--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -150,12 +150,14 @@ AddOnsPackager::AddOnsPackager(FsMenu::MainMenu& parent, AddOnsCtrl& ctrl)
 	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
 	box_right_subbox_header_box_left_.add(
 	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
-	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Minimum Widelands Version:"), UI::Align::kRight),
+	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Minimum Widelands Version:"),
+	                    UI::Align::kRight),
 	   UI::Box::Resizing::kFullSize);
 	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
 	box_right_subbox_header_box_left_.add(
 	   new UI::Textarea(&box_right_subbox_header_box_left_, UI::PanelStyle::kFsMenu,
-	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Maximum Widelands Version:"), UI::Align::kRight),
+	                    UI::FontStyle::kFsMenuInfoPanelHeading, _("Maximum Widelands Version:"),
+	                    UI::Align::kRight),
 	   UI::Box::Resizing::kFullSize);
 	box_right_subbox_header_box_left_.add_space(3 * kSpacing);
 	box_right_subbox_header_box_left_.add(
@@ -321,7 +323,8 @@ void AddOnsPackager::current_addon_edited() {
 	const std::string& sel = addons_.get_selected();
 	AddOns::MutableAddOn* m = mutable_addons_.at(sel).get();
 
-	m->update_info(name_.text(), author_.text(), descr_.get_text(), version_.text(), min_wl_version_.text(), max_wl_version_.text());
+	m->update_info(name_.text(), author_.text(), descr_.get_text(), version_.text(),
+	               min_wl_version_.text(), max_wl_version_.text());
 
 	addons_with_changes_[sel] = false;
 	check_for_unsaved_changes();

--- a/src/ui_fsmenu/addons/packager.h
+++ b/src/ui_fsmenu/addons/packager.h
@@ -50,7 +50,7 @@ private:
 	UI::Box main_box_, box_left_, box_right_, box_left_buttons_, box_right_subbox_header_hbox_,
 	   box_right_subbox_header_box_left_, box_right_subbox_header_box_right_,
 	   box_right_addon_specific_, box_right_bottombox_;
-	UI::EditBox name_, author_, version_;
+	UI::EditBox name_, author_, version_, min_wl_version_, max_wl_version_;
 	UI::MultilineEditbox& descr_;
 	UI::Button addon_new_, addon_delete_, discard_changes_, write_changes_, ok_;
 	UI::Listselect<std::string> addons_;

--- a/src/wui/mapdata.cc
+++ b/src/wui/mapdata.cc
@@ -67,6 +67,7 @@ MapData::MapData(const Widelands::Map& map,
 	height = map.get_height();
 	suggested_teams = map.get_suggested_teams();
 	tags = map.get_tags();
+	minimum_required_widelands_version = map.version().minimum_required_widelands_version;
 
 	if (maptype == MapData::MapType::kScenario) {
 		tags.insert("scenario");

--- a/src/wui/mapdata.h
+++ b/src/wui/mapdata.h
@@ -86,6 +86,7 @@ public:
 	MapData::MapType maptype;
 	MapData::DisplayType displaytype;
 	AddOns::AddOnRequirements required_addons;
+	std::string minimum_required_widelands_version;
 };
 
 #endif  // end of include guard: WL_WUI_MAPDATA_H

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -164,32 +164,46 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
                forms here, please let us know. */
                _("Authors");
 		std::string description = as_heading(authors_heading, style_);
-		description = format("%s%s", description, as_content(mapdata.authors.get_names(), style_));
+		description += as_content(mapdata.authors.get_names(), style_);
 
 		std::vector<std::string> tags;
 		for (const auto& tag : mapdata.tags) {
 			tags.push_back(localize_tag(tag).displayname);
 		}
 		std::sort(tags.begin(), tags.end());
-		description = format("%s%s", description, as_heading(_("Tags"), style_));
-		description =
-		   format("%s%s", description,
-		          as_content(i18n::localize_list(tags, i18n::ConcatenateWith::COMMA), style_));
+		description += as_heading(_("Tags"), style_);
+		description += as_content(i18n::localize_list(tags, i18n::ConcatenateWith::COMMA), style_);
 
 		AddOns::AddOnConflict addons = AddOns::check_requirements(mapdata.required_addons);
 		loadable = !addons.second;
 
-		description =
-		   format("%s%s", description,
-		          as_heading_with_content(_("Add-Ons:"), addons.first, style_, false, true));
+		description += as_heading_with_content(_("Add-Ons:"), addons.first, style_, false, true);
 
-		description = format("%s%s", description, as_heading(_("Description"), style_));
-		description = format("%s%s", description, as_content(mapdata.description, style_));
+		if (!mapdata.minimum_required_widelands_version.empty()) {
+			bool compatible;
+			try {
+				compatible = AddOns::matches_widelands_version(mapdata.minimum_required_widelands_version, std::string());
+			} catch (const std::exception& e) {
+				compatible = false;
+				log_warn("Could not parse map version requirement '%s': %s", mapdata.minimum_required_widelands_version.c_str(), e.what());
+			}
+
+			loadable &= compatible;
+
+			if (compatible) {
+				description += as_heading_with_content(_("Minimum Widelands Version:"), mapdata.minimum_required_widelands_version, style_, false, true);
+			} else {
+				description += as_heading_with_content(_("Minimum Widelands Version:"), as_font_tag(UI::FontStyle::kWarning, mapdata.minimum_required_widelands_version), style_, false, true);
+			}
+		}
+
+		description += as_heading(_("Description"), style_);
+		description += as_content(mapdata.description, style_);
 
 		if (!mapdata.hint.empty()) {
 			/** TRANSLATORS: Map hint header when selecting a map. */
-			description = format("%s%s", description, as_heading(_("Hint"), style_));
-			description = format("%s%s", description, as_content(mapdata.hint, style_));
+			description += as_heading(_("Hint"), style_);
+			description += as_content(mapdata.hint, style_);
 		}
 
 		// Render minimap

--- a/src/wui/mapdetails.cc
+++ b/src/wui/mapdetails.cc
@@ -182,18 +182,25 @@ bool MapDetails::update(const MapData& mapdata, bool localize_mapname, bool rend
 		if (!mapdata.minimum_required_widelands_version.empty()) {
 			bool compatible;
 			try {
-				compatible = AddOns::matches_widelands_version(mapdata.minimum_required_widelands_version, std::string());
+				compatible = AddOns::matches_widelands_version(
+				   mapdata.minimum_required_widelands_version, std::string());
 			} catch (const std::exception& e) {
 				compatible = false;
-				log_warn("Could not parse map version requirement '%s': %s", mapdata.minimum_required_widelands_version.c_str(), e.what());
+				log_warn("Could not parse map version requirement '%s': %s",
+				         mapdata.minimum_required_widelands_version.c_str(), e.what());
 			}
 
 			loadable &= compatible;
 
 			if (compatible) {
-				description += as_heading_with_content(_("Minimum Widelands Version:"), mapdata.minimum_required_widelands_version, style_, false, true);
+				description += as_heading_with_content(_("Minimum Widelands Version:"),
+				                                       mapdata.minimum_required_widelands_version,
+				                                       style_, false, true);
 			} else {
-				description += as_heading_with_content(_("Minimum Widelands Version:"), as_font_tag(UI::FontStyle::kWarning, mapdata.minimum_required_widelands_version), style_, false, true);
+				description += as_heading_with_content(
+				   _("Minimum Widelands Version:"),
+				   as_font_tag(UI::FontStyle::kWarning, mapdata.minimum_required_widelands_version),
+				   style_, false, true);
 			}
 		}
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes https://www.widelands.org/forum/topic/5767/?page=1#post-40291

**New behavior**
- When selecting a map in the user interface, also show the map's minimum required Widelands version and forbid loading the map if it's too new.
- The editor's Publish feature automatically sets the minimum WL version in accordance with the map's.
- The add-ons packager also allows setting the min and max WL version now, but it's not yet computed automatically.

**Screenshots**
![grafik](https://user-images.githubusercontent.com/48293446/235321471-3b84f0d1-1e34-436e-925e-00d5ac39be32.png) ![grafik](https://user-images.githubusercontent.com/48293446/235321494-0604527a-ba7a-40cb-9a53-1a6f065497c6.png)
