### PR TITLE
Fix wild pointer dereference during ship removal

### DIFF
--- a/src/economy/ship_fleet.cc
+++ b/src/economy/ship_fleet.cc
@@ -465,7 +465,7 @@ void ShipFleet::remove_ship(EditorGameBase& egbase, Ship* ship) {
 	if (ships_.empty()) {
 		if (empty()) {
 			remove(egbase);
-		} else {
+		} else if (ports_.size() > 1) {
 			Flag& base = ports_[0]->base_flag();
 			for (uint32_t i = 1; i < ports_.size(); ++i) {
 				// since two ports can be connected by land, it is possible that


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Should fix #5965

**New behavior**
Fleets can now be non-empty even if they have no ships and no ports left due to remaining shipyard interfaces. So that assumption needed updating.

**Possible regressions**
Ship fleet cleanup

**Additional context**
I could not actually reproduce the problem, it is dependent on the exact order in which the port, shipyard, and ship are completed. Please check.