### PR TITLE
Push vcpkg ref only to main repo

### DIFF
--- a/.github/workflows/check_vcpkg.yaml
+++ b/.github/workflows/check_vcpkg.yaml
@@ -55,7 +55,7 @@ jobs:
       shell: bash
   update:
     needs: vcpkg-packages
-    if: ${{ needs.vcpkg-packages.outputs.result-x64 && needs.vcpkg-packages.outputs.result-x86 }}
+    if: ${{ github.repository == 'widelands/widelands' && needs.vcpkg-packages.outputs.result-x64 && needs.vcpkg-packages.outputs.result-x86 }}
     name: Commit new version
     runs-on: windows-2022
     env:


### PR DESCRIPTION
**Type of change**
Maintenance

**Issue(s) closed**
Fixes #5961 

**New behavior**
Only run the push step on the main repo similar to the i18n workflow.

(side note: currently failing builds are caused by partial update of Visual Studio in the latest runner image. We had this issue previously and I reported it on the runner-images repo)