### PR TITLE
Skip timestamp-only POT changes during translations update

### DIFF
--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -96,30 +96,16 @@ fi
 python3 utils/fix_formatting.py --lua --dir data/i18n
 python3 utils/fix_formatting.py --lua --dir data/txts
 
-# Undo one-liner diffs in po directory - these are pure timestamps with no other content
-if false; then  # Currently disabled due to TX no longer updating timestamps reliably
+# Undo one-liner diffs of pure timestamps with no other content
 set +x
-nrAdded=""
-nrDeleted=""
-for entry in $(git diff --numstat po); do
-  if [ -z "$nrAdded" ]
+for entry in $(git diff --numstat po | sed -En '/^1\t1\t.*\.pot$/s/^1\t1\t(.*)/\1/p'); do
+  if [ -z "$(git diff "$entry" | grep '^[+-][^+-]' | grep -v '^[+-]"POT-Creation-Date:')" ]
   then
-    nrAdded=$entry
-  elif [ -z "$nrDeleted" ]
-  then
-    nrDeleted=$entry
-  else
-    if [[ $nrAdded == 1 ]] && [[ $nrDeleted == 1 ]]
-    then
-      echo "Skipping changes to $entry"
-      git checkout $entry
-    fi
-    nrAdded=""
-    nrDeleted=""
+    echo "Skipping changes to $entry"
+    git checkout $entry
   fi
 done
 set -x
-fi
 
 # Stage changes
 # - Translations

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -98,7 +98,7 @@ python3 utils/fix_formatting.py --lua --dir data/txts
 
 # Undo one-liner diffs of pure timestamps with no other content
 set +x
-for entry in $(git diff --numstat po/*/*.pot | sed -En '/^1\t1\t/s/^1\t1\t(.*)/\1/p'); do
+for entry in $(git diff --numstat po/*/*.pot | sed -En '/^1\t1\t/s/^1\t1\t//p'); do
   if [ -z "$(git diff "$entry" | grep '^[+-][^+-]' | grep -v '^[+-]"POT-Creation-Date:')" ]
   then
     echo "Skipping changes to $entry"

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -98,7 +98,7 @@ python3 utils/fix_formatting.py --lua --dir data/txts
 
 # Undo one-liner diffs of pure timestamps with no other content
 set +x
-for entry in $(git diff --numstat po/*/*.pot | sed -En '/^1\t1\t/s/^1\t1\t//p'); do
+for entry in $(git diff --numstat po/*/*.pot | sed -En 's/^1\t1\t//p'); do
   if [ -z "$(git diff "$entry" | grep '^[+-][^+-]' | grep -v '^[+-]"POT-Creation-Date:')" ]
   then
     echo "Skipping changes to $entry"

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -98,7 +98,7 @@ python3 utils/fix_formatting.py --lua --dir data/txts
 
 # Undo one-liner diffs of pure timestamps with no other content
 set +x
-for entry in $(git diff --numstat po | sed -En '/^1\t1\t.*\.pot$/s/^1\t1\t(.*)/\1/p'); do
+for entry in $(git diff --numstat po/*/*.pot | sed -En '/^1\t1\t/s/^1\t1\t(.*)/\1/p'); do
   if [ -z "$(git diff "$entry" | grep '^[+-][^+-]' | grep -v '^[+-]"POT-Creation-Date:')" ]
   then
     echo "Skipping changes to $entry"


### PR DESCRIPTION
**Type of change**
Bugfix / Refactoring

**Issue(s) closed**
Fixes #5936

**Possible regressions**
Translation updates

**Additional context**
I made it only check the templates. PO files shouldn't have timestamp-only updates of their own, but if something slips through, they should be in sync with the template anyway.