### PR TITLE
Clean up legacy resource handling code

### DIFF
--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -716,7 +716,8 @@ void EditorInteractive::draw(RenderTarget& dst) {
 		}
 	}
 
-	std::map<std::pair<Widelands::DescriptionIndex, Widelands::ResourceAmount>, const Image*> resource_images_cache;
+	std::map<std::pair<Widelands::DescriptionIndex, Widelands::ResourceAmount>, const Image*>
+	   resource_images_cache;
 
 	for (size_t idx = 0; idx < fields_to_draw->size(); ++idx) {
 		const FieldsToDraw::Field& field = fields_to_draw->at(idx);
@@ -742,16 +743,19 @@ void EditorInteractive::draw(RenderTarget& dst) {
 
 		// Draw resource overlay.
 		if (get_display_flag(dfShowResources) && field.fcoords.field->get_resources_amount() > 0) {
-			std::pair<Widelands::DescriptionIndex, Widelands::ResourceAmount> cachekey(field.fcoords.field->get_resources(), field.fcoords.field->get_resources_amount());
+			std::pair<Widelands::DescriptionIndex, Widelands::ResourceAmount> cachekey(
+			   field.fcoords.field->get_resources(), field.fcoords.field->get_resources_amount());
 			auto it = resource_images_cache.find(cachekey);
 			if (it == resource_images_cache.end()) {
-				it = resource_images_cache.emplace(cachekey,
-						g_image_cache->get(ebase.descriptions().get_resource_descr(cachekey.first)->editor_image(cachekey.second))
-					).first;
+				it = resource_images_cache
+				        .emplace(cachekey, g_image_cache->get(ebase.descriptions()
+				                                                 .get_resource_descr(cachekey.first)
+				                                                 ->editor_image(cachekey.second)))
+				        .first;
 			}
 
-			blit_field_overlay(
-			   &dst, field, it->second, Vector2i(it->second->width() / 2, it->second->height() / 2), scale);
+			blit_field_overlay(&dst, field, it->second,
+			                   Vector2i(it->second->width() / 2, it->second->height() / 2), scale);
 		}
 
 		const Widelands::NodeCaps nodecaps =

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -716,6 +716,8 @@ void EditorInteractive::draw(RenderTarget& dst) {
 		}
 	}
 
+	std::map<std::pair<Widelands::DescriptionIndex, Widelands::ResourceAmount>, const Image*> resource_images_cache;
+
 	for (size_t idx = 0; idx < fields_to_draw->size(); ++idx) {
 		const FieldsToDraw::Field& field = fields_to_draw->at(idx);
 		if (field.obscured_by_slope) {
@@ -739,16 +741,17 @@ void EditorInteractive::draw(RenderTarget& dst) {
 		}
 
 		// Draw resource overlay.
-		uint8_t const amount = field.fcoords.field->get_resources_amount();
-		if (get_display_flag(dfShowResources) && amount > 0) {
-			const std::string& immname = ebase.descriptions()
-			                                .get_resource_descr(field.fcoords.field->get_resources())
-			                                ->editor_image(amount);
-			if (!immname.empty()) {
-				const auto* pic = g_image_cache->get(immname);
-				blit_field_overlay(
-				   &dst, field, pic, Vector2i(pic->width() / 2, pic->height() / 2), scale);
+		if (get_display_flag(dfShowResources) && field.fcoords.field->get_resources_amount() > 0) {
+			std::pair<Widelands::DescriptionIndex, Widelands::ResourceAmount> cachekey(field.fcoords.field->get_resources(), field.fcoords.field->get_resources_amount());
+			auto it = resource_images_cache.find(cachekey);
+			if (it == resource_images_cache.end()) {
+				it = resource_images_cache.emplace(cachekey,
+						g_image_cache->get(ebase.descriptions().get_resource_descr(cachekey.first)->editor_image(cachekey.second))
+					).first;
 			}
+
+			blit_field_overlay(
+			   &dst, field, it->second, Vector2i(it->second->width() / 2, it->second->height() / 2), scale);
 		}
 
 		const Widelands::NodeCaps nodecaps =

--- a/src/logic/field.h
+++ b/src/logic/field.h
@@ -80,15 +80,6 @@ public:
 	};
 	static_assert(sizeof(Terrains) == sizeof(DescriptionIndex) * 2,
 	              "assert(sizeof(Terrains) == sizeof(DescriptionIndex) * 2) failed.");
-	struct Resources {
-		DescriptionIndex d : 4, r : 4;
-	};
-	static_assert(sizeof(Resources) <= sizeof(DescriptionIndex),
-	              "assert(sizeof(Resources) <= sizeof(DescriptionIndex)) failed.");
-	struct ResourceAmounts {
-		ResourceAmount d : 4, r : 4;
-	};
-	static_assert(sizeof(ResourceAmounts) == 1, "assert(sizeof(ResourceAmounts) == 1) failed.");
 
 	Field() : brightness(0), owner_info_and_selections(Widelands::neutral()) {
 	}

--- a/src/logic/map_objects/world/resource_description.cc
+++ b/src/logic/map_objects/world/resource_description.cc
@@ -46,7 +46,8 @@ ResourceDescription::ResourceDescription(const LuaTable& table)
 
 const std::string& ResourceDescription::editor_image(uint32_t const amount) const {
 	if (amount > editor_pictures_.back().second) {
-		throw wexception("Resource %s has no image for amount %u (highest amount is %u)", name().c_str(), amount, editor_pictures_.back().second);
+		throw wexception("Resource %s has no image for amount %u (highest amount is %u)",
+		                 name().c_str(), amount, editor_pictures_.back().second);
 	}
 
 	for (size_t i = 1; i < editor_pictures_.size(); ++i) {

--- a/src/logic/map_objects/world/resource_description.cc
+++ b/src/logic/map_objects/world/resource_description.cc
@@ -58,6 +58,7 @@ const std::string& ResourceDescription::editor_image(uint32_t const amount) cons
 		}
 	}
 
+	assert(result != nullptr);
 	return *result;
 }
 

--- a/src/logic/map_objects/world/resource_description.cc
+++ b/src/logic/map_objects/world/resource_description.cc
@@ -50,13 +50,15 @@ const std::string& ResourceDescription::editor_image(uint32_t const amount) cons
 		                 name().c_str(), amount, editor_pictures_.back().second);
 	}
 
-	for (size_t i = 1; i < editor_pictures_.size(); ++i) {
-		if (editor_pictures_.at(i).second > amount) {
-			return editor_pictures_.at(i - 1).first;
+	const std::string* result = nullptr;
+	for (const auto& pair : editor_pictures_) {
+		result = &pair.first;
+		if (pair.second >= amount) {
+			break;
 		}
 	}
 
-	NEVER_HERE();
+	return *result;
 }
 
 const std::string& ResourceDescription::name() const {

--- a/src/logic/map_objects/world/resource_description.h
+++ b/src/logic/map_objects/world/resource_description.h
@@ -30,11 +30,6 @@ namespace Widelands {
 
 class ResourceDescription {
 public:
-	struct EditorPicture {
-		std::string picname;
-		int upper_limit;
-	};
-
 	explicit ResourceDescription(const LuaTable& table);
 
 	/// Returns the in engine name of this resource.
@@ -76,7 +71,7 @@ private:
 	const uint32_t timeout_radius_;
 	ResourceAmount max_amount_;
 	const std::string representative_image_;
-	std::vector<EditorPicture> editor_pictures_;
+	std::vector<std::pair<std::string /* image */, uint32_t /* upper limit */>> editor_pictures_;
 
 	DISALLOW_COPY_AND_ASSIGN(ResourceDescription);
 };

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -211,9 +211,6 @@ public:
 			//  even for triangles that the player does not see (it is the
 			//  darkening that actually hides the ground from the user).
 			terrains.store(Widelands::Field::Terrains{0, 0});
-
-			time_triangle_last_surveyed[0] = Time();
-			time_triangle_last_surveyed[1] = Time();
 		}
 
 		~Field() {
@@ -305,25 +302,6 @@ public:
 		}
 
 		/**
-		 * The last time when this player surveyed the respective triangle
-		 * geologically. Indexed by TCoords::TriangleIndex. A geologic survey is a
-		 * thorough investigation. Therefore it is considered impossible to have
-		 * knowledge about the resources of a triangle without having knowledge
-		 * about each of the surrounding nodes:
-		 *
-		 *     geologic information about a triangle =>
-		 *         each neighbouring node has been seen
-		 *
-		 * and the contrapositive:
-		 *
-		 *     some neighbouring node has never been seen =>
-		 *         no geologic information about the triangle
-		 *
-		 * Is EditorGameBase::Never() when never surveyed.
-		 */
-		Time time_triangle_last_surveyed[2];
-
-		/**
 		 * The last time when this player saw this node.
 		 * Only valid when \ref seeing is kPreviouslySeen, i.e. the player has previously seen
 		 * this node but can't see it right now.
@@ -388,15 +366,6 @@ public:
 		 * Only valid when this player has seen this node.
 		 */
 		PlayerNumber owner{0U};
-
-		/**
-		 * The amount of resource at each of the triangles, as far as this player
-		 * knows.
-		 * The d component is only valid when time_last_surveyed[0] != Never().
-		 * The r component is only valid when time_last_surveyed[1] != Never().
-		 */
-		// TODO(unknown): Check this on access, at least in debug builds
-		Widelands::Field::ResourceAmounts resource_amounts;
 
 	private:
 		DISALLOW_COPY_AND_ASSIGN(Field);

--- a/src/wui/game_debug_ui.cc
+++ b/src/wui/game_debug_ui.cc
@@ -210,30 +210,6 @@ void FieldDebugWindow::think() {
 
 		Widelands::Vision const vision = player_field.vision;
 		str += format("  vision: %u\n", vision.value());
-		{
-			Time const time_last_surveyed =
-			   player_field.time_triangle_last_surveyed[static_cast<int>(Widelands::TriangleIndex::D)];
-
-			if (time_last_surveyed.is_valid()) {
-				str += format("  D triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
-				              static_cast<unsigned int>(player_field.resource_amounts.d));
-
-			} else {
-				str += "  D triangle never surveyed\n";
-			}
-		}
-		{
-			Time const time_last_surveyed =
-			   player_field.time_triangle_last_surveyed[static_cast<int>(Widelands::TriangleIndex::R)];
-
-			if (time_last_surveyed.is_valid()) {
-				str += format("  R triangle last surveyed at %u: amount %u\n", time_last_surveyed.get(),
-				              static_cast<unsigned int>(player_field.resource_amounts.r));
-
-			} else {
-				str += "  R triangle never surveyed\n";
-			}
-		}
 
 		if (!vision.is_explored()) {
 			str += "  never seen\n";


### PR DESCRIPTION
**Type of change**
Refactoring

**Issue(s) closed**
Our resource handling code has some legacy stuff in it that has been eating up performance, memory, and disk space despite being unused for many years.

This branch removes some long-unused fields from large data structures and savegames.

Further, in the editor the resources overlay view is a performance bottleneck – switching on resource view slows Widelands to a crawl. With the refactoring and caching introduced in this branch, there is no noticeable slowdown by turning on resource view.

**Possible regressions**
Resource overlays; view packet saveloading