### PR TITLE
[refactor] Make `WLApplication::get()` return reference

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -38,13 +38,10 @@
 int main(int argc, char* argv[]) {
 	std::cout << "This is Widelands version " << build_ver_details() << std::endl;
 
-	WLApplication* g_app = nullptr;
 	try {
-		g_app = WLApplication::get(argc, const_cast<char const**>(argv));
+		WLApplication& g_app = WLApplication::get(argc, const_cast<char const**>(argv));
 		// TODO(unknown): handle exceptions from the constructor
-		g_app->run();
-
-		delete g_app;
+		g_app.run();
 
 		return 0;
 	} catch (const ParameterError& e) {
@@ -53,7 +50,6 @@ int main(int argc, char* argv[]) {
 		if (e.what()[0] != 0) {
 			std::cerr << std::string(60, '=') << std::endl << std::endl << e.what() << std::endl;
 		}
-		delete g_app;
 
 		return 0;
 	}
@@ -65,7 +61,6 @@ int main(int argc, char* argv[]) {
 		          << build_ver_details() << ".\n"
 		          << "and remember to specify your operating system.\n\n"
 		          << std::flush;
-		delete g_app;
 
 		return 1;
 	} catch (const std::exception& e) {
@@ -75,7 +70,6 @@ int main(int argc, char* argv[]) {
 		          << build_ver_details() << ".\n"
 		          << "and remember to specify your operating system.\n\n"
 		          << std::flush;
-		delete g_app;
 
 		return 1;
 	}

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -183,9 +183,9 @@ constexpr uint32_t kGameLogicDelay = 50;
 void Panel::logic_thread() {
 	set_logic_thread();
 	logic_thread_running_ = true;
-	WLApplication* const app = WLApplication::get();
+	const WLApplication& app = WLApplication::get();
 
-	while (!app->should_die()) {
+	while (!app.should_die()) {
 		Panel* m =
 		   modal_;  // copy this because another panel may become modal during a lengthy logic frame
 
@@ -238,12 +238,12 @@ Panel& Panel::get_topmost_forefather() {
 void Panel::do_redraw_now(const bool handle_input, const std::string& message) {
 	assert(is_initializer_thread());
 
-	WLApplication* const app = WLApplication::get();
+	WLApplication& app = WLApplication::get();
 	static InputCallback input_callback = {Panel::ui_mousepress, Panel::ui_mouserelease,
 	                                       Panel::ui_mousemove,  Panel::ui_key,
 	                                       Panel::ui_textinput,  Panel::ui_mousewheel};
 	if (handle_input && message.empty()) {
-		app->handle_input(&input_callback);
+		app.handle_input(&input_callback);
 	}
 
 	Panel& ff = get_topmost_forefather();
@@ -265,8 +265,8 @@ void Panel::do_redraw_now(const bool handle_input, const std::string& message) {
 	}
 
 	if (g_mouse_cursor->is_visible()) {
-		g_mouse_cursor->change_cursor(app->is_mouse_pressed());
-		g_mouse_cursor->draw(rt, app->get_mouse_position());
+		g_mouse_cursor->change_cursor(app.is_mouse_pressed());
+		g_mouse_cursor->draw(rt, app.get_mouse_position());
 
 		// Tooltip magic. Some panels never want to show a tooltip, and if the display an
 		// overlay message we ignore user input and don't draw tooltips any more either.
@@ -336,10 +336,10 @@ int Panel::do_run() {
 	   LogicThreadState::kEndingConfirmed;  // don't start the logic thread ere we're ready
 
 	// TODO(sirver): the main loop should not be in UI, but in WLApplication.
-	WLApplication* const app = WLApplication::get();
+	WLApplication& app = WLApplication::get();
 	ModalGuard prevmodal(*this);
 	mousegrab_ = nullptr;        // good ol' paranoia
-	app->set_mouse_lock(false);  // more paranoia :-)
+	app.set_mouse_lock(false);  // more paranoia :-)
 
 	// With the default of 30FPS, the game will be drawn every 33ms.
 	const uint32_t draw_delay = 1000 / std::max(5, get_config_int("maxfps", 30));
@@ -380,11 +380,11 @@ int Panel::do_run() {
 		}
 
 		if (is_initializer) {
-			app->handle_input(&input_callback);
+			app.handle_input(&input_callback);
 		}
 
 		if (start_time >= next_time) {
-			if (app->should_die()) {
+			if (app.should_die()) {
 				end_modal<Returncodes>(Returncodes::kBack);
 				assert(!running_);
 			}
@@ -801,7 +801,7 @@ void Panel::do_think() {
  */
 Vector2i Panel::get_mouse_position() const {
 	return (parent_ != nullptr ? parent_->get_mouse_position() :
-                                WLApplication::get()->get_mouse_position()) -
+                                WLApplication::get().get_mouse_position()) -
 	       Vector2i(get_x() + get_lborder(), get_y() + get_tborder());
 }
 
@@ -813,7 +813,7 @@ void Panel::set_mouse_pos(const Vector2i p) {
 	if (parent_ != nullptr) {
 		parent_->set_mouse_pos(relative_p);
 	} else {
-		WLApplication::get()->warp_mouse(relative_p);
+		WLApplication::get().warp_mouse(relative_p);
 	}
 }
 
@@ -1187,7 +1187,7 @@ void Panel::set_tooltip(const std::string& text) {
 			tooltip_fixed_pos_ = Vector2i::invalid();
 		} else if (!text.empty()) {
 			tooltip_panel_ = this;
-			tooltip_fixed_pos_ = WLApplication::get()->get_mouse_position();
+			tooltip_fixed_pos_ = WLApplication::get().get_mouse_position();
 		}
 	}
 }
@@ -1250,7 +1250,7 @@ void Panel::do_mousein(bool const inside) {
 		    ((tooltip_panel_ == nullptr) || tooltip_fixed_pos_ == Vector2i::invalid()) &&
 		    !tooltip().empty()) {
 			tooltip_panel_ = this;
-			tooltip_fixed_pos_ = WLApplication::get()->get_mouse_position();
+			tooltip_fixed_pos_ = WLApplication::get().get_mouse_position();
 		} else if (!inside && tooltip_panel_ == this && tooltip_fixed_pos_ == Vector2i::invalid()) {
 			tooltip_panel_ = nullptr;
 		}
@@ -1442,7 +1442,7 @@ bool Panel::do_tooltip() {
  * \return \c true if the given key is currently pressed, or \c false otherwise
  */
 bool Panel::get_key_state(const SDL_Scancode key) const {
-	return WLApplication::get()->get_key_state(key);
+	return WLApplication::get().get_key_state(key);
 }
 
 UI::Panel* Panel::get_open_dropdown() {
@@ -1563,7 +1563,7 @@ bool Panel::ui_mousemove(uint8_t const state, int32_t x, int32_t y, int32_t xdif
 	}
 
 	int factor = 1;
-	if (WLApplication::get()->is_mouse_locked()) {
+	if (WLApplication::get().is_mouse_locked()) {
 		if (matches_keymod(SDL_GetModState(), KMOD_CTRL)) {
 			factor = 4;
 		} else if (!matches_keymod(SDL_GetModState(), KMOD_SHIFT)) {
@@ -1668,7 +1668,7 @@ bool Panel::draw_tooltip(const std::string& text, const PanelStyle style, Vector
 	const uint16_t tip_height = rendered_text->height() + kPadding;
 
 	if (pos == Vector2i::invalid()) {
-		pos = WLApplication::get()->get_mouse_position();
+		pos = WLApplication::get().get_mouse_position();
 	}
 	tooltip_fixed_rect_ = Recti(pos + Vector2i(2, kCursorHeight), tip_width, tip_height);
 	const Vector2i tooltip_bottom_right = tooltip_fixed_rect_.opposite_of_origin();

--- a/src/ui_basic/progresswindow.cc
+++ b/src/ui_basic/progresswindow.cc
@@ -189,7 +189,7 @@ bool ProgressWindow::try_set_background(const std::string& template_directory) {
 /// Callback function: Buffer keypress events to be replayed after the loading is over.
 bool ProgressWindow::ui_key(bool const down, SDL_Keysym const code) {
 	// WLApplication can handle some keys immediately; don't buffer them.
-	if (WLApplication::get()->handle_key(down, code.sym, code.mod)) {
+	if (WLApplication::get().handle_key(down, code.sym, code.mod)) {
 		return true;
 	}
 	SDL_Event event;
@@ -203,7 +203,7 @@ void ProgressWindow::step(const std::string& description) {
 	// Handle events to respond to window resizing, to buffer keypresses,
 	// and to prevent "not responding" on windows & "beach ball" on macOS.
 	InputCallback input_callback = {nullptr, nullptr, nullptr, ui_key, nullptr, nullptr};
-	WLApplication::get()->handle_input(&input_callback);
+	WLApplication::get().handle_input(&input_callback);
 
 	progress_message_ =
 	   UI::g_fh->render(as_richtext_paragraph(description, progress_style().font()));

--- a/src/ui_fsmenu/keyboard_options.cc
+++ b/src/ui_fsmenu/keyboard_options.cc
@@ -247,8 +247,8 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 		box.add_space(kPadding);
 		b->sigclicked.connect([this, b, key, generate_title]() {
 			const bool fastplace = is_fastplace(key);
-			WLApplication* const app = WLApplication::get();
-			app->enable_handle_key(false);
+			WLApplication& app = WLApplication::get();
+			app.enable_handle_key(false);
 			ShortcutChooser c(*this, key, fastplace ? game_.get() : nullptr);
 			while (c.run<UI::Panel::Returncodes>() == UI::Panel::Returncodes::kOk) {
 				KeyboardShortcut conflict;
@@ -270,7 +270,7 @@ KeyboardOptions::KeyboardOptions(Panel& parent)
 				   UI::WLMessageBox::MBoxType::kOk);
 				warning.run<UI::Panel::Returncodes>();
 			}
-			app->enable_handle_key(true);
+			app.enable_handle_key(true);
 		});
 	};
 

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -902,7 +902,7 @@ void OptionsCtrl::save_options() {
 	// Language options
 	opt_section_.set_string("language", opt.language);
 
-	WLApplication::get()->set_input_grab(opt.inputgrab);
+	WLApplication::get().set_input_grab(opt.inputgrab);
 	g_mouse_cursor->set_use_sdl(opt_dialog_->get_values().sdl_cursor);
 	i18n::set_locale(opt.language);
 	UI::g_fh->reinitialize_fontset(i18n::get_locale());

--- a/src/ui_fsmenu/tech_info.cc
+++ b/src/ui_fsmenu/tech_info.cc
@@ -109,7 +109,7 @@ TechInfoBox::TechInfoBox(UI::Panel* parent, TechInfoBox::Type t)
 		ADD_CONTENT("Locale:", _("Locale:"), i18n::get_locale(), "");
 		ADD_CONTENT("Home Directory:", _("Home Directory:"), i18n::get_homedir(), "");
 		ADD_CONTENT("Configuration File:", _("Configuration File:"), get_config_file(), "");
-		ADD_CONTENT("Data Directory:", _("Data Directory:"), WLApplication::get()->get_datadir(), "");
+		ADD_CONTENT("Data Directory:", _("Data Directory:"), WLApplication::get().get_datadir(), "");
 		ADD_CONTENT("Locale Directory:", _("Locale Directory:"), i18n::get_localedir(), "");
 		ADD_CONTENT(
 		   "Executable Directory:", _("Executable Directory:"), get_executable_directory(false), "");

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -309,8 +309,6 @@ void WLApplication::setup_homedir() {
 	i18n::set_homedir(homedir_);
 }
 
-WLApplication* WLApplication::the_singleton = nullptr;
-
 /**
  * The main entry point for the WLApplication singleton.
  *
@@ -325,14 +323,6 @@ WLApplication* WLApplication::the_singleton = nullptr;
  * \param argv Array of command line arguments
  * \return An (always valid!) pointer to the WLApplication singleton
  */
-// TODO(unknown): Return a reference - the return value is always valid anyway
-WLApplication* WLApplication::get(int const argc, char const** argv) {
-	if (the_singleton == nullptr) {
-		the_singleton = new WLApplication(argc, argv);
-	}
-	return the_singleton;
-}
-
 /**
  * Initialize an instance of WLApplication.
  *
@@ -468,6 +458,11 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 	// Save configuration now. Otherwise, the UUID and sound options
 	// are not saved, when the game crashes
 	write_config();
+}
+
+WLApplication& WLApplication::get(int const argc, char const** argv) {
+	static WLApplication the_singleton{argc, argv};
+	return the_singleton;
 }
 
 /**

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -321,8 +321,13 @@ void WLApplication::setup_homedir() {
  *
  * \param argc The number of command line arguments
  * \param argv Array of command line arguments
- * \return An (always valid!) pointer to the WLApplication singleton
+ * \return A reference to the WLApplication singleton
  */
+WLApplication& WLApplication::get(int const argc, char const** argv) {
+	static WLApplication the_singleton{argc, argv};
+	return the_singleton;
+}
+
 /**
  * Initialize an instance of WLApplication.
  *
@@ -458,11 +463,6 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 	// Save configuration now. Otherwise, the UUID and sound options
 	// are not saved, when the game crashes
 	write_config();
-}
-
-WLApplication& WLApplication::get(int const argc, char const** argv) {
-	static WLApplication the_singleton{argc, argv};
-	return the_singleton;
 }
 
 /**

--- a/src/wlapplication.h
+++ b/src/wlapplication.h
@@ -139,7 +139,7 @@ struct InputCallback {
 // TODO(sirver): this class makes no sense for c++ - most of these should be
 // stand alone functions.
 struct WLApplication {
-	static WLApplication* get(int argc = 0, char const** argv = nullptr);
+	static WLApplication& get(int argc = 0, char const** argv = nullptr);
 	~WLApplication();
 
 	void run();
@@ -281,11 +281,6 @@ private:
 
 	/// Prevent toggling fullscreen on and off from flickering
 	uint32_t last_resolution_change_{0U};
-
-	/// Holds this process' one and only instance of WLApplication, if it was
-	/// created already. nullptr otherwise.
-	/// \note This is private on purpose. Read the class documentation.
-	static WLApplication* the_singleton;
 
 	void handle_mousebutton(SDL_Event&, InputCallback const*);
 };

--- a/src/wui/mapview.cc
+++ b/src/wui/mapview.cc
@@ -500,7 +500,7 @@ void MapView::pan_by(Vector2i delta_pixels, const Transition& transition) {
 
 void MapView::stop_dragging() {
 	if (dragging_) {
-		WLApplication::get()->set_mouse_lock(false);
+		WLApplication::get().set_mouse_lock(false);
 		grab_mouse(false);
 		dragging_ = false;
 	}
@@ -518,7 +518,7 @@ bool MapView::handle_mousepress(uint8_t const btn, int32_t const x, int32_t cons
 		jump();
 		dragging_ = true;
 		grab_mouse(true);
-		WLApplication::get()->set_mouse_lock(true);
+		WLApplication::get().set_mouse_lock(true);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
Refactoring

**Issue(s) closed**

Address a [TODO in the sources](https://github.com/widelands/widelands/blob/7147e595ac4faa1dffe6b01caf4bef8cdade7040/src/wlapplication.cc#L328): the method `WLApplication::get` now returns a reference instead of a raw pointer. It uses Meyer's singleton

**Additional context**
I've being playing the game for some quite time now and I wanted to contribute to the codebase. I've checked the issues with the label `cleanup & refactoring` and `good first issue`, but still I'd like to get a bit more familiar with the sources, the CI, the contributing process... step by step.