### PR TITLE
Naval Warfare: Better Invasion End Detection

### DIFF
--- a/src/logic/map_objects/findimmovable.cc
+++ b/src/logic/map_objects/findimmovable.cc
@@ -56,14 +56,16 @@ bool FindImmovablePlayerImmovable::accept(const BaseImmovable& imm) const {
 }
 
 bool FindImmovablePlayerMilitarySite::accept(const BaseImmovable& imm) const {
-	if (upcast(MilitarySite const, ms, &imm)) {
+	if (imm.descr().type() == MapObjectType::MILITARYSITE) {
+		upcast(MilitarySite const, ms, &imm);
 		return &ms->owner() == &player;
 	}
 	return false;
 }
 
 bool FindImmovableAttackTarget::accept(const BaseImmovable& imm) const {
-	if (upcast(Building const, b, &imm)) {
+	if (imm.descr().type() >= MapObjectType::BUILDING) {
+		upcast(Building const, b, &imm);
 		return b->attack_target() != nullptr;
 	}
 	return false;
@@ -76,18 +78,14 @@ bool FindImmovableAttackTarget::accept(const BaseImmovable& imm) const {
 
 bool FindForeignMilitarysite::accept(const BaseImmovable& imm) const {
 	if (imm.descr().type() == MapObjectType::MILITARYSITE) {
-		if (upcast(MilitarySite const, ms, &imm)) {
-			return &ms->owner() != &player;
-		}
+		upcast(MilitarySite const, ms, &imm);
+		return &ms->owner() != &player;
 	}
 	return false;
 }
 
 bool FindImmovableByDescr::accept(const BaseImmovable& baseimm) const {
-	if (&baseimm.descr() == &descr) {
-		return true;
-	}
-	return false;
+	return &baseimm.descr() == &descr;
 }
 
 bool FindFlagOf::accept(const BaseImmovable& baseimm) const {

--- a/src/logic/map_objects/findimmovable.h
+++ b/src/logic/map_objects/findimmovable.h
@@ -159,6 +159,15 @@ struct FindFlagOf {
 	const FindImmovable finder;
 };
 
+struct FindFlagWithPlayersWarehouse {
+	explicit FindFlagWithPlayersWarehouse(const Player& owner) : owner_(owner) {
+	}
+	[[nodiscard]] bool accept(const BaseImmovable& imm) const;
+
+private:
+	const Player& owner_;
+};
+
 }  // namespace Widelands
 
 #endif  // end of include guard: WL_LOGIC_MAP_OBJECTS_FINDIMMOVABLE_H

--- a/src/logic/map_objects/findimmovable.h
+++ b/src/logic/map_objects/findimmovable.h
@@ -99,6 +99,7 @@ struct FindImmovableSize {
 private:
 	int32_t min, max;
 };
+
 struct FindImmovableType {
 	explicit FindImmovableType(MapObjectType const init_type) : type(init_type) {
 	}
@@ -108,6 +109,7 @@ struct FindImmovableType {
 private:
 	MapObjectType type;
 };
+
 struct FindImmovableAttribute {
 	explicit FindImmovableAttribute(uint32_t const init_attrib) : attrib(init_attrib) {
 	}
@@ -117,28 +119,36 @@ struct FindImmovableAttribute {
 private:
 	int32_t attrib;
 };
+
 struct FindImmovablePlayerImmovable {
 	FindImmovablePlayerImmovable() = default;
 
 	[[nodiscard]] bool accept(const BaseImmovable&) const;
 };
+
 struct FindImmovablePlayerMilitarySite {
 	explicit FindImmovablePlayerMilitarySite(const Player& init_player) : player(init_player) {
 	}
 
 	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
+private:
 	const Player& player;
 };
+
 struct FindImmovableAttackTarget {
 	FindImmovableAttackTarget() = default;
 
 	[[nodiscard]] bool accept(const BaseImmovable&) const;
 };
+
 struct FindForeignMilitarysite {
 	explicit FindForeignMilitarysite(const Player& init_player) : player(init_player) {
 	}
+
 	[[nodiscard]] bool accept(const BaseImmovable&) const;
+
+private:
 	const Player& player;
 };
 
@@ -148,20 +158,24 @@ struct FindImmovableByDescr {
 
 	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
+private:
 	const ImmovableDescr& descr;
 };
+
 struct FindFlagOf {
 	explicit FindFlagOf(const FindImmovable& init_finder) : finder(init_finder) {
 	}
 
 	[[nodiscard]] bool accept(const BaseImmovable&) const;
 
+private:
 	const FindImmovable finder;
 };
 
 struct FindFlagWithPlayersWarehouse {
 	explicit FindFlagWithPlayersWarehouse(const Player& owner) : owner_(owner) {
 	}
+
 	[[nodiscard]] bool accept(const BaseImmovable& imm) const;
 
 private:

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1761,7 +1761,7 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 		do {
 			if (mr.location().field->get_owned_by() != owner().player_number()) {
 				molog(game.get_gametime(), "[naval_invasion] Conquering port area\n");
-				game.conquer_area_no_building(PlayerArea<Area<FCoords>>(
+				game.conquer_area(PlayerArea<Area<FCoords>>(
 				   owner().player_number(), Area<FCoords>(portspace_fcoords, kPortSpaceRadius)));
 				return start_task_idle(game, descr().get_animation("idle", this), 1000);
 			}

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1747,6 +1747,12 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 		}
 	}
 
+	// The player doesn't have to build the port exactly where we envision it.
+	if (map.find_reachable_immovables(game, Area<FCoords>(get_position(), kPortSpaceGeneralAreaRadius), nullptr, checkstep, FindFlagWithPlayersWarehouse(*get_owner())) > 0) {
+		molog(game.get_gametime(), "[naval_invasion] Nearby economy found, join it\n");
+		return pop_task(game);
+	}
+
 	if (map.calc_distance(get_position(), state.coords) <= kPortSpaceGeneralAreaRadius) {
 		// The target should be unguarded now, conquer the port space.
 		MapRegion<Area<FCoords>> mr(map, Area<FCoords>(portspace_fcoords, kPortSpaceRadius));

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1748,7 +1748,9 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 	}
 
 	// The player doesn't have to build the port exactly where we envision it.
-	if (map.find_reachable_immovables(game, Area<FCoords>(get_position(), kPortSpaceGeneralAreaRadius), nullptr, checkstep, FindFlagWithPlayersWarehouse(*get_owner())) > 0) {
+	if (map.find_reachable_immovables(
+	       game, Area<FCoords>(get_position(), kPortSpaceGeneralAreaRadius), nullptr, checkstep,
+	       FindFlagWithPlayersWarehouse(*get_owner())) > 0) {
 		molog(game.get_gametime(), "[naval_invasion] Nearby economy found, join it\n");
 		return pop_task(game);
 	}

--- a/src/logic/map_objects/tribes/worker.cc
+++ b/src/logic/map_objects/tribes/worker.cc
@@ -2643,24 +2643,6 @@ void Worker::start_task_fugitive(Game& game) {
 	top_state().ivar1 = game.get_gametime().get() + 120000 + 200 * (game.logic_rand() % 600);
 }
 
-struct FindFlagWithPlayersWarehouse {
-	explicit FindFlagWithPlayersWarehouse(const Player& owner) : owner_(owner) {
-	}
-	[[nodiscard]] bool accept(const BaseImmovable& imm) const {
-		if (upcast(Flag const, flag, &imm)) {
-			if (flag->get_owner() == &owner_) {
-				if (!flag->economy(wwWORKER).warehouses().empty()) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-private:
-	const Player& owner_;
-};
-
 void Worker::fugitive_update(Game& game, State& state) {
 	if (!get_signal().empty()) {
 		molog(game.get_gametime(), "[fugitive]: interrupted by signal '%s'\n", get_signal().c_str());


### PR DESCRIPTION
**Type of change**
Feature enhancement

**Issue(s) closed**
Re naval warfare:
Found while testing this with a bigger game on the Tiperary 16 players add-on map: 
A naval invasion can currently only be completed by building a port at exactly the point where you sent your invasion force. So a port two nodes over doesn't count, and "backdoor" invasions where you don't intend to build a port at all are also unexpectedly problematic. In those perfectly valid cases the soldiers never stop behaving like invaders, even when the entire island firmly belongs to you.

**How it works**
This extends the invasion soldier logic so the invasion is also considered successfully over when a flag connected to an own warehouse is found close to the port space.

**Possible regressions**
n/a

**Additional context**
Only tested together with #5885, but pulled out as a separate PR.