### PR TITLE
Continuous Bob Animations

### DIFF
--- a/src/logic/map_objects/bob.cc
+++ b/src/logic/map_objects/bob.cc
@@ -824,8 +824,10 @@ void Bob::draw(const EditorGameBase& egbase,
  * Set a looping animation, starting now.
  */
 void Bob::set_animation(const EditorGameBase& egbase, uint32_t const anim) {
-	anim_ = anim;
-	animstart_ = egbase.get_gametime();
+	if (anim_ != anim) {
+		anim_ = anim;
+		animstart_ = egbase.get_gametime();
+	}
 }
 
 /**


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5951

**New behavior**
Don't start the animation from the beginning if the new anim is the same as the current anim

**Possible regressions**
Bob animations