### PR TITLE
Support `SIGUSR1` to toggle verbose output

### DIFF
--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -136,6 +136,10 @@ void terminate(int /*unused*/) {
 }
 #endif
 
+void toggle_verbose(int /*unused*/) {
+	g_verbose = !g_verbose;
+}
+
 bool is_absolute_path(const std::string& path) {
 	std::regex re("^/|\\w:");
 	return std::regex_search(path.c_str(), re);
@@ -366,6 +370,10 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 	datadir_for_testing_ = g_fs->canonicalize_name(datadir_for_testing_);
 
 	set_initializer_thread();
+
+#ifdef SIGUSR1
+	signal(SIGUSR1, toggle_verbose);
+#endif
 
 	log_info("Adding directory: %s\n", datadir_.c_str());
 	g_fs->add_file_system(&FileSystem::create(datadir_));


### PR DESCRIPTION
**Type of change**
New feature

**Issue(s) closed**
Currently, verbose output has to be enabled when starting Widelands from the command line. However this generates masses of output, and there are often cases in debugging where you only really want verbose output for a brief section of simulation, or where you realize after already debugging a bigger savegame for a while that verbose output would be handy but you forgot to turn it on and don't want to start over. 

This patch allows you to send a `SIGUSR1` on POSIX to the Widelands process to toggle verbose output on/off during runtime.

I decided to use a signal instead of a keyboard shortcut or UI element because this is only ever useful for terminal-based debugging, and never for regular gameplay.

**How it works**
```bash
kill -SIGUSR1 `pidof widelands`
```

**Possible regressions**
N/A