### PR TITLE
Set fixed msvc toolset version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -273,6 +273,8 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
+        # Check https://github.com/actions/runner-images/blob/main/images/win/toolsets/toolset-2022.json for installed versions
+        toolset: 14.36
     - name: Compiler
       env:
         VCPKG_ROOT: C:\vcpkg


### PR DESCRIPTION
**Type of change**
Maintenace

**Issue(s) closed**
Fixes msvc workflow
Re https://github.com/actions/runner-images/issues/7832

**New behavior**
Select a fixed compiler toolset version

**How it works**
Apparently the [problem is in Visual Studio](https://developercommunity.visualstudio.com/t/MicrosoftVCToolsVersionv143defaulttx/10041951), so the default version is not guaranteed to be correct and an image update will not prevent a regression with the next VC update. Instead we do not rely on automatic version detection, but choose one specifically.

**Possible regressions**
MSVC not failing for a few days ;)