### PR TITLE
define PRIuS using PRIuPTR if available

### DIFF
--- a/src/base/macros.h
+++ b/src/base/macros.h
@@ -128,6 +128,9 @@
 #define PRINTF_FORMAT(b, c)
 #endif
 
+#ifdef PRIuPTR
+#define PRIuS PRIuPTR
+#else
 #ifdef _WIN32
 #ifdef _WIN64
 #define PRIuS PRIu64
@@ -139,6 +142,7 @@
 #define PRIuS "lu"
 #else
 #define PRIuS "u"
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
On OpenBSD amd64 a warning is emitted during compilation about `__WORDSIZE` being undefined. `PRIuS` is then wrongly defined as `u`.

**Fix**
Define `PRIuS` as `PRIuPTR` if the latter is available.

**Possible regressions**
Since it falls back to the old behavior in case `PRIuPTR` is undefined I don't expect any regressions. It still won't help platforms having neither `__WORDSIZE` nor `PRIuPTR`.