### PR TITLE
help text about roads blocking shoreline for workers

### DIFF
--- a/data/tribes/initialization/amazons/units.lua
+++ b/data/tribes/initialization/amazons/units.lua
@@ -1300,7 +1300,7 @@ wl.Descriptions():new_tribe {
                pgettext("amazons_building", "The hunter-gatherer’s hut needs animals or fish to hunt or catch within the work area."),
                -- TRANSLATORS: Note helptext for an Amazon production site: Hunter-Gatherer's Hut
                pgettext("amazons_building", "Roads and trees along the shoreline block fishing."),
-            }
+            },
             -- TRANSLATORS: Performance helptext for an Amazon production site: Hunter-Gatherer's Hut
             performance = pgettext("amazons_building", "The hunter-gatherer pauses %s before going to work again."):bformat(format_seconds(34))
 

--- a/data/tribes/initialization/amazons/units.lua
+++ b/data/tribes/initialization/amazons/units.lua
@@ -1295,8 +1295,12 @@ wl.Descriptions():new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for an Amazon production site: Hunter-Gatherer's Hut
             purpose = pgettext("amazons_building", "Hunts animals to produce meat. Catches fish in the waters."),
-            -- TRANSLATORS: Note helptext for an Amazon production site: Hunter-Gatherer's Hut
-            note = pgettext("amazons_building", "The hunter-gatherer’s hut needs animals or fish to hunt or catch within the work area."),
+            note = {
+               -- TRANSLATORS: Note helptext for an Amazon production site: Hunter-Gatherer's Hut
+               pgettext("amazons_building", "The hunter-gatherer’s hut needs animals or fish to hunt or catch within the work area."),
+               -- TRANSLATORS: Note helptext for an Amazon production site: Hunter-Gatherer's Hut
+               pgettext("amazons_building", "Roads and trees along the shoreline block fishing."),
+            }
             -- TRANSLATORS: Performance helptext for an Amazon production site: Hunter-Gatherer's Hut
             performance = pgettext("amazons_building", "The hunter-gatherer pauses %s before going to work again."):bformat(format_seconds(34))
 
@@ -1322,8 +1326,12 @@ wl.Descriptions():new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for an Amazon production site: Water Gatherer's Hut
             purpose = pgettext("amazons_building", "Draws water out of the rivers and lakes."),
-            -- TRANSLATORS: Note helptext for an Amazon production site: Water Gatherer's Hut
-            note = pgettext("amazons_building", "The water gatherer’s hut needs open water within the work area. Your workers cannot dig up water from the ground!")
+            note = {
+               -- TRANSLATORS: Note helptext for an Amazon production site: Water Gatherer's Hut, part 1
+               pgettext("amazons_building", "The water gatherer’s hut needs open water within the work area. Your workers cannot dig up water from the ground!"),
+               -- TRANSLATORS: Note helptext for an Amazon production site: Water Gatherer's Hut, part 2
+               pgettext("amazons_building", "Roads and trees along the shoreline block drawing water."),
+            }
          }
       },
       {
@@ -1596,15 +1604,25 @@ wl.Descriptions():new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for an Amazon production site: Ferry Yard
             purpose = pgettext("amazons_building", "Builds ferries."),
-            -- TRANSLATORS: Note helptext for an Amazon production site: Ferry Yard
-            note = pgettext("amazons_building", "Needs water nearby.")
+            note = {
+               -- TRANSLATORS: Note helptext for an Amazon production site: Ferry Yard, part 1
+               pgettext("amazons_building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for an Amazon production site: Ferry Yard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
       {
          name = "amazons_shipyard",
          helptexts = {
             -- TRANSLATORS: Purpose helptext for an Amazon production site: Shipyard
-            purpose = pgettext("amazons_building", "Constructs ships that are used for overseas colonization and for trading between ports.")
+            purpose = pgettext("amazons_building", "Constructs ships that are used for overseas colonization and for trading between ports."),
+            note = {
+               -- TRANSLATORS: Note helptext for an Amazon production site: Shipyard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for an Amazon production site: Shipyard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
 

--- a/data/tribes/initialization/amazons/units.lua
+++ b/data/tribes/initialization/amazons/units.lua
@@ -1606,7 +1606,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("amazons_building", "Builds ferries."),
             note = {
                -- TRANSLATORS: Note helptext for an Amazon production site: Ferry Yard, part 1
-               pgettext("amazons_building", "Needs water nearby."),
+               pgettext("amazons_building", "Needs water nearby. Be aware ferries carry wares only, no workers."),
                -- TRANSLATORS: Note helptext for an Amazon production site: Ferry Yard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }
@@ -1619,7 +1619,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("amazons_building", "Constructs ships that are used for overseas colonization and for trading between ports."),
             note = {
                -- TRANSLATORS: Note helptext for an Amazon production site: Shipyard, part 1
-               pgettext("building", "Needs water nearby."),
+               pgettext("building", "Needs wide open water nearby."),
                -- TRANSLATORS: Note helptext for an Amazon production site: Shipyard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }

--- a/data/tribes/initialization/atlanteans/units.lua
+++ b/data/tribes/initialization/atlanteans/units.lua
@@ -2003,6 +2003,12 @@ wl.Descriptions():new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for an Atlantean production site: Shipyard
             purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports."),
+            note = {
+               -- TRANSLATORS: Note helptext for an Atlantean production site: Shipyard, part 1
+               pgettext("building", "Needs wide open water nearby."),
+               -- TRANSLATORS: Note helptext for an Atlantean production site: Shipyard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            },
             -- TRANSLATORS: Lore helptext for an Atlantean production site: Shipyard
             lore = pgettext("atlanteans_building", [[‘Soon may the wellerman come,<br>]] ..
                                           [[to bring us bread and smoked fish.<br>]] ..
@@ -2010,12 +2016,6 @@ wl.Descriptions():new_tribe {
                                           [[we praise Satul the best we wish.’]]),
             -- TRANSLATORS: Lore author helptext for an Atlantean production site: Shipyard -- not directly stolen from the wellerman song
             lore_author = pgettext("atlanteans_building", "Transcript from oral tradition"),
-            note = {
-               -- TRANSLATORS: Note helptext for an Atlantean production site: Shipyard, part 1
-               pgettext("building", "Needs water nearby."),
-               -- TRANSLATORS: Note helptext for an Atlantean production site: Shipyard, part 2
-               pgettext("building", "Roads and trees along the shoreline block access to water."),
-            }
          }
       },
 

--- a/data/tribes/initialization/atlanteans/units.lua
+++ b/data/tribes/initialization/atlanteans/units.lua
@@ -1521,7 +1521,9 @@ wl.Descriptions():new_tribe {
                -- TRANSLATORS: Note helptext for an Atlantean production site: Fisher's House, part 1
                pgettext("atlanteans_building", "The fisher’s house needs water full of fish within the work area."),
                -- TRANSLATORS: Note helptext for an Atlantean production site: Fisher's House, part 2
-               pgettext("atlanteans_building", "Build a fish breeder’s house close to the fisher’s house to make sure that you don’t run out of fish.")
+               pgettext("atlanteans_building", "Build a fish breeder’s house close to the fisher’s house to make sure that you don’t run out of fish."),
+               -- TRANSLATORS: Note helptext for an Atlantean production site: Fisher's House, part 3
+               pgettext("atlanteans_building", "Roads and trees along the shoreline block fishing."),
             },
             -- TRANSLATORS: Note lore for an Atlantean production site: Fisher's House use some local fise song as you like
             lore = pgettext("atlanteans_building", [[‘Take your net and come to the sea<br>]] ..
@@ -1981,8 +1983,12 @@ wl.Descriptions():new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for an Atlantean production site: Ferry Yard
             purpose = pgettext("building", "Builds ferries."),
-            -- TRANSLATORS: Note helptext for an Atlantean production site: Ferry Yard
-            note = pgettext("building", "Needs water nearby. Be aware ferries carry wares only, no workers."),
+            note = {
+               -- TRANSLATORS: Note helptext for an Atlantean production site: Ferry Yard, part 1
+               pgettext("building", "Needs water nearby. Be aware ferries carry wares only, no workers."),
+               -- TRANSLATORS: Note helptext for an Atlantean production site: Ferry Yard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            },
             -- TRANSLATORS: Lore helptext for an Atlantean production site: Ferry Yard
             lore = pgettext("atlanteans_building", [[‘Row, row, row your boat<br>]] ..
                                           [[gently ’long the shore.<br>]] ..
@@ -2003,8 +2009,13 @@ wl.Descriptions():new_tribe {
                                           [[We set sail for a faraway shore<br>]] ..
                                           [[we praise Satul the best we wish.’]]),
             -- TRANSLATORS: Lore author helptext for an Atlantean production site: Shipyard -- not directly stolen from the wellerman song
-            lore_author = pgettext("atlanteans_building", "Transcript from oral tradition")
-
+            lore_author = pgettext("atlanteans_building", "Transcript from oral tradition"),
+            note = {
+               -- TRANSLATORS: Note helptext for an Atlantean production site: Shipyard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for an Atlantean production site: Shipyard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
 

--- a/data/tribes/initialization/barbarians/units.lua
+++ b/data/tribes/initialization/barbarians/units.lua
@@ -1187,10 +1187,10 @@ wl.Descriptions():new_tribe {
             -- TRANSLATORS: Purpose helptext for production site: Fisher's Hut
             purpose = pgettext("barbarians_building", "Fishes on the coast near the fisher’s hut."),
             note = {
-               -- TRANSLATORS: Note helptext for production site: Fisher's Hut
+               -- TRANSLATORS: Note helptext for production site: Fisher's Hut, part 1
                pgettext("barbarians_building", "The fisher’s hut needs water full of fish within the work area."),
-               --
-               pgettext("barbarians_building", "Roads and trees along the shoreline block fishing."),
+               -- TRANSLATORS: Note helptext for production site: Fisher's Hut, part 2
+               pgettext("building", "Roads and trees along the shoreline block fishing."),
             }
             -- TRANSLATORS: Performance helptext for production site: Fisher's Hut
             performance = pgettext("barbarians_building", "The fisher pauses %s before going to work again."):bformat(format_seconds(18))

--- a/data/tribes/initialization/barbarians/units.lua
+++ b/data/tribes/initialization/barbarians/units.lua
@@ -1191,7 +1191,7 @@ wl.Descriptions():new_tribe {
                pgettext("barbarians_building", "The fisher’s hut needs water full of fish within the work area."),
                -- TRANSLATORS: Note helptext for production site: Fisher's Hut, part 2
                pgettext("building", "Roads and trees along the shoreline block fishing."),
-            }
+            },
             -- TRANSLATORS: Performance helptext for production site: Fisher's Hut
             performance = pgettext("barbarians_building", "The fisher pauses %s before going to work again."):bformat(format_seconds(18))
          }

--- a/data/tribes/initialization/barbarians/units.lua
+++ b/data/tribes/initialization/barbarians/units.lua
@@ -1186,8 +1186,12 @@ wl.Descriptions():new_tribe {
             lore_author = pgettext("barbarians_building", "Frequent response of a Barbarian fisherman,<br>often followed by an enjoyable brawl"),
             -- TRANSLATORS: Purpose helptext for production site: Fisher's Hut
             purpose = pgettext("barbarians_building", "Fishes on the coast near the fisher’s hut."),
-            -- TRANSLATORS: Note helptext for production site: Fisher's Hut
-            note = pgettext("barbarians_building", "The fisher’s hut needs water full of fish within the work area."),
+            note = {
+               -- TRANSLATORS: Note helptext for production site: Fisher's Hut
+               pgettext("barbarians_building", "The fisher’s hut needs water full of fish within the work area."),
+               --
+               pgettext("barbarians_building", "Roads and trees along the shoreline block fishing."),
+            }
             -- TRANSLATORS: Performance helptext for production site: Fisher's Hut
             performance = pgettext("barbarians_building", "The fisher pauses %s before going to work again."):bformat(format_seconds(18))
          }
@@ -1767,8 +1771,12 @@ wl.Descriptions():new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for production site: Ferry Yard
             purpose = pgettext("building", "Builds ferries."),
-            -- TRANSLATORS: Note helptext for production site: Ferry Yard
-            note = pgettext("building", "Needs water nearby.")
+            note = {
+               -- TRANSLATORS: Note helptext for a Barbarian production site: Ferry Yard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for a Barbarian production site: Ferry Yard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
       {
@@ -1780,7 +1788,13 @@ wl.Descriptions():new_tribe {
             -- TRANSLATORS: Lore author helptext for a Barbarian production site: Shipyard
             lore_author = pgettext("barbarians_building", "Captain Thanlas the Elder,<br>Explorer"),
             -- TRANSLATORS: Purpose helptext for a Barbarian production site: Shipyard
-            purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports.")
+            purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports."),
+            note = {
+               -- TRANSLATORS: Note helptext for a Barbarian production site: Shipyard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for a Barbarian production site: Shipyard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
       {

--- a/data/tribes/initialization/barbarians/units.lua
+++ b/data/tribes/initialization/barbarians/units.lua
@@ -1773,7 +1773,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("building", "Builds ferries."),
             note = {
                -- TRANSLATORS: Note helptext for a Barbarian production site: Ferry Yard, part 1
-               pgettext("building", "Needs water nearby."),
+               pgettext("building", "Needs water nearby. Be aware ferries carry wares only, no workers."),
                -- TRANSLATORS: Note helptext for a Barbarian production site: Ferry Yard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }
@@ -1791,7 +1791,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports."),
             note = {
                -- TRANSLATORS: Note helptext for a Barbarian production site: Shipyard, part 1
-               pgettext("building", "Needs water nearby."),
+               pgettext("building", "Needs wide open water nearby."),
                -- TRANSLATORS: Note helptext for a Barbarian production site: Shipyard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }

--- a/data/tribes/initialization/empire/units.lua
+++ b/data/tribes/initialization/empire/units.lua
@@ -1309,8 +1309,12 @@ wl.Descriptions():new_tribe {
             lore_author = pgettext("empire_building", "A fisherman criticising the Grand Master of the Fishermans’ Guild"),
             -- TRANSLATORS: Purpose helptext for an Empire production site: Fisher's House
             purpose = pgettext("empire_building", "Fishes on the coast near the fisher’s house."),
-            -- TRANSLATORS: Note helptext for an Empire production site: Fisher's House
-            note = pgettext("empire_building", "The fisher’s house needs water full of fish within the work area.")
+            note = {
+               -- TRANSLATORS: Note helptext for an Empire production site: Fisher's House, part 1
+               pgettext("empire_building", "The fisher’s house needs water full of fish within the work area."),
+               -- TRANSLATORS: Note helptext for an Empire production site: Fisher's House, part 2
+               pgettext("empire_building", "Roads and trees along the shreline block fishing."),
+            }
          }
       },
       {
@@ -2241,8 +2245,11 @@ wl.Descriptions():new_tribe {
             ),
             -- TRANSLATORS: Purpose helptext for an Empire production site: Ferry Yard
             purpose = pgettext("building", "Builds ferries."),
-            -- TRANSLATORS: Note helptext for an Empire production site: Ferry Yard
-            note = pgettext("building", "Needs water nearby.")
+            note = {
+               -- TRANSLATORS: Note helptext for an Empire production site: Ferry Yard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for an Empire production site: Ferry Yard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
          }
       },
       {
@@ -2263,7 +2270,13 @@ wl.Descriptions():new_tribe {
                "A shipwright lamenting when he was instructed to stop working"
             ),
             -- TRANSLATORS: Purpose helptext for an Empire production site: Shipyard
-            purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports.")
+            purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports."),
+            note = {
+               -- TRANSLATORS: Note helptext for an Empire production site: Shipyard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for an Empire production site: Shipyard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
 

--- a/data/tribes/initialization/empire/units.lua
+++ b/data/tribes/initialization/empire/units.lua
@@ -2247,7 +2247,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("building", "Builds ferries."),
             note = {
                -- TRANSLATORS: Note helptext for an Empire production site: Ferry Yard, part 1
-               pgettext("building", "Needs water nearby."),
+               pgettext("building", "Needs water nearby. Be aware ferries carry wares only, no workers."),
                -- TRANSLATORS: Note helptext for an Empire production site: Ferry Yard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }
@@ -2274,7 +2274,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports."),
             note = {
                -- TRANSLATORS: Note helptext for an Empire production site: Shipyard, part 1
-               pgettext("building", "Needs water nearby."),
+               pgettext("building", "Needs wide open water nearby."),
                -- TRANSLATORS: Note helptext for an Empire production site: Shipyard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }

--- a/data/tribes/initialization/empire/units.lua
+++ b/data/tribes/initialization/empire/units.lua
@@ -1313,7 +1313,7 @@ wl.Descriptions():new_tribe {
                -- TRANSLATORS: Note helptext for an Empire production site: Fisher's House, part 1
                pgettext("empire_building", "The fisher’s house needs water full of fish within the work area."),
                -- TRANSLATORS: Note helptext for an Empire production site: Fisher's House, part 2
-               pgettext("empire_building", "Roads and trees along the shreline block fishing."),
+               pgettext("empire_building", "Roads and trees along the shoreline block fishing."),
             }
          }
       },
@@ -2250,6 +2250,7 @@ wl.Descriptions():new_tribe {
                pgettext("building", "Needs water nearby."),
                -- TRANSLATORS: Note helptext for an Empire production site: Ferry Yard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
       {

--- a/data/tribes/initialization/frisians/units.lua
+++ b/data/tribes/initialization/frisians/units.lua
@@ -2167,7 +2167,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("building", "Builds ferries."),
             note = {
                -- TRANSLATORS: Note helptext for a Frisian production site: Ferry Yard, part 1
-               pgettext("building", "Needs water nearby."),
+               pgettext("building", "Needs water nearby. Be aware ferries carry wares only, no workers."),
                -- TRANSLATORS: Note helptext for an Frisian production site: Ferry Yard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }
@@ -2184,7 +2184,7 @@ wl.Descriptions():new_tribe {
             purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports."),
             note = {
                -- TRANSLATORS: Note helptext for a Frisian production site: Shipyard, part 1
-               pgettext("building", "Needs water nearby."),
+               pgettext("building", "Needs wide open water nearby."),
                -- TRANSLATORS: Note helptext for a Frisian production site: Shipyard, part 2
                pgettext("building", "Roads and trees along the shoreline block access to water."),
             }

--- a/data/tribes/initialization/frisians/units.lua
+++ b/data/tribes/initialization/frisians/units.lua
@@ -1612,8 +1612,12 @@ wl.Descriptions():new_tribe {
             lore_author = pgettext("frisians_building", "A hunter admiring a fisher"),
             -- TRANSLATORS: Purpose helptext for a Frisian production site: Fisher's House
             purpose = pgettext("frisians_building", "Fishes on the coast near the fisher’s house."),
-            -- TRANSLATORS: Note helptext for a Frisian production site: Fisher's House
-            note = pgettext("frisians_building", "The fisher’s house needs water full of fish within the work area."),
+            note = {
+               -- TRANSLATORS: Note helptext for a Frisian production site: Fisher's House, part 1
+               pgettext("frisians_building", "The fisher’s house needs water full of fish within the work area."),
+               -- TRANSLATORS: Note helptext for a Frisian production site: Fisher's House, part 2
+               pgettext("frisians_building", "Roads and trees along the shoreline block fishing."),
+            }
             -- TRANSLATORS: Performance helptext for a Frisian production site: Fisher's House
             performance = pgettext("frisians_building", "The fisher pauses %s before going to work again."):bformat(format_seconds(16))
          }
@@ -2161,8 +2165,12 @@ wl.Descriptions():new_tribe {
          helptexts = {
             -- TRANSLATORS: Purpose helptext for a Frisian production site: Ferry Yard
             purpose = pgettext("building", "Builds ferries."),
-            -- TRANSLATORS: Note helptext for a Frisian production site: Ferry Yard
-            note = pgettext("building", "Needs water nearby.")
+            note = {
+               -- TRANSLATORS: Note helptext for a Frisian production site: Ferry Yard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for an Frisian production site: Ferry Yard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
       {
@@ -2173,7 +2181,13 @@ wl.Descriptions():new_tribe {
             -- TRANSLATORS: Lore author helptext for a Frisian production site: Shipyard
             lore_author = pgettext("frisians_building", "A shipwright who only constructed toy ships after being chid that his ships were too small"),
             -- TRANSLATORS: Purpose helptext for a Frisian production site: Shipyard
-            purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports.")
+            purpose = pgettext("building", "Constructs ships that are used for overseas colonization and for trading between ports."),
+            note = {
+               -- TRANSLATORS: Note helptext for a Frisian production site: Shipyard, part 1
+               pgettext("building", "Needs water nearby."),
+               -- TRANSLATORS: Note helptext for a Frisian production site: Shipyard, part 2
+               pgettext("building", "Roads and trees along the shoreline block access to water."),
+            }
          }
       },
       {

--- a/data/tribes/initialization/frisians/units.lua
+++ b/data/tribes/initialization/frisians/units.lua
@@ -1617,7 +1617,7 @@ wl.Descriptions():new_tribe {
                pgettext("frisians_building", "The fisher’s house needs water full of fish within the work area."),
                -- TRANSLATORS: Note helptext for a Frisian production site: Fisher's House, part 2
                pgettext("frisians_building", "Roads and trees along the shoreline block fishing."),
-            }
+            },
             -- TRANSLATORS: Performance helptext for a Frisian production site: Fisher's House
             performance = pgettext("frisians_building", "The fisher pauses %s before going to work again."):bformat(format_seconds(16))
          }


### PR DESCRIPTION
**Type of change**
Enhancement of help text

**Issue(s) closed**
improves #1187

**Rational**
Many new players find out that 

**New behavior**
Extend help texts of
- fisher's hut (including Amazones hunter-gatherer)
- ferry yard
- ship yard
- water gatherer

**Additional context**
The text about roads and trees is inspired by this text:
https://github.com/widelands/widelands/blob/241283e71bd360ebd1f8457d7f2cdd17a967d596/data/campaigns/tutorial03_seafaring.wmf/scripting/texts.lua#L87

some related discussions:
https://www.widelands.org/forum/topic/5807/
https://www.widelands.org/forum/topic/2788/
https://www.widelands.org/forum/topic/5698/?page=1#post-39955