### PR TITLE
Translation update: Exit cleanly when nothing needs to be committed

### DIFF
--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -119,6 +119,11 @@ git add xdg/org.widelands.Widelands.appdata.xml xdg/org.widelands.Widelands.desk
 # - Statistics
 git add data/i18n/translation_stats.conf || true
 
+if [ -z "$(git status -s)" ]; then
+  echo "Run completed, nothing to commit."
+  exit 0
+fi
+
 # Commit and push.
 git commit -m "Fetched translations and updated catalogs."
 git push "$push_target" master


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
The translation update script doesn't fail any more if no changes need committing.

**Possible regressions**
none?