### PR TITLE
Fix stacking order of new ship battles

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1102,10 +1102,10 @@ void Ship::warship_command(Game& game,
 			std::vector<Coords> dockpoints = game.map().find_portdock(portspace, true);
 			assert(!dockpoints.empty());
 
-			start_battle(
-			   game, Battle(nullptr, dockpoints.at(game.logic_rand() % dockpoints.size()),
-			                std::vector<uint32_t>(parameters.begin() + 2, parameters.end()), true),
-			   false);
+			start_battle(game,
+			             Battle(nullptr, dockpoints.at(game.logic_rand() % dockpoints.size()),
+			                    std::vector<uint32_t>(parameters.begin() + 2, parameters.end()), true),
+			             false);
 		}
 		return;
 	}

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -19,6 +19,7 @@
 #ifndef WL_LOGIC_MAP_OBJECTS_TRIBES_SHIP_H
 #define WL_LOGIC_MAP_OBJECTS_TRIBES_SHIP_H
 
+#include <deque>
 #include <memory>
 
 #include "base/macros.h"
@@ -161,7 +162,7 @@ struct Ship : Bob {
 		Phase phase{Phase::kNotYetStarted};
 		bool is_first;
 	};
-	void start_battle(Game&, Battle);
+	void start_battle(Game&, Battle, bool immediately);
 
 	uint32_t calculate_sea_route(EditorGameBase&, PortDock&, Path* = nullptr) const;
 
@@ -387,7 +388,7 @@ private:
 	};
 	std::unique_ptr<Expedition> expedition_;
 
-	std::vector<Battle> battles_;
+	std::deque<Battle> battles_;
 	uint32_t hitpoints_;
 	Time last_heal_time_{0U};
 	bool send_message_at_destination_{false};
@@ -423,7 +424,7 @@ protected:
 		ShipType pending_refit_{ShipType::kTransport};
 		std::string shipname_;
 		std::unique_ptr<Expedition> expedition_;
-		std::vector<Battle> battles_;
+		std::deque<Battle> battles_;
 		std::vector<ShippingItem::Loader> items_;
 		std::set<Serial> expedition_attack_target_serials_{0U};
 		std::vector<Serial> battle_serials_;


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Should fix #5960

**New behavior**
New attacking battles take lower priority than existing battles. Only new defensive battles take precedence over existing ones.