### PR TITLE
Fix Shipyard/PortDock/FleetInterface Load Order Regression

### DIFF
--- a/src/economy/ship_fleet.cc
+++ b/src/economy/ship_fleet.cc
@@ -177,8 +177,7 @@ bool ShipFleet::find_other_fleet(EditorGameBase& egbase) {
 				if (dock->get_fleet() == nullptr) {
 					log_warn_time(egbase.get_gametime(), "The dock on %3dx%3d without a fleet!\n",
 					              dock->dockpoints_.front().x, dock->dockpoints_.front().y);
-				}
-				if (dock->get_fleet() != this && dock->get_owner() == get_owner()) {
+				} else if (dock->get_fleet() != this && dock->get_owner() == get_owner()) {
 					return dock->get_fleet()->merge(egbase, this);
 				}
 			}

--- a/src/logic/map_objects/map_object.h
+++ b/src/logic/map_objects/map_object.h
@@ -195,6 +195,8 @@ public:
 
 	virtual void load_finish(EditorGameBase&) {
 	}
+	virtual void postload(EditorGameBase&) {
+	}
 
 	virtual const Image* representative_image() const;
 

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -309,6 +309,15 @@ void ProductionSite::load_finish(EditorGameBase& egbase) {
 	format_statistics_string();
 }
 
+void ProductionSite::postload(EditorGameBase& egbase) {
+	Building::postload(egbase);
+
+	// TODO(Nordfriese): This is only needed for v1.1 savegame compatibility
+	if ((descr().has_ship_fleet_check() && ship_fleet_interfaces_.empty()) || (descr().has_ferry_fleet_check() && ferry_fleet_interfaces_.empty())) {
+		init_yard_interfaces(egbase);
+	}
+}
+
 /**
  * Display whether we're occupied.
  */

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -313,7 +313,8 @@ void ProductionSite::postload(EditorGameBase& egbase) {
 	Building::postload(egbase);
 
 	// TODO(Nordfriese): This is only needed for v1.1 savegame compatibility
-	if ((descr().has_ship_fleet_check() && ship_fleet_interfaces_.empty()) || (descr().has_ferry_fleet_check() && ferry_fleet_interfaces_.empty())) {
+	if ((descr().has_ship_fleet_check() && ship_fleet_interfaces_.empty()) ||
+	    (descr().has_ferry_fleet_check() && ferry_fleet_interfaces_.empty())) {
 		init_yard_interfaces(egbase);
 	}
 }

--- a/src/logic/map_objects/tribes/productionsite.h
+++ b/src/logic/map_objects/tribes/productionsite.h
@@ -451,6 +451,7 @@ protected:
 	void update_statistics_string(std::string* statistics) override;
 
 	void load_finish(EditorGameBase& egbase) override;
+	void postload(EditorGameBase& egbase) override;
 
 	struct State {
 		const ProductionProgram* program{nullptr};  ///< currently running program

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -835,8 +835,6 @@ void MapBuildingdataPacket::read_productionsite(ProductionSite& productionsite,
 					productionsite.ferry_fleet_interfaces_.push_back(
 					   &mol.get<FerryFleetYardInterface>(fr.unsigned_32()));
 				}
-			} else {
-				productionsite.init_yard_interfaces(game);
 			}
 
 			productionsite.infinite_production_ = packet_version >= 10 && fr.unsigned_8() > 0;

--- a/src/map_io/widelands_map_loader.cc
+++ b/src/map_io/widelands_map_loader.cc
@@ -374,7 +374,8 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 			const Field& fields_end = map()[map().max_index()];
 			for (Field* field = &map()[0]; field < &fields_end; ++field) {
 				if (BaseImmovable* const imm = field->get_immovable(); imm != nullptr) {
-					if (imm->descr().type() >= MapObjectType::BUILDING && field != &map()[dynamic_cast<Building*>(imm)->get_position()]) {
+					if (imm->descr().type() >= MapObjectType::BUILDING &&
+					    field != &map()[dynamic_cast<Building*>(imm)->get_position()]) {
 						continue;  //  not the building's main position
 					}
 					imm->load_finish(egbase);
@@ -451,7 +452,8 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 			const Field& fields_end = map()[map().max_index()];
 			for (Field* field = &map()[0]; field < &fields_end; ++field) {
 				if (BaseImmovable* const imm = field->get_immovable(); imm != nullptr) {
-					if (imm->descr().type() >= MapObjectType::BUILDING && field != &map()[dynamic_cast<Building*>(imm)->get_position()]) {
+					if (imm->descr().type() >= MapObjectType::BUILDING &&
+					    field != &map()[dynamic_cast<Building*>(imm)->get_position()]) {
 						continue;  //  not the building's main position
 					}
 					imm->postload(egbase);

--- a/src/map_io/widelands_map_loader.cc
+++ b/src/map_io/widelands_map_loader.cc
@@ -206,7 +206,7 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 	// PRELOAD DATA BEGIN
 	auto set_progress_message = [is_editor](const std::string& text, unsigned step) {
 		Notifications::publish(UI::NoteLoadingMessage(
-		   format(_("Loading map: %1$s (%2$u/%3$d)"), text, step, (is_editor ? 9 : 23))));
+		   format(_("Loading map: %1$s (%2$u/%3$d)"), text, step, (is_editor ? 9 : 24))));
 	};
 
 	set_progress_message(_("Elemental data"), 1);
@@ -373,11 +373,9 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 		{
 			const Field& fields_end = map()[map().max_index()];
 			for (Field* field = &map()[0]; field < &fields_end; ++field) {
-				if (BaseImmovable* const imm = field->get_immovable()) {
-					if (upcast(Building const, building, imm)) {
-						if (field != &map()[building->get_position()]) {
-							continue;  //  not the building's main position
-						}
+				if (BaseImmovable* const imm = field->get_immovable(); imm != nullptr) {
+					if (imm->descr().type() >= MapObjectType::BUILDING && field != &map()[dynamic_cast<Building*>(imm)->get_position()]) {
+						continue;  //  not the building's main position
 					}
 					imm->load_finish(egbase);
 				}
@@ -445,6 +443,22 @@ int32_t WidelandsMapLoader::load_map_complete(EditorGameBase& egbase,
 	map_.recalc_whole_map(egbase);
 
 	map_.ensure_resource_consistency(egbase.descriptions());
+
+	if (!is_editor) {
+		verb_log_info("Fourth phase loading Map Objects ... ");
+		set_progress_message(_("Postloading map objects"), 24);
+		{
+			const Field& fields_end = map()[map().max_index()];
+			for (Field* field = &map()[0]; field < &fields_end; ++field) {
+				if (BaseImmovable* const imm = field->get_immovable(); imm != nullptr) {
+					if (imm->descr().type() >= MapObjectType::BUILDING && field != &map()[dynamic_cast<Building*>(imm)->get_position()]) {
+						continue;  //  not the building's main position
+					}
+					imm->postload(egbase);
+				}
+			}
+		}
+	}
 
 	set_state(State::kLoaded);
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes https://github.com/widelands/widelands/pull/5912#issuecomment-1569027437

**To reproduce**
1. In v1.1 or a pre-`#5912` dev version, build _first_ a port and _then_ a shipyard, then save.
2. Load the savegame in master.
3. In master it crashes during loading. In this branch it loads fine and all interfaces are initialized correctly.

**Possible regressions**
None I think…

**Additional context**
We have to initialize the interfaces really, really late to make sure that all other map objects as well as the map itself are in a fully finalized and usable state. So I added an extra post-load step just for this, `load_finish` is called far too early.