### PR TITLE
Add display selection to graphics options

### DIFF
--- a/src/graphic/graphic.cc
+++ b/src/graphic/graphic.cc
@@ -185,6 +185,14 @@ int Graphic::get_display_at(int x, int y) const {
 	return -1;
 }
 
+void Graphic::move_to_display(int display) {
+	if (display < 0 || display >= SDL_GetNumVideoDisplays()) {
+		return;
+	}
+
+	SDL_SetWindowPosition(sdl_window_, SDL_WINDOWPOS_CENTERED_DISPLAY(display), SDL_WINDOWPOS_CENTERED_DISPLAY(display));
+}
+
 /**
  * Return the screen x resolution
  */
@@ -267,19 +275,37 @@ int Graphic::max_texture_size_for_font_rendering() const {
 #endif
 }
 
+int Graphic::get_display() const {
+	int x;
+	int y;
+	int w;
+	int h;
+	SDL_GetWindowPosition(sdl_window_, &x, &y);
+	SDL_GetWindowSize(sdl_window_, &w, &h);
+	return get_display_at(x + w / 2, y + h / 2);
+}
+
 bool Graphic::maximized() const {
 	uint32_t flags = SDL_GetWindowFlags(sdl_window_);
 	return (flags & SDL_WINDOW_MAXIMIZED) != 0u;
 }
 
-void Graphic::set_maximized(const bool to_maximize) {
+void Graphic::set_maximized(const bool to_maximize, int to_display) {
 	window_mode_maximized_ = to_maximize;
-	if (fullscreen() || maximized() == to_maximize) {
+	int display = get_display();
+	if (to_display < 0) {
+		to_display = display;
+	}
+	if (fullscreen() || (maximized() == to_maximize && display == to_display)) {
 		return;
 	}
 	if (to_maximize) {
 		// Maximizing only works if the window is resizable.
 		SDL_SetWindowResizable(sdl_window_, SDL_TRUE);
+		if (display != to_display) {
+			SDL_RestoreWindow(sdl_window_);
+			move_to_display(to_display);
+		}
 		SDL_MaximizeWindow(sdl_window_);
 	} else {
 		// Avoid glitches. See the comment in set_window_size().
@@ -294,8 +320,12 @@ bool Graphic::fullscreen() const {
 	       ((flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0u);
 }
 
-void Graphic::set_fullscreen(const bool value) {
-	if (value == fullscreen()) {
+void Graphic::set_fullscreen(const bool value, int to_display) {
+	int display = get_display();
+	if (to_display < 0) {
+		to_display = display;
+	}
+	if (value == fullscreen() && display == to_display) {
 		return;
 	}
 
@@ -306,6 +336,12 @@ void Graphic::set_fullscreen(const bool value) {
 	// SDL will resize the window for us.
 	if (value) {
 		window_mode_maximized_ = maximized();
+		if (display != to_display) {
+			SDL_SetWindowFullscreen(sdl_window_, 0);
+			SDL_SetWindowResizable(sdl_window_, SDL_TRUE);
+			SDL_RestoreWindow(sdl_window_);
+			move_to_display(to_display);
+		}
 		SDL_SetWindowFullscreen(sdl_window_, SDL_WINDOW_FULLSCREEN_DESKTOP);
 	} else {
 		SDL_SetWindowFullscreen(sdl_window_, 0);

--- a/src/graphic/graphic.cc
+++ b/src/graphic/graphic.cc
@@ -106,9 +106,8 @@ void Graphic::initialize(const TraceGl& trace_gl,
 #ifdef RESIZABLE_WINDOW
 	window_flags |= SDL_WINDOW_RESIZABLE;
 #endif
-	sdl_window_ =
-	   SDL_CreateWindow("Widelands Window", window_x, window_y,
-	                    window_mode_width_, window_mode_height_, window_flags);
+	sdl_window_ = SDL_CreateWindow("Widelands Window", window_x, window_y, window_mode_width_,
+	                               window_mode_height_, window_flags);
 	SDL_SetWindowMinimumSize(sdl_window_, kMinimumResolutionW, kMinimumResolutionH);
 
 	GLint max;
@@ -177,8 +176,8 @@ Graphic::~Graphic() {
 int Graphic::get_display_at(int x, int y) const {
 	for (int i = 0; i < SDL_GetNumVideoDisplays(); ++i) {
 		SDL_Rect r;
-		if (SDL_GetDisplayBounds(i, &r) == 0 &&
-			r.x <= x && x < r.x + r.w && r.y <= y && y < r.y + r.h) {
+		if (SDL_GetDisplayBounds(i, &r) == 0 && r.x <= x && x < r.x + r.w && r.y <= y &&
+		    y < r.y + r.h) {
 			return i;
 		}
 	}
@@ -190,7 +189,8 @@ void Graphic::move_to_display(int display) {
 		return;
 	}
 
-	SDL_SetWindowPosition(sdl_window_, SDL_WINDOWPOS_CENTERED_DISPLAY(display), SDL_WINDOWPOS_CENTERED_DISPLAY(display));
+	SDL_SetWindowPosition(sdl_window_, SDL_WINDOWPOS_CENTERED_DISPLAY(display),
+	                      SDL_WINDOWPOS_CENTERED_DISPLAY(display));
 }
 
 /**

--- a/src/graphic/graphic.h
+++ b/src/graphic/graphic.h
@@ -69,12 +69,13 @@ public:
 	[[nodiscard]] int get_window_mode_xres() const;
 	[[nodiscard]] int get_window_mode_yres() const;
 
+	[[nodiscard]] int get_display() const;
 	[[nodiscard]] bool maximized() const;
-	void set_maximized(bool);
+	void set_maximized(bool, int to_display = -1);
 
 	// Changes the window to be fullscreen or not.
 	[[nodiscard]] bool fullscreen() const;
-	void set_fullscreen(bool);
+	void set_fullscreen(bool, int to_display = -1);
 
 	RenderTarget* get_render_target();
 	void refresh();
@@ -89,6 +90,7 @@ public:
 
 private:
 	[[nodiscard]] int get_display_at(int x, int y) const;
+	void move_to_display(int display);
 
 	// Set the window size. Use this instead of calling SDL_SetWindowSize directly.
 	void set_window_size(int w, int h);

--- a/src/graphic/graphic.h
+++ b/src/graphic/graphic.h
@@ -53,6 +53,7 @@ public:
 	// 'Gl::initialize'.
 	enum class TraceGl { kNo, kYes };
 	void initialize(const TraceGl& trace_gl,
+	                int display,
 	                int window_mode_w,
 	                int window_mode_height,
 	                bool fullscreen,
@@ -87,6 +88,8 @@ public:
 	void screenshot(const std::string& fname);
 
 private:
+	[[nodiscard]] int get_display_at(int x, int y) const;
+
 	// Set the window size. Use this instead of calling SDL_SetWindowSize directly.
 	void set_window_size(int w, int h);
 

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -929,9 +929,10 @@ void OptionsCtrl::handle_menu() {
 	MenuTarget i = opt_dialog_->run<MenuTarget>();
 	if (i != MenuTarget::kBack) {
 		save_options();
-		g_gr->set_fullscreen(opt_dialog_->get_values().fullscreen);
+		int display = opt_dialog_->get_values().display;
+		g_gr->set_fullscreen(opt_dialog_->get_values().fullscreen, display);
 		if (opt_dialog_->get_values().maximized) {
-			g_gr->set_maximized(true);
+			g_gr->set_maximized(true, display);
 		} else if (!opt_dialog_->get_values().fullscreen && !opt_dialog_->get_values().maximized) {
 			g_gr->change_resolution(
 			   opt_dialog_->get_values().xres, opt_dialog_->get_values().yres, true);

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -149,16 +149,16 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
                           UI::PanelStyle::kFsMenu,
                           UI::ButtonStyle::kFsMenuMenu),
      display_dropdown_(&box_interface_vbox_,
-                          "dropdown_display",
-                          0,
-                          0,
-                          100,  // 100 is arbitrary, will be resized in layout().
-                          50,
-                          24,
-                          _("Display"),
-                          UI::DropdownType::kTextual,
-                          UI::PanelStyle::kFsMenu,
-                          UI::ButtonStyle::kFsMenuMenu),
+                       "dropdown_display",
+                       0,
+                       0,
+                       100,  // 100 is arbitrary, will be resized in layout().
+                       50,
+                       24,
+                       _("Display"),
+                       UI::DropdownType::kTextual,
+                       UI::PanelStyle::kFsMenu,
+                       UI::ButtonStyle::kFsMenuMenu),
 
      inputgrab_(&box_interface_,
                 UI::PanelStyle::kFsMenu,
@@ -565,8 +565,8 @@ void Options::add_displays(const OptionsCtrl::OptionsStruct& opt) {
 		if (SDL_GetDisplayBounds(i, &r) == 0) {
 			display_dropdown_.add(
 			   /** TRANSLATORS: Display index and virtual coordinates, e.g, '#0 (0, 0, 1920, 1080)'*/
-			  format(_("#%1% (%2%, %3%, %4%, %5%)"), i, r.x, r.y, r.w, r.h),
-			  i, nullptr, opt.display == i);
+			   format(_("#%1% (%2%, %3%, %4%, %5%)"), i, r.x, r.y, r.w, r.h), i, nullptr,
+			   opt.display == i);
 		}
 	}
 	if (!display_dropdown_.has_selection()) {
@@ -633,8 +633,8 @@ void Options::layout() {
 		language_dropdown_.set_height(tabs_.get_h() - language_dropdown_.get_y() - buth -
 		                              3 * kPadding);
 		translation_info_.set_size(
-		   language_dropdown_.get_w(),
-		   language_dropdown_.get_h() + resolution_dropdown_.get_h() + display_dropdown_.get_h() + 2 * kPadding);
+		   language_dropdown_.get_w(), language_dropdown_.get_h() + resolution_dropdown_.get_h() +
+		                                  display_dropdown_.get_h() + 2 * kPadding);
 		sb_maxfps_.set_unit_width(unit_w);
 		sb_maxfps_.set_desired_size(tab_panel_width, sb_maxfps_.get_h());
 

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -896,9 +896,10 @@ void OptionsCtrl::handle_menu() {
 	MenuTarget i = opt_dialog_->run<MenuTarget>();
 	if (i != MenuTarget::kBack) {
 		save_options();
-		g_gr->set_fullscreen(opt_dialog_->get_values().fullscreen);
+		int display = opt_dialog_->get_values().display;
+		g_gr->set_fullscreen(opt_dialog_->get_values().fullscreen, display);
 		if (opt_dialog_->get_values().maximized) {
-			g_gr->set_maximized(true);
+			g_gr->set_maximized(true, display);
 		} else if (!opt_dialog_->get_values().fullscreen && !opt_dialog_->get_values().maximized) {
 			g_gr->change_resolution(
 			   opt_dialog_->get_values().xres, opt_dialog_->get_values().yres, true);

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -50,6 +50,8 @@ namespace {
 constexpr int kDropdownFullscreen = -2;
 constexpr int kDropdownMaximized = -1;
 
+constexpr int kDropdownFollowMouse = -1;
+
 // Locale identifiers can look like this: ca_ES@valencia.UTF-8
 // The contents of 'selected_locale' will be changed to match the 'current_locale'
 void find_selected_locale(std::string* selected_locale, const std::string& current_locale) {
@@ -144,6 +146,17 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
                           50,
                           24,
                           _("Window Size"),
+                          UI::DropdownType::kTextual,
+                          UI::PanelStyle::kFsMenu,
+                          UI::ButtonStyle::kFsMenuMenu),
+     display_dropdown_(&box_interface_vbox_,
+                          "dropdown_display",
+                          0,
+                          0,
+                          100,  // 100 is arbitrary, will be resized in layout().
+                          50,
+                          24,
+                          _("Display"),
                           UI::DropdownType::kTextual,
                           UI::PanelStyle::kFsMenu,
                           UI::ButtonStyle::kFsMenuMenu),
@@ -408,6 +421,7 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	// Interface
 	box_interface_vbox_.add(&language_dropdown_, UI::Box::Resizing::kFullSize);
 	box_interface_vbox_.add(&resolution_dropdown_, UI::Box::Resizing::kFullSize);
+	box_interface_vbox_.add(&display_dropdown_, UI::Box::Resizing::kFullSize);
 	// TODO(tothxa): Replace with infinite space if box layouting quirks get fixed
 	box_interface_vbox_.add(&translation_padding_, UI::Box::Resizing::kFullSize);
 	// box_interface_vbox_.add_inf_space();
@@ -510,6 +524,7 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 
 	// Fill in data
 	// Interface options
+	add_displays(opt);
 	add_screen_resolutions(opt);
 
 	sdl_cursor_.set_state(opt.sdl_cursor);
@@ -556,6 +571,25 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	}
 	initialization_complete();
 }
+
+void Options::add_displays(const OptionsCtrl::OptionsStruct& opt) {
+	display_dropdown_.add(
+	   /** TRANSLATORS: Entry in the display selection dropdown */
+	   _("Follow mouse"), kDropdownFollowMouse, nullptr, opt.display < 0);
+	for (int i = 0; i < SDL_GetNumVideoDisplays(); ++i) {
+		SDL_Rect r;
+		if (SDL_GetDisplayBounds(i, &r) == 0) {
+			display_dropdown_.add(
+			   /** TRANSLATORS: Display index and virtual coordinates, e.g, '#0 (0, 0, 1920, 1080)'*/
+			  format(_("#%1% (%2%, %3%, %4%, %5%)"), i, r.x, r.y, r.w, r.h),
+			  i, nullptr, opt.display == i);
+		}
+	}
+	if (!display_dropdown_.has_selection()) {
+		display_dropdown_.select(kDropdownFollowMouse);
+	}
+}
+
 void Options::add_screen_resolutions(const OptionsCtrl::OptionsStruct& opt) {
 	ScreenResolution current_res = {g_gr->get_window_mode_xres(), g_gr->get_window_mode_yres()};
 
@@ -615,7 +649,7 @@ void Options::layout() {
 		language_dropdown_.set_height(tabs_.get_h() - language_dropdown_.get_y() - buth -
 		                              3 * kPadding);
 
-		const int min_h = language_dropdown_.get_h() + resolution_dropdown_.get_h() + 2 * kPadding;
+		const int min_h = language_dropdown_.get_h() + resolution_dropdown_.get_h() + display_dropdown_.get_h() + 3 * kPadding;
 		const int half_w = (tab_panel_width - 3 * kPadding) / 2;
 
 		// Make initial value big enough to avoid needing a scrollbar
@@ -834,6 +868,9 @@ OptionsCtrl::OptionsStruct Options::get_values() {
 			os_.yres = res.yres;
 		}
 	}
+	if (display_dropdown_.has_selection()) {
+		os_.display = display_dropdown_.get_selected();
+	}
 	os_.sdl_cursor = sdl_cursor_.get_state();
 	os_.tooltip_accessibility_mode = tooltip_accessibility_mode_.get_state();
 
@@ -911,6 +948,7 @@ void OptionsCtrl::handle_menu() {
 OptionsCtrl::OptionsStruct OptionsCtrl::options_struct(uint32_t active_tab) {
 	OptionsStruct opt;
 	// Interface options
+	opt.display = opt_section_.get_int("display", kDropdownFollowMouse);
 	opt.xres = opt_section_.get_int("xres", kDefaultResolutionW);
 	opt.yres = opt_section_.get_int("yres", kDefaultResolutionH);
 	opt.maximized = opt_section_.get_bool("maximized", false);
@@ -960,6 +998,7 @@ void OptionsCtrl::save_options() {
 	OptionsCtrl::OptionsStruct opt = opt_dialog_->get_values();
 
 	// Interface options
+	opt_section_.set_int("display", opt.display);
 	opt_section_.set_int("xres", opt.xres);
 	opt_section_.set_int("yres", opt.yres);
 	opt_section_.set_bool("maximized", opt.maximized);

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -44,6 +44,7 @@ public:
 	struct OptionsStruct {
 
 		// Interface options
+		int32_t display;
 		int32_t xres;
 		int32_t yres;
 		bool maximized;
@@ -119,6 +120,7 @@ private:
 	void add_languages_to_list(const std::string& current_locale);
 	void update_language_stats();
 
+	void add_displays(const OptionsCtrl::OptionsStruct& opt);
 	void add_screen_resolutions(const OptionsCtrl::OptionsStruct& opt);
 
 	// Saves the options and closes the window
@@ -155,6 +157,7 @@ private:
 	// Interface options
 	UI::Dropdown<std::string> language_dropdown_;
 	UI::Dropdown<ScreenResolution> resolution_dropdown_;
+	UI::Dropdown<int> display_dropdown_;
 	UI::Checkbox sdl_cursor_;
 	UI::Checkbox tooltip_accessibility_mode_;
 	UI::MultilineTextarea translation_info_;

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -44,6 +44,7 @@ public:
 	struct OptionsStruct {
 
 		// Interface options
+		int32_t display;
 		int32_t xres;
 		int32_t yres;
 		bool maximized;
@@ -119,6 +120,7 @@ private:
 	void add_languages_to_list(const std::string& current_locale);
 	void update_language_stats();
 
+	void add_displays(const OptionsCtrl::OptionsStruct& opt);
 	void add_screen_resolutions(const OptionsCtrl::OptionsStruct& opt);
 
 	// Saves the options and closes the window
@@ -155,6 +157,7 @@ private:
 	// Interface options
 	UI::Dropdown<std::string> language_dropdown_;
 	UI::Dropdown<ScreenResolution> resolution_dropdown_;
+	UI::Dropdown<int> display_dropdown_;
 	UI::Checkbox inputgrab_;
 	UI::Checkbox sdl_cursor_;
 	UI::SpinBox sb_maxfps_;

--- a/src/website/website_common.cc
+++ b/src/website/website_common.cc
@@ -46,7 +46,7 @@ void initialize() {
 	// We don't really need graphics here, but we will get error messages
 	// when they aren't initialized
 	g_gr = new Graphic();
-	g_gr->initialize(Graphic::TraceGl::kNo, 1, 1, false, false);
+	g_gr->initialize(Graphic::TraceGl::kNo, 0, 1, 1, false, false);
 }
 
 // Cleanup before program end

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -442,9 +442,9 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 
 	g_gr->initialize(
 	   get_config_bool("debug_gl_trace", false) ? Graphic::TraceGl::kYes : Graphic::TraceGl::kNo,
-	   get_config_int("display", -1),
-	   get_config_int("xres", kDefaultResolutionW), get_config_int("yres", kDefaultResolutionH),
-	   get_config_bool("fullscreen", false), get_config_bool("maximized", false));
+	   get_config_int("display", -1), get_config_int("xres", kDefaultResolutionW),
+	   get_config_int("yres", kDefaultResolutionH), get_config_bool("fullscreen", false),
+	   get_config_bool("maximized", false));
 
 	g_mouse_cursor = new MouseCursor();
 	g_mouse_cursor->initialize(get_config_bool("sdl_cursor", true));

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -454,6 +454,7 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 
 	g_gr->initialize(
 	   get_config_bool("debug_gl_trace", false) ? Graphic::TraceGl::kYes : Graphic::TraceGl::kNo,
+	   get_config_int("display", -1),
 	   get_config_int("xres", kDefaultResolutionW), get_config_int("yres", kDefaultResolutionH),
 	   get_config_bool("fullscreen", false), get_config_bool("maximized", false));
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -442,6 +442,7 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 
 	g_gr->initialize(
 	   get_config_bool("debug_gl_trace", false) ? Graphic::TraceGl::kYes : Graphic::TraceGl::kNo,
+	   get_config_int("display", -1),
 	   get_config_int("xres", kDefaultResolutionW), get_config_int("yres", kDefaultResolutionH),
 	   get_config_bool("fullscreen", false), get_config_bool("maximized", false));
 


### PR DESCRIPTION
**Type of change**
New feature

**New behavior**
* New setting "display" in the options, next to the "window size".
* On systems with multiple displays, this specifies:
    * The display to show the main window on, when widelands starts. ("preferred display")
    * The display to use, if fullscreen is enabled.
* Possible values for the setting are "follow mouse" or selecting a specific display.
    * The default "Follow mouse" means: when starting widelands, the main window will be shown on the display, the mouse pointer is on.

**Screenshots**
![image](https://github.com/widelands/widelands/assets/23150643/a57faf94-da23-4820-9cb0-65180c020d10)

