### PR TITLE
Fix soldier request deletion when ship is destroyed

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -241,6 +241,10 @@ bool Ship::init_fleet(EditorGameBase& egbase) {
 }
 
 void Ship::cleanup(EditorGameBase& egbase) {
+	if (PortDock* last = lastdock_.get(egbase); last != nullptr) {
+		last->erase_warship_request(serial());
+	}
+
 	if (fleet_ != nullptr) {
 		fleet_->remove_ship(egbase, this);
 	}

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -541,10 +541,10 @@ void MapBuildingdataPacket::read_warehouse(Warehouse& warehouse,
 						// development version. Require its existence after v1.2.
 						if (!mol.is_object_known(ship_serial)) {
 							log_warn("Reading soldier request for nonexistent ship %u", ship_serial);
-							SoldierRequest* req = new SoldierRequest(
+							SoldierRequest req(
 							   warehouse, SoldierPreference::kHeroes, Ship::warship_soldier_callback,
 							   []() { return 0U; }, []() { return std::vector<Widelands::Soldier*>(); });
-							req->read(fr, game, mol);
+							req.read(fr, game, mol);
 							continue;
 						}
 

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -543,8 +543,7 @@ void MapBuildingdataPacket::read_warehouse(Warehouse& warehouse,
 							log_warn("Reading soldier request for nonexistent ship %u", ship_serial);
 							SoldierRequest* req = new SoldierRequest(
 							   warehouse, SoldierPreference::kHeroes, Ship::warship_soldier_callback,
-							   []() { return 0U; },
-							   []() { return std::vector<Widelands::Soldier*>(); });
+							   []() { return 0U; }, []() { return std::vector<Widelands::Soldier*>(); });
 							req->read(fr, game, mol);
 							continue;
 						}

--- a/src/map_io/map_buildingdata_packet.cc
+++ b/src/map_io/map_buildingdata_packet.cc
@@ -536,7 +536,20 @@ void MapBuildingdataPacket::read_warehouse(Warehouse& warehouse,
 					}
 
 					for (uint32_t i = packet_version >= 10 ? fr.unsigned_32() : 0; i > 0; --i) {
-						Ship* ship = &mol.get<Ship>(fr.unsigned_32());
+						Serial ship_serial = fr.unsigned_32();
+						// TODO(Nordfriese): The ship can only fail to exist in a pre-v1.2
+						// development version. Require its existence after v1.2.
+						if (!mol.is_object_known(ship_serial)) {
+							log_warn("Reading soldier request for nonexistent ship %u", ship_serial);
+							SoldierRequest* req = new SoldierRequest(
+							   warehouse, SoldierPreference::kHeroes, Ship::warship_soldier_callback,
+							   []() { return 0U; },
+							   []() { return std::vector<Widelands::Soldier*>(); });
+							req->read(fr, game, mol);
+							continue;
+						}
+
+						Ship* ship = &mol.get<Ship>(ship_serial);
 						assert(warehouse.portdock_->warship_soldier_requests_.count(ship->serial()) == 0);
 						SoldierRequest* req = new SoldierRequest(
 						   warehouse, SoldierPreference::kHeroes, Ship::warship_soldier_callback,


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
The savegame from the battle royale fails to load. This patch both fixes the underlying issue and also includes compatibility code to allow the broken savegame to load again.

**To reproduce**
Destroy an enemy warship while that ship is anchored in a port. Then save and reload.

**New behavior**
Delete a ship's soldier request upon destruction.