### PR TITLE
Fix Segfault in `FieldActionWindow`

### DIFF
--- a/src/wui/fieldaction.cc
+++ b/src/wui/fieldaction.cc
@@ -503,6 +503,9 @@ void FieldActionWindow::add_buttons_auto() {
 		if (bob->descr().type() == Widelands::MapObjectType::SHIP_FLEET_YARD_INTERFACE &&
 		    !has_ship_fleet &&
 		    (ipl == nullptr || bob->owner().player_number() == ipl->player_number())) {
+			if (buildbox == nullptr) {
+				buildbox = new UI::Box(&tabpanel_, UI::PanelStyle::kWui, 0, 0, UI::Box::Horizontal);
+			}
 			has_ship_fleet = true;
 			add_button(
 			   buildbox, "configure_ship_fleet", "images/wui/fieldaction/menu_tab_ship_targets.png",
@@ -510,6 +513,9 @@ void FieldActionWindow::add_buttons_auto() {
 		} else if (bob->descr().type() == Widelands::MapObjectType::FERRY_FLEET_YARD_INTERFACE &&
 		           !has_ferry_fleet &&
 		           (ipl == nullptr || bob->owner().player_number() == ipl->player_number())) {
+			if (buildbox == nullptr) {
+				buildbox = new UI::Box(&tabpanel_, UI::PanelStyle::kWui, 0, 0, UI::Box::Horizontal);
+			}
 			has_ferry_fleet = true;
 			add_button(
 			   buildbox, "configure_ferry_fleet", "images/wui/fieldaction/menu_tab_ferry_targets.png",


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
When you click on an unowned field that has a shipyard interface but no buildcaps the buildbox has not been created yet, so it segfaults.

**To reproduce**
Triggered by clicking on a blocked field on unowned territory in range of an own shipyard, like this shipconstructionsite here:
![grafik](https://github.com/widelands/widelands/assets/48293446/e75dd1c1-310e-4d11-a885-19ce6043ccd1)

**Additional context**
Found in yesterday's naval battle royale
