### PR TITLE
Revert preventing move_inside_parent() to move UniqueWindows with saved position

### DIFF
--- a/src/ui_basic/unique_window.cc
+++ b/src/ui_basic/unique_window.cc
@@ -156,7 +156,9 @@ void UniqueWindow::move_inside_parent() {
 		return;
 	}
 
-	if (registry_->valid_pos) {
+	// TODO(tothxa): needs refining to handle window size changes (e.g on tab switching)
+	/*
+	if (moved_by_user()) {
 		constexpr int32_t kMinVisible = 100;
 
 		const bool top_visible = registry_->y < parent->get_inner_h() - kMinVisible;
@@ -169,6 +171,7 @@ void UniqueWindow::move_inside_parent() {
 			return;
 		}
 	}
+	*/
 	Window::move_inside_parent();
 }
 

--- a/src/ui_basic/window.cc
+++ b/src/ui_basic/window.cc
@@ -594,7 +594,6 @@ bool Window::handle_mousepress(const uint8_t btn, int32_t mx, int32_t my) {
 		is_minimal() ? restore() : minimize();
 	} else if (btn == SDL_BUTTON_LEFT) {
 		dragging_ = true;
-		moved_by_user_ = true;
 		drag_start_win_x_ = get_x();
 		drag_start_win_y_ = get_y();
 		drag_start_mouse_x_ = get_x() + get_lborder() + mx;
@@ -833,6 +832,7 @@ bool Window::handle_mousemove(
 			}
 		}
 		set_pos(Vector2i(new_left, new_top));
+		moved_by_user_ = true;
 	}
 	return true;
 }


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #5984

**New behavior**
`UniqueWindow`s now always honour `move_inside_parent()`

**Possible regressions**
Windows intentionally moved partially outside by the user get moved back in

**Additional context**
I wanted to make window size changes work similar to when the main window is resized, but I'll be away for 2 weeks starting on Saturday, so this is just the quick fix for now.