### PR TITLE
Cleanup failed game object before entering menu

### DIFF
--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -804,6 +804,7 @@ void WLApplication::run() {
 			title = _("Error message:");
 		}
 		if (!message.empty()) {
+			game.cleanup_objects();
 			g_sh->change_music(Songset::kMenu);
 			FsMenu::MainMenu m(true);
 			m.show_messagebox(title, message);

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -804,7 +804,7 @@ void WLApplication::run() {
 			title = _("Error message:");
 		}
 		if (!message.empty()) {
-			game.cleanup_objects();
+			game.full_cleanup();
 			g_sh->change_music(Songset::kMenu);
 			FsMenu::MainMenu m(true);
 			m.show_messagebox(title, message);


### PR DESCRIPTION
**Type of change**
Bugfix 

**Issue(s) closed**
Fixes #5754 

**How it works**
Cleanup the failed game object properly before entering the main menu
