### PR TITLE
Add "all" to player:get_buildings() and player:get_constructionsites()

### DIFF
--- a/src/scripting/lua_game.cc
+++ b/src/scripting/lua_game.cc
@@ -910,8 +910,8 @@ int LuaPlayer::get_ships(lua_State* L) {
 
       **which** can be either a single name or an :class:`array` of names. In the first
       case, the method returns an :class:`array` of all Buildings that the player has of
-      this kind. If **which** is an :class:`array`, the function returns a :class:`table` of
-      ``{name=array_of_buildings}`` pairs.
+      this kind. If **which** is an :class:`array` or "all", the function returns a
+      :class:`table` of ``{name=array_of_buildings}`` pairs.
 
       :arg which: The name of a building or an :class:`array` of building names.
       :type which: :class:`string` or :class:`array`
@@ -928,11 +928,11 @@ int LuaPlayer::get_buildings(lua_State* L) {
 
       **which** can be either a single name or an :class:`array` of names. In the first
       case, the method returns an :class:`array` of all constructionsites that the
-      player has of this kind. If which is an :class:`array`, the function returns a
+      player has of this kind. If which is an :class:`array` or "all", the function returns a
       :class:`table` of ``{name=array_of_constructionsites}`` pairs.
 
       :arg which: The internal name of a constructionsites building or an :class:`array` of
-         building names.
+         building names or "all".
       :type which: :class:`string` or :class:`array`
       :returns: Information about the player's constructionsites,
          see :class:`wl.map.ConstructionSite`.
@@ -1187,12 +1187,14 @@ int LuaPlayer::do_get_buildings(lua_State* L, const bool csites) {
 	bool return_array = true;
 	if (lua_isstring(L, -1) != 0) {
 		const char* name = luaL_checkstring(L, -1);
-		lua_pop(L, 1);
-		lua_newtable(L);
-		lua_pushuint32(L, 1);
-		lua_pushstring(L, name);
-		lua_rawset(L, -3);
-		return_array = false;
+		if (name != "all") {
+			lua_pop(L, 1);
+			lua_newtable(L);
+			lua_pushuint32(L, 1);
+			lua_pushstring(L, name);
+			lua_rawset(L, -3);
+			return_array = false;
+		}
 	}
 
 	std::vector<Widelands::DescriptionIndex> houses;

--- a/src/scripting/lua_game.cc
+++ b/src/scripting/lua_game.cc
@@ -1186,7 +1186,7 @@ int LuaPlayer::do_get_buildings(lua_State* L, const bool csites) {
 	// parse_building_list
 	bool return_array = true;
 	if (lua_isstring(L, -1) != 0) {
-		const char* name = luaL_checkstring(L, -1);
+		const std::string name = luaL_checkstring(L, -1);
 		if (name != "all") {
 			lua_pop(L, 1);
 			lua_newtable(L);

--- a/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
@@ -36,8 +36,7 @@ function constructionsite_tests:test_type()
 end
 
 function constructionsite_tests:test_size()
-
-local building = egbase:get_building_description(self.l.building)
+   local building = egbase:get_building_description(self.l.building)
    assert_equal("small", egbase:get_building_description(self.l.building).size)
    assert_equal("big", egbase:get_building_description(self.f.building).size)
 end

--- a/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
@@ -47,8 +47,9 @@ function constructionsite_tests:test_building()
 end
 
 function constructionsite_tests:test_get_constructionsites()
-   assert_equal(#player1:get_constructionsites("barbarians_lumberjacks_hut", 1), "#lumberjacks_hut")
-   assert_equal(#player1:get_constructionsites("barbarians_fortress", 1), "#fortress")
+   local player1 = self.l.owner
+   assert_equal(#player1:get_constructionsites("barbarians_lumberjacks_hut"), 1, "#lumberjacks_hut")
+   assert_equal(#player1:get_constructionsites("barbarians_fortress"), 1, "#fortress")
 
    assert_equal(player1:get_constructionsites("barbarians_lumberjacks_hut")[1], self.f1.immovable, "1st lumberjacks_hut")
 

--- a/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
@@ -45,21 +45,3 @@ function constructionsite_tests:test_building()
    assert_equal("barbarians_lumberjacks_hut", self.l.building)
    assert_equal("barbarians_fortress", self.f.building)
 end
-
-function constructionsite_tests:test_get_constructionsites()
-   local player1 = self.l.owner
-   assert_equal(#player1:get_constructionsites("barbarians_lumberjacks_hut"), 1, "#lumberjacks_hut")
-   assert_equal(#player1:get_constructionsites("barbarians_fortress"), 1, "#fortress")
-
-   assert_equal(player1:get_constructionsites("barbarians_lumberjacks_hut")[1], self.f1.immovable, "1st lumberjacks_hut")
-
-   local rv = #player1:get_constructionsites({"barbarians_fortress", "barbarians_lumberjacks_hut", "barbarians_quarry"})
-   assert_equal(#rv.barbarians_lumberjacks_hut, 1, "#lumberjacks_hut (multiple)")
-   assert_equal(#rv.barbarians_fortress, 1, "#fortress (multiple)")
-   assert_equal(#rv.barbarians_quarry, 0, "#quarry (multiple)") -- in result, but none exists
-
-   local rv_all = #player1:get_constructionsites("all")
-   assert_equal(rv_all.barbarians_lumberjacks_hut, rv.barbarians_lumberjacks_hut, "lumberjacks_hut (all)")
-   assert_equal(rv_all.barbarians_fortress, rv.barbarians_fortress, "fortress (all)")
-   assert_equal(rv_all.barbarians_wood_hardener, {}, "wood_hardener (all)")
-end

--- a/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/constructionsite.lua
@@ -46,3 +46,20 @@ function constructionsite_tests:test_building()
    assert_equal("barbarians_lumberjacks_hut", self.l.building)
    assert_equal("barbarians_fortress", self.f.building)
 end
+
+function constructionsite_tests:test_get_constructionsites()
+   assert_equal(#player1:get_constructionsites("barbarians_lumberjacks_hut", 1), "#lumberjacks_hut")
+   assert_equal(#player1:get_constructionsites("barbarians_fortress", 1), "#fortress")
+
+   assert_equal(player1:get_constructionsites("barbarians_lumberjacks_hut")[1], self.f1.immovable, "1st lumberjacks_hut")
+
+   local rv = #player1:get_constructionsites({"barbarians_fortress", "barbarians_lumberjacks_hut", "barbarians_quarry"})
+   assert_equal(#rv.barbarians_lumberjacks_hut, 1, "#lumberjacks_hut (multiple)")
+   assert_equal(#rv.barbarians_fortress, 1, "#fortress (multiple)")
+   assert_equal(#rv.barbarians_quarry, 0, "#quarry (multiple)") -- in result, but none exists
+
+   local rv_all = #player1:get_constructionsites("all")
+   assert_equal(rv_all.barbarians_lumberjacks_hut, rv.barbarians_lumberjacks_hut, "lumberjacks_hut (all)")
+   assert_equal(rv_all.barbarians_fortress, rv.barbarians_fortress, "fortress (all)")
+   assert_equal(rv_all.barbarians_wood_hardener, {}, "wood_hardener (all)")
+end

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -118,7 +118,7 @@ function player_building_access:test_constructionsites()
    assert_equal(#rv.barbarians_fortress, 1, "#fortress (multiple)")
    assert_equal(#rv.barbarians_quarry, 0, "#quarry (multiple)") -- listed in result, but empty
 
-   local rv_all = #player1:get_constructionsites("all")
+   local rv_all = player1:get_constructionsites("all")
    assert_equal(#rv_all.barbarians_lumberjacks_hut, #rv.barbarians_lumberjacks_hut, "#lumberjacks_hut (all)")
    assert_equal(#rv_all.barbarians_fortress, #rv.barbarians_fortress, "#fortress (all)")
    assert_equal(#rv_all.barbarians_wood_hardener, 0, "#wood_hardener (all)") -- all types are listed

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -106,12 +106,12 @@ function player_building_access:test_constructionsites()
    -- place construction sites
    local c1 = player1:place_building("barbarians_lumberjacks_hut", f1, true)
    local c2 = player1:place_building("barbarians_fortress", f2, true)
-   self.bs = { c1, c2}
+   self.bs = {c1, c2}
 
    assert_equal(#player1:get_constructionsites("barbarians_lumberjacks_hut"), 1, "#lumberjacks_hut")
    assert_equal(#player1:get_constructionsites("barbarians_fortress"), 1, "#fortress")
 
-   assert_equal(player1:get_constructionsites("barbarians_lumberjacks_hut")[1], self.f1.immovable, "the lumberjacks_hut")
+   assert_equal(player1:get_constructionsites("barbarians_lumberjacks_hut")[1], c1, "the lumberjacks_hut")
 
    local rv = player1:get_constructionsites({"barbarians_fortress", "barbarians_lumberjacks_hut", "barbarians_quarry"})
    assert_equal(#rv, 3, "#rv (multiple)")
@@ -123,6 +123,7 @@ function player_building_access:test_constructionsites()
    assert_equal(#rv_all.barbarians_lumberjacks_hut, #rv.barbarians_lumberjacks_hut, "#lumberjacks_hut (all)")
    assert_equal(#rv_all.barbarians_fortress, #rv.barbarians_fortress, "#fortress (all)")
    assert_equal(#rv_all.barbarians_wood_hardener, 0, "#wood_hardener (all)") -- all types are listed
+   assert_true(#rv_all > 10, "rv has many entries (all)")
 end
 
 -- ================

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -114,7 +114,6 @@ function player_building_access:test_constructionsites()
    assert_equal(player1:get_constructionsites("barbarians_lumberjacks_hut")[1], c1, "the lumberjacks_hut")
 
    local rv = player1:get_constructionsites({"barbarians_fortress", "barbarians_lumberjacks_hut", "barbarians_quarry"})
-   assert_equal(#rv, 3, "#rv (multiple)")
    assert_equal(#rv.barbarians_lumberjacks_hut, 1, "#lumberjacks_hut (multiple)")
    assert_equal(#rv.barbarians_fortress, 1, "#fortress (multiple)")
    assert_equal(#rv.barbarians_quarry, 0, "#quarry (multiple)") -- listed in result, but empty
@@ -123,7 +122,6 @@ function player_building_access:test_constructionsites()
    assert_equal(#rv_all.barbarians_lumberjacks_hut, #rv.barbarians_lumberjacks_hut, "#lumberjacks_hut (all)")
    assert_equal(#rv_all.barbarians_fortress, #rv.barbarians_fortress, "#fortress (all)")
    assert_equal(#rv_all.barbarians_wood_hardener, 0, "#wood_hardener (all)") -- all types are listed
-   assert_true(#rv_all > 10, "rv has many entries (all)")
 end
 
 -- ================

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -80,6 +80,11 @@ function player_building_access:test_multi()
 
    assert_equal(2, #rv.barbarians_lumberjacks_hut)
    assert_equal(1, #rv.barbarians_quarry)
+
+   local rv_all = player1:get_buildings("all")
+   assert_equal(#rv_all.barbarians_lumberjacks_hut, #rv.barbarians_lumberjacks_hut, "#lumberjacks_hut (all)")
+   assert_equal(rv_all.barbarians_quarry, rv.barbarians_quarry, "quarry (all)")
+   assert_equal(rv_all.barbarians_fishers_hut, {}, "fishers_hut (all)")
 end
 function player_building_access:test_access()
    local b1 = player1:place_building("barbarians_lumberjacks_hut", map:get_field(10,10))

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -83,8 +83,8 @@ function player_building_access:test_multi()
 
    local rv_all = player1:get_buildings("all")
    assert_equal(#rv_all.barbarians_lumberjacks_hut, #rv.barbarians_lumberjacks_hut, "#lumberjacks_hut (all)")
-   assert_equal(rv_all.barbarians_quarry, rv.barbarians_quarry, "quarry (all)")
-   assert_equal(rv_all.barbarians_fishers_hut, {}, "fishers_hut (all)")
+   assert_equal(#rv_all.barbarians_quarry, #rv.barbarians_quarry, "#quarry (all)")
+   assert_equal(#rv_all.barbarians_fishers_hut, 0, "#fishers_hut (all)")
 end
 function player_building_access:test_access()
    local b1 = player1:place_building("barbarians_lumberjacks_hut", map:get_field(10,10))
@@ -97,11 +97,39 @@ function player_building_access:test_access()
    b1.fields[1].brn.immovable:remove()
    assert_equal(1, #player1:get_buildings("barbarians_lumberjacks_hut"))
 end
+function player_building_access:test_constructionsites()
+   local f1 = map:get_field(8,10)
+   local f2 = map:get_field(12,10)
+   player1:conquer(f1, 3)
+   player1:conquer(f2, 3)
+
+   -- place construction sites
+   local c1 = player1:place_building("barbarians_lumberjacks_hut", f1, true)
+   local c2 = player1:place_building("barbarians_fortress", f2, true)
+   self.bs = { c1, c2}
+
+   assert_equal(#player1:get_constructionsites("barbarians_lumberjacks_hut"), 1, "#lumberjacks_hut")
+   assert_equal(#player1:get_constructionsites("barbarians_fortress"), 1, "#fortress")
+
+   assert_equal(player1:get_constructionsites("barbarians_lumberjacks_hut")[1], self.f1.immovable, "the lumberjacks_hut")
+
+   local rv = player1:get_constructionsites({"barbarians_fortress", "barbarians_lumberjacks_hut", "barbarians_quarry"})
+   assert_equal(#rv, 3, "#rv (multiple)")
+   assert_equal(#rv.barbarians_lumberjacks_hut, 1, "#lumberjacks_hut (multiple)")
+   assert_equal(#rv.barbarians_fortress, 1, "#fortress (multiple)")
+   assert_equal(#rv.barbarians_quarry, 0, "#quarry (multiple)") -- listed in result, but empty
+
+   local rv_all = #player1:get_constructionsites("all")
+   assert_equal(#rv_all.barbarians_lumberjacks_hut, #rv.barbarians_lumberjacks_hut, "#lumberjacks_hut (all)")
+   assert_equal(#rv_all.barbarians_fortress, #rv.barbarians_fortress, "#fortress (all)")
+   assert_equal(#rv_all.barbarians_wood_hardener, 0, "#wood_hardener (all)") -- all types are listed
+end
+
 -- ================
 -- Players production statistics
 -- ================
 player_production_statistics = lunit.TestCase("Players production statistics")
-function player_building_access:test_single()
+function player_production_statistics:test_single()
    self.bs = {
       player1:place_building("barbarians_lumberjacks_hut", map:get_field(10,10)),
       player1:place_building("barbarians_lumberjacks_hut", map:get_field(13,10)),


### PR DESCRIPTION
`player:get_buildings("all")` and `player:get_constructionsites("all")` is supported

**Type of change**
Bugfix

**Issue(s) closed**
Fixes #4946