### PR TITLE
Remove superfluous SDL_GetModState() calls

### DIFF
--- a/src/ui_basic/button.cc
+++ b/src/ui_basic/button.cc
@@ -321,7 +321,7 @@ void Button::think() {
 }
 
 bool Button::handle_key(bool down, SDL_Keysym code) {
-	if (down && code.sym == SDLK_RETURN && (SDL_GetModState() & KMOD_CTRL) == 0) {
+	if (down && code.sym == SDLK_RETURN && (code.mod & KMOD_CTRL) == 0) {
 		play_click();
 		sigclicked();
 		return true;

--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -221,7 +221,7 @@ bool Statebox::handle_mousemove(
 }
 
 bool Statebox::handle_key(bool down, SDL_Keysym code) {
-	if (down && code.sym == SDLK_RETURN && (SDL_GetModState() & KMOD_CTRL) == 0) {
+	if (down && code.sym == SDLK_RETURN && (code.mod & KMOD_CTRL) == 0) {
 		button_clicked();
 		return true;
 	}

--- a/src/ui_basic/dropdown.cc
+++ b/src/ui_basic/dropdown.cc
@@ -501,7 +501,7 @@ bool BaseDropdown::is_mouse_away() const {
 }
 
 bool BaseDropdown::handle_key(bool down, SDL_Keysym code) {
-	if (down && (SDL_GetModState() & KMOD_CTRL) == 0) {
+	if (down && (code.mod & KMOD_CTRL) == 0) {
 		switch (code.sym) {
 		case SDLK_RETURN:
 			if (list_->is_visible()) {

--- a/src/ui_basic/listselect.cc
+++ b/src/ui_basic/listselect.cc
@@ -583,7 +583,7 @@ bool BaseListselect::handle_key(bool const down, SDL_Keysym const code) {
 			return UI::Panel::handle_key(down, code);
 		case SDLK_ESCAPE:
 		case SDLK_RETURN:
-			if (linked_dropdown != nullptr && (SDL_GetModState() & KMOD_CTRL) == 0) {
+			if (linked_dropdown != nullptr && (code.mod & KMOD_CTRL) == 0) {
 				return linked_dropdown->handle_key(down, code);
 			}
 			return UI::Panel::handle_key(down, code);

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -890,7 +890,7 @@ bool Panel::handle_key(bool down, SDL_Keysym code) {
 		}
 		switch (code.sym) {
 		case SDLK_TAB:
-			return handle_tab_pressed((SDL_GetModState() & KMOD_SHIFT) != 0);
+			return handle_tab_pressed((code.mod & KMOD_SHIFT) != 0);
 		case SDLK_ESCAPE:
 			if ((parent_ != nullptr) && parent_->focus_ == this && get_can_focus()) {
 				parent_->focus_ = nullptr;

--- a/src/ui_basic/textinput.cc
+++ b/src/ui_basic/textinput.cc
@@ -596,14 +596,14 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 						}
 						newpos = prev;
 					}
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(newpos);
 					} else {
 						d_->reset_selection();
 					}
 					d_->set_cursor_pos(newpos);
 				} else {
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(d_->prev_char(d_->cursor_pos));
 					} else {
 						d_->reset_selection();
@@ -625,14 +625,14 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 					while (newpos < d_->text.size() && (isspace(d_->text[newpos]) == 0)) {
 						newpos = d_->next_char(newpos);
 					}
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(newpos);
 					} else {
 						d_->reset_selection();
 					}
 					d_->set_cursor_pos(newpos);
 				} else {
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(d_->next_char(d_->cursor_pos));
 					} else {
 						d_->reset_selection();
@@ -663,14 +663,14 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 					} else {
 						newpos = d_->snap_to_char(newpos);
 					}
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(newpos);
 					} else {
 						d_->reset_selection();
 					}
 					d_->set_cursor_pos(newpos);
 				} else {
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(d_->text.size());
 					} else {
 						d_->reset_selection();
@@ -698,14 +698,14 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 					} else {
 						newpos = d_->snap_to_char(newpos);
 					}
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(newpos);
 					} else {
 						d_->reset_selection();
 					}
 					d_->set_cursor_pos(newpos);
 				} else {
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(0);
 					} else {
 						d_->reset_selection();
@@ -717,7 +717,7 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 
 		case SDLK_HOME:
 			if ((code.mod & KMOD_CTRL) != 0) {
-				if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+				if ((code.mod & KMOD_SHIFT) != 0) {
 					select_until(0);
 				} else {
 					d_->reset_selection();
@@ -729,7 +729,7 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 				uint32_t cursorpos = 0;
 				d_->ww.calc_wrapped_pos(d_->cursor_pos, cursorline, cursorpos);
 
-				if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+				if ((code.mod & KMOD_SHIFT) != 0) {
 					select_until(d_->ww.line_offset(cursorline));
 				} else {
 					d_->reset_selection();
@@ -740,7 +740,7 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 
 		case SDLK_END:
 			if ((code.mod & KMOD_CTRL) != 0) {
-				if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+				if ((code.mod & KMOD_SHIFT) != 0) {
 					select_until(d_->text.size());
 				} else {
 					d_->reset_selection();
@@ -754,14 +754,14 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 				d_->ww.calc_wrapped_pos(d_->cursor_pos, cursorline, cursorpos);
 
 				if (cursorline + 1 < d_->ww.nrlines()) {
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(d_->prev_char(d_->ww.line_offset(cursorline + 1)));
 					} else {
 						d_->reset_selection();
 					}
 					d_->set_cursor_pos(d_->prev_char(d_->ww.line_offset(cursorline + 1)));
 				} else {
-					if ((SDL_GetModState() & KMOD_SHIFT) != 0) {
+					if ((code.mod & KMOD_SHIFT) != 0) {
 						select_until(d_->text.size());
 					} else {
 						d_->reset_selection();
@@ -776,7 +776,7 @@ bool AbstractTextInputPanel::handle_key(bool const down, SDL_Keysym const code) 
 			return true;
 
 		case SDLK_RETURN:
-			if ((SDL_GetModState() & KMOD_CTRL) != 0) {
+			if ((code.mod & KMOD_CTRL) != 0) {
 				return false;
 			}
 			d_->insert(d_->cursor_pos, "\n");
@@ -797,7 +797,7 @@ bool EditBox::handle_key(bool const down, SDL_Keysym const code) {
 	if (down) {
 		switch (code.sym) {
 		case SDLK_RETURN:
-			if ((SDL_GetModState() & KMOD_CTRL) != 0) {
+			if ((code.mod & KMOD_CTRL) != 0) {
 				return false;
 			}
 

--- a/src/wui/game_chat_panel.cc
+++ b/src/wui/game_chat_panel.cc
@@ -134,7 +134,7 @@ bool GameChatPanel::handle_key(const bool down, const SDL_Keysym code) {
 		return false;
 	}
 
-	if (!down || code.sym != SDLK_SPACE || ((SDL_GetModState() & KMOD_CTRL) == 0)) {
+	if (!down || code.sym != SDLK_SPACE || ((code.mod & KMOD_CTRL) == 0)) {
 		return false;
 	}
 


### PR DESCRIPTION
**Type of change**
Refactoring

**Issue(s) closed**
Some UI elements used `SDL_GetModState()` to retrieve the active modifier keys in their `handle_key()` implementation which already receives the modifier state as part of the `SDL_Keysym code` argument. Not only is this superfluous, but it's also wrong theoretically, because the modstate may (theoretically) change between the time of generating the keyboard event and the actual processing by these functions.

**Possible regressions**
Shouldn't be any…

**Additional context**
The majority of the remaining uses are `sigclicked()` handlers or similar delegated functions, which also have the theoretical problem but need significant refactoring to eliminate it. There are also a handful of uses in `handle_mousepress()` and `handle_mousemove()` functions, which could get a `modstate` argument (like `handle_mousewheel()`), but that's also a bigger refactoring to change all instances and are actually likely to result in more calls, not fewer.