### PR TITLE
Don't detect portspace under own port

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -622,8 +622,10 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 			if (map->is_port_space(mr.location()) &&
 			    std::find(portspaces.begin(), portspaces.end(), mr.location()) == portspaces.end()) {
 				const Field& field = (*map)[mr.location()];
-				if (field.get_immovable() != nullptr && field.get_immovable()->get_owner() == get_owner() &&
-						game.descriptions().building_index(field.get_immovable()->descr().name()) == owner().tribe().port()) {
+				if (field.get_immovable() != nullptr &&
+				    field.get_immovable()->get_owner() == get_owner() &&
+				    game.descriptions().building_index(field.get_immovable()->descr().name()) ==
+				       owner().tribe().port()) {
 					continue;  // Skip if the player already has a port there
 				}
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -621,6 +621,12 @@ bool Ship::ship_update_expedition(Game& game, Bob::State& /* state */) {
 		do {
 			if (map->is_port_space(mr.location()) &&
 			    std::find(portspaces.begin(), portspaces.end(), mr.location()) == portspaces.end()) {
+				const Field& field = (*map)[mr.location()];
+				if (field.get_immovable() != nullptr && field.get_immovable()->get_owner() == get_owner() &&
+						game.descriptions().building_index(field.get_immovable()->descr().name()) == owner().tribe().port()) {
+					continue;  // Skip if the player already has a port there
+				}
+
 				found_new_target = true;
 				portspaces.push_back(mr.location());
 				remember_detected_portspace(mr.location());


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5971

**New behavior**
If the player already has an own port at a port space, don't consider it a naval invasion target.

**Additional context**
We don't generally exclude the player's own territory as an invasion target, as there are valid usecases where you'd want to send an invasion to a coast you already own. But actual ports are excluded, such an "invasion" would be completed the moment it begins.