### PR TITLE
Layout ship window before setting fastclick target

### DIFF
--- a/src/wui/shipwindow.cc
+++ b/src/wui/shipwindow.cc
@@ -163,9 +163,6 @@ ShipWindow::ShipWindow(InteractiveBase& ib, UniqueWindow::Registry& reg, Widelan
 
 	set_center_panel(&vbox_);
 	set_thinks(true);
-	set_fastclick_panel(btn_goto_);
-	move_out_of_the_way();
-	warp_mouse_to_fastclick_panel();
 
 	shipnotes_subscriber_ =
 	   Notifications::subscribe<Widelands::NoteShip>([this](const Widelands::NoteShip& note) {
@@ -195,6 +192,11 @@ ShipWindow::ShipWindow(InteractiveBase& ib, UniqueWindow::Registry& reg, Widelan
 	navigation_box_.set_visible(false);
 	btn_cancel_expedition_->set_enabled(false);
 	update_destination_button(ship);
+	set_button_visibility();
+
+	move_out_of_the_way();
+	set_fastclick_panel(btn_goto_);
+	warp_mouse_to_fastclick_panel();
 
 	initialization_complete();
 }


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5940

**Possible regressions**
Ship window init behaviour. I'm not sure it's safe to call layout`()` before `initialization_complete()`.

**Additional context**
I tested and this works in the naval warfare branch too.