### PR TITLE
Fix Kicking Out Superfluous Warship Soldiers

### DIFF
--- a/src/economy/soldier_request.cc
+++ b/src/economy/soldier_request.cc
@@ -59,6 +59,9 @@ void SoldierRequest::update() {
 
 		request_->set_requirements(Requirements());
 		request_->set_count(target - current);
+		if (Economy* economy = request_->get_economy(); economy != nullptr) {
+			economy->rebalance_supply();
+		}
 		return;
 	}
 
@@ -111,6 +114,9 @@ void SoldierRequest::update() {
 
 	request_->set_count(1);
 	request_->set_requirements(RequireAttribute(TrainingAttribute::kTotal, rmin, rmax));
+	if (Economy* economy = request_->get_economy(); economy != nullptr) {
+		economy->rebalance_supply();
+	}
 }
 
 constexpr uint16_t kCurrentPacketVersion = 1;

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1046,8 +1046,8 @@ void Ship::kickout_superfluous_soldiers(Game& game) {
 			}
 			unsigned soldier_level = soldier->get_total_level();
 			if (worst_fit == nullptr || (get_soldier_preference() == SoldierPreference::kRookies ?
-                                        soldier_level >= worst_fit_level :
-                                        soldier_level <= worst_fit_level)) {
+                                         soldier_level >= worst_fit_level :
+                                         soldier_level <= worst_fit_level)) {
 				worst_fit = &si;
 				worst_fit_level = soldier_level;
 			}
@@ -2075,7 +2075,8 @@ void Ship::exp_cancel(Game& game) {
 	// Running colonization has the highest priority before cancelation
 	// + cancelation only works if an expedition is actually running
 
-	if ((ship_state_ == ShipStates::kExpeditionColonizing) || !state_is_expedition() || get_ship_type() == ShipType::kWarship) {
+	if ((ship_state_ == ShipStates::kExpeditionColonizing) || !state_is_expedition() ||
+	    get_ship_type() == ShipType::kWarship) {
 		return;
 	}
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -282,6 +282,15 @@ void Ship::wakeup_neighbours(Game& game) {
 	}
 }
 
+void Ship::set_capacity(Quantity c) {
+	capacity_ = c;
+	warship_soldier_capacity_ = std::min(warship_soldier_capacity_, capacity_);
+}
+void Ship::set_warship_soldier_capacity(Quantity c) {
+	assert(c <= capacity_);
+	warship_soldier_capacity_ = c;
+}
+
 /**
  * Standard behaviour of ships.
  *

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -869,6 +869,7 @@ void Ship::warship_soldier_callback(Game& game,
 
 	ship->add_item(game, ShippingItem(*worker));
 	ship->update_warship_soldier_request(false);
+	ship->kickout_superfluous_soldiers(game);
 }
 
 bool Ship::is_attackable_enemy_warship(const Bob& b) const {
@@ -1025,6 +1026,41 @@ void Ship::drop_soldier(Game& game, Serial soldier) {
 	verb_log_warn_time(game.get_gametime(), "Ship::drop_soldier: %u is not on board", soldier);
 }
 
+/** If we have too many soldiers on board, unload the extras. */
+void Ship::kickout_superfluous_soldiers(Game& game) {
+	PortDock* dest = get_destination_port(game);
+	if (dest == nullptr) {
+		return;  // Not in port
+	}
+
+	while (get_nritems() > warship_soldier_capacity_) {
+		// Always kick out a rookie, unless rookies are preferred.
+		ShippingItem* worst_fit = nullptr;
+		unsigned worst_fit_level = 0;
+		for (ShippingItem& si : items_) {
+			Worker* worker;
+			si.get(game, nullptr, &worker);
+			Soldier* soldier = dynamic_cast<Soldier*>(worker);
+			if (soldier == nullptr) {
+				continue;
+			}
+			unsigned soldier_level = soldier->get_total_level();
+			if (worst_fit == nullptr || (get_soldier_preference() == SoldierPreference::kRookies ?
+                                        soldier_level >= worst_fit_level :
+                                        soldier_level <= worst_fit_level)) {
+				worst_fit = &si;
+				worst_fit_level = soldier_level;
+			}
+		}
+
+		assert(worst_fit != nullptr);
+		molog(game.get_gametime(), "Kicking out soldier with total level %u", worst_fit_level);
+		dest->shipping_item_arrived(game, *worst_fit);
+		*worst_fit = items_.back();
+		items_.pop_back();
+	}
+}
+
 void Ship::warship_command(Game& game,
                            const WarshipCommand cmd,
                            const std::vector<uint32_t>& parameters) {
@@ -1038,36 +1074,7 @@ void Ship::warship_command(Game& game,
 		warship_soldier_capacity_ =
 		   std::max(std::min(parameters.back(), get_capacity()), min_warship_soldier_capacity());
 		update_warship_soldier_request(false);
-
-		// If we have too many soldiers on board now, unload the extras.
-		PortDock* dest = get_destination_port(game);
-		while (get_nritems() > warship_soldier_capacity_) {
-			// Always kick out a rookie, unless rookies are preferred.
-			ShippingItem* worst_fit = nullptr;
-			unsigned worst_fit_level = 0;
-			for (ShippingItem& si : items_) {
-				Worker* worker;
-				si.get(game, nullptr, &worker);
-				Soldier* soldier = dynamic_cast<Soldier*>(worker);
-				if (soldier == nullptr) {
-					continue;
-				}
-				unsigned soldier_level = soldier->get_total_level();
-				if (worst_fit == nullptr || (get_soldier_preference() == SoldierPreference::kRookies ?
-                                            soldier_level >= worst_fit_level :
-                                            soldier_level <= worst_fit_level)) {
-					worst_fit = &si;
-					worst_fit_level = soldier_level;
-				}
-			}
-
-			assert(worst_fit != nullptr);
-			assert(dest != nullptr);
-			dest->shipping_item_arrived(game, *worst_fit);
-			*worst_fit = items_.back();
-			items_.pop_back();
-		}
-
+		kickout_superfluous_soldiers(game);
 		return;
 	}
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2075,7 +2075,7 @@ void Ship::exp_cancel(Game& game) {
 	// Running colonization has the highest priority before cancelation
 	// + cancelation only works if an expedition is actually running
 
-	if ((ship_state_ == ShipStates::kExpeditionColonizing) || !state_is_expedition()) {
+	if ((ship_state_ == ShipStates::kExpeditionColonizing) || !state_is_expedition() || get_ship_type() == ShipType::kWarship) {
 		return;
 	}
 

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -255,9 +255,7 @@ struct Ship : Bob {
 	[[nodiscard]] Quantity get_capacity() const {
 		return capacity_;
 	}
-	void set_capacity(Quantity c) {
-		capacity_ = c;
-	}
+	void set_capacity(Quantity c);
 
 	[[nodiscard]] bool has_attack_target(Ship* s) const {
 		return expedition_ != nullptr && expedition_->attack_targets.count(s) > 0;
@@ -313,10 +311,7 @@ struct Ship : Bob {
 
 	// Editor only
 	void set_ship_type(EditorGameBase& egbase, ShipType t);
-	void set_warship_soldier_capacity(uint32_t c) {
-		assert(c <= capacity_);
-		warship_soldier_capacity_ = c;
-	}
+	void set_warship_soldier_capacity(Quantity c);
 
 	void draw_healthbar(const EditorGameBase& egbase,
 	                    RenderTarget* dst,

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -347,6 +347,7 @@ private:
 	void ship_update_idle(Game&, State&);
 	void battle_update(Game&);
 	void update_warship_soldier_request(bool create);
+	void kickout_superfluous_soldiers(Game& game);
 	/// Set the ship's state to 'state' and if the ship state has changed, publish a notification.
 	void set_ship_state_and_notify(ShipStates state, NoteShip::Action action);
 	bool check_port_space_still_available(Game&);


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Should fix #5948

**New behavior**
This fixes the capacity bug by kicking out superfluous soldiers whenever a new soldier arrives, and not just when changing the capacity. This is needed to expel the replaced soldier during hero-rookie-exchanges.

The last crash is actually a completely separate issue, but I fixed it here as well with a one-liner – the AI tries to cancel warship "expeditions" like regular expeditions since it only wants to handle 1 expedition at a time or some such, but that's not allowed for warships. Only AIs can even try to do that since the UI doesn't show that button for warships. That's something of a hotfix until the AI is taught how to use warships properly (right now it treats them exactly like expeditions).

I cannot reproduce the other crashes with this branch, but this needs more testing to check this really catches all flavours of the issue.

The 29 capacity is not a bug – New World gives you ships with non-standard capacities designed to exactly fit all items, and for empire this actually means a capacity of 1 less than default.