### PR TITLE
Fix modality and threading issues around `StoryMessageBox`

### DIFF
--- a/src/base/multithreading.cc
+++ b/src/base/multithreading.cc
@@ -80,7 +80,7 @@ void NoteThreadSafeFunction::instantiate(const std::function<void()>& fn,
 	} else {
 		// All other threads must ask it politely to do this for them.
 		if (wait_until_completion) {
-			bool done = false;
+			volatile bool done = false;
 
 			// Some codepaths want to perform special error handling, so we catch
 			// any errors and forward them to the caller in a thread-safe manner.
@@ -100,7 +100,7 @@ void NoteThreadSafeFunction::instantiate(const std::function<void()>& fn,
 				}
 				done = true;
 			}));
-			while (!done) {  // NOLINT
+			while (!done) {
 				// Wait until the NoteThreadSafeFunction has been handled.
 				// Since `done` was passed by address, it will set to
 				// `true` when the function has been executed.

--- a/src/scripting/lua_game.cc
+++ b/src/scripting/lua_game.cc
@@ -560,7 +560,7 @@ int LuaPlayer::message_box(lua_State* L) {
 		std::unique_ptr<StoryMessageBox> mb(new StoryMessageBox(&game, coords, luaL_checkstring(L, 2),
 		                                                        luaL_checkstring(L, 3), posx, posy, w,
 		                                                        h, is_modal, allow_next_scenario));
-		mb->run<UI::Panel::Returncodes>();
+		NoteThreadSafeFunction::instantiate([&mb]() { mb->run<UI::Panel::Returncodes>(); }, true);
 	} else {
 		new StoryMessageBox(&game, coords, luaL_checkstring(L, 2), luaL_checkstring(L, 3), posx, posy,
 		                    w, h, is_modal, allow_next_scenario);

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -217,11 +217,13 @@ void Panel::handle_notes() {
 			// If there are multiple modal panels, ensure each note is handled only once
 			Notifications::publish(NoteThreadSafeFunctionHandled(notes_.front().id));
 
-			notes_.front().run();
+			NoteThreadSafeFunction note = notes_.front();
+			notes_.pop_front();
+			note.run();
 		} else {
 			handled_notes_.erase(notes_.front().id);
+			notes_.pop_front();
 		}
-		notes_.pop_front();
 	}
 }
 

--- a/src/wui/story_message_box.cc
+++ b/src/wui/story_message_box.cc
@@ -74,6 +74,7 @@ StoryMessageBox::StoryMessageBox(Widelands::Game* game,
                 _("Main Menu"),
                 _("Return to the main menu")),
      desired_speed_(game->game_controller()->desired_speed()),
+     modal_(modal),
      game_(game) {
 
 	// Pause the game
@@ -129,10 +130,7 @@ StoryMessageBox::StoryMessageBox(Widelands::Game* game,
 }
 
 void StoryMessageBox::clicked_ok() {
-	set_visible(false);
-	set_thinks(false);
-
-	if (is_modal()) {
+	if (modal_) {
 		resume_game();
 		end_modal<UI::Panel::Returncodes>(UI::Panel::Returncodes::kOk);
 	} else {
@@ -162,7 +160,7 @@ void StoryMessageBox::clicked_main_menu() {
 }
 
 bool StoryMessageBox::handle_mousepress(const uint8_t btn, int32_t mx, int32_t my) {
-	if (btn == SDL_BUTTON_RIGHT && is_modal()) {
+	if (btn == SDL_BUTTON_RIGHT && modal_) {
 		return true;
 	}
 

--- a/src/wui/story_message_box.h
+++ b/src/wui/story_message_box.h
@@ -70,7 +70,7 @@ private:
 
 	const uint32_t desired_speed_;  // Remember the previous game speed
 	const bool modal_;
-	Widelands::Game* game_;         // For controlling the game speed
+	Widelands::Game* game_;  // For controlling the game speed
 };
 
 #endif  // end of include guard: WL_WUI_STORY_MESSAGE_BOX_H

--- a/src/wui/story_message_box.h
+++ b/src/wui/story_message_box.h
@@ -69,6 +69,7 @@ private:
 	UI::Button ok_, next_scenario_, main_menu_;
 
 	const uint32_t desired_speed_;  // Remember the previous game speed
+	const bool modal_;
 	Widelands::Game* game_;         // For controlling the game speed
 };
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5775 – I hope, please confirm!

**New behavior**
The original issue happens when the OK signal appears twice. This can be reproduced by setting an extremely high gamespeed and holding down the Enter key even before the window appears. This issue can be solved easily enough by caching the value of `modal` as a member variable of `StoryMessageBox` and using that instead of `is_modal()`.

However, this then leads to a nice bug chase around threading problems since this is a *modal* window that is created by the *logic* thread. I think I got it all straightened out now. But don't look at it askance or it may break ;)

**Possible regressions**
Modality!