### PR TITLE
Make Game::random_location() safer

### DIFF
--- a/src/logic/game.h
+++ b/src/logic/game.h
@@ -516,6 +516,7 @@ inline Coords Game::random_location(Coords location, uint8_t radius) {
 	const uint16_t s = radius * 2 + 1;
 	location.x += logic_rand() % s - radius;
 	location.y += logic_rand() % s - radius;
+	map().normalize_coords(location);
 	return location;
 }
 }  // namespace Widelands


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Re: https://github.com/widelands/widelands/issues/5973#issuecomment-1615993364 and https://github.com/widelands/widelands/issues/5973#issuecomment-1616170779

**New behavior**
`Game::random_location()` now normalises the coordinates before returning them.

**Possible regressions**
n/a?

**Additional context**
I should probably have done it for master…