### PR TITLE
Select info tool after opening history window

### DIFF
--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -395,7 +395,7 @@ void EditorInteractive::add_tool_menu() {
 	              shortcut_string_for(KeyboardShortcut::kEditorToolHistory, false));
 	tool_windows_.toolhistory.open_window = [this] {
 		new EditorToolhistoryOptionsMenu(*this, tools()->tool_history, tool_windows_.toolhistory);
-        select_tool(tools()->info, EditorTool::First);
+		select_tool(tools()->info, EditorTool::First);
 	};
 
 	toolmenu_.selected.connect([this] { tool_menu_selected(toolmenu_.get_selected()); });

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -395,6 +395,7 @@ void EditorInteractive::add_tool_menu() {
 	              shortcut_string_for(KeyboardShortcut::kEditorToolHistory, false));
 	tool_windows_.toolhistory.open_window = [this] {
 		new EditorToolhistoryOptionsMenu(*this, tools()->tool_history, tool_windows_.toolhistory);
+        select_tool(tools()->info, EditorTool::First);
 	};
 
 	toolmenu_.selected.connect([this] { tool_menu_selected(toolmenu_.get_selected()); });


### PR DESCRIPTION
**Type of change**
Bugfix 

**Issue(s) closed**
Fixes #5865 

**New behavior**
The history tool is no real tool. You can change its size, but cannot click on the map. So instead change to the standard info tool after opening the window

**Possible regressions**
Other tool selections