### PR TITLE
Do not hide Add-On comment text during layout

### DIFF
--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -133,19 +133,6 @@ void CommentRow::update_edit_enabled() {
 	layout();
 }
 
-void CommentRow::layout() {
-	if (layouting_) {
-		return;
-	}
-	layouting_ = true;
-
-	text_.set_visible(false);  // Prevent the text from taking up all available space
-	UI::Box::layout();
-	text_.set_visible(true);
-
-	layouting_ = false;
-}
-
 /* CommentEditor implementation */
 
 CommentEditor::CommentEditor(AddOnsCtrl& ctrl,
@@ -629,8 +616,6 @@ RemoteInteractionWindow::RemoteInteractionWindow(AddOnsCtrl& parent,
      box_votes_(&tabs_, UI::PanelStyle::kFsMenu, "votes_box", 0, 0, UI::Box::Vertical),
      voting_stats_(
         &box_votes_, UI::PanelStyle::kFsMenu, "voting_stats_box", 0, 0, UI::Box::Horizontal),
-     box_comment_rows_placeholder_(
-        &box_comments_, UI::PanelStyle::kFsMenu, "comment_rows_placeholder", 0, 0, 0, 0),
      comments_header_(&box_comments_,
                       "comments_header",
                       0,
@@ -754,7 +739,7 @@ RemoteInteractionWindow::RemoteInteractionWindow(AddOnsCtrl& parent,
 	box_comment_rows_.set_force_scrolling(true);
 	box_comments_.add(&comments_header_, UI::Box::Resizing::kFullSize);
 	box_comments_.add_space(kRowButtonSpacing);
-	box_comments_.add(&box_comment_rows_placeholder_, UI::Box::Resizing::kExpandBoth);
+	box_comments_.add(&box_comment_rows_, UI::Box::Resizing::kExpandBoth);
 	box_comments_.add_space(kRowButtonSpacing);
 	box_comments_.add(&write_comment_, UI::Box::Resizing::kFullSize);
 
@@ -856,9 +841,7 @@ void RemoteInteractionWindow::layout() {
 		admin_action_.set_pos(Vector2i(
 		   login_button_.get_x() - admin_action_.get_w() - kRowButtonSpacing, login_button_.get_y()));
 
-		box_comment_rows_.set_pos(box_comment_rows_placeholder_.get_pos());
-		box_comment_rows_.set_size(
-		   box_comment_rows_placeholder_.get_w(), box_comment_rows_placeholder_.get_h());
+		box_comment_rows_.set_desired_size(0,0);
 	}
 	UI::Window::layout();
 }

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -841,7 +841,7 @@ void RemoteInteractionWindow::layout() {
 		admin_action_.set_pos(Vector2i(
 		   login_button_.get_x() - admin_action_.get_w() - kRowButtonSpacing, login_button_.get_y()));
 
-		box_comment_rows_.set_desired_size(0,0);
+		box_comment_rows_.set_desired_size(0, 0);
 	}
 	UI::Window::layout();
 }

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -133,6 +133,17 @@ void CommentRow::update_edit_enabled() {
 	layout();
 }
 
+void CommentRow::layout() {
+	UI::Box::layout();
+	if (layouting_) {
+		return;
+	}
+	// Prevent stack overflow through recursive call of layout()
+	layouting_ = true;
+	text_.set_desired_size(0, 0);
+	layouting_ = false;
+}
+
 /* CommentEditor implementation */
 
 CommentEditor::CommentEditor(AddOnsCtrl& ctrl,

--- a/src/ui_fsmenu/addons/remote_interaction.h
+++ b/src/ui_fsmenu/addons/remote_interaction.h
@@ -54,7 +54,6 @@ private:
 	AddOnsCtrl& ctrl_;
 	std::shared_ptr<AddOns::AddOnInfo> info_;
 	const size_t& index_;
-	bool layouting_{false};
 	UI::MultilineTextarea text_;
 	UI::Box buttons_;
 	UI::Button edit_, delete_;

--- a/src/ui_fsmenu/addons/remote_interaction.h
+++ b/src/ui_fsmenu/addons/remote_interaction.h
@@ -49,7 +49,6 @@ public:
 	           const size_t& index);
 
 	void update_edit_enabled();
-	void layout() override;
 
 private:
 	AddOnsCtrl& ctrl_;
@@ -142,7 +141,6 @@ private:
 	UI::TabPanel tabs_;
 	UI::Box box_comments_, box_comment_rows_, box_screenies_, box_screenies_buttons_, box_votes_,
 	   voting_stats_;
-	UI::Panel box_comment_rows_placeholder_;
 
 	UI::MultilineTextarea comments_header_;
 	std::list<std::unique_ptr<CommentRow>> comment_rows_;

--- a/src/ui_fsmenu/addons/remote_interaction.h
+++ b/src/ui_fsmenu/addons/remote_interaction.h
@@ -49,11 +49,13 @@ public:
 	           const size_t& index);
 
 	void update_edit_enabled();
+	void layout() override;
 
 private:
 	AddOnsCtrl& ctrl_;
 	std::shared_ptr<AddOns::AddOnInfo> info_;
 	const size_t& index_;
+	bool layouting_{false};
 	UI::MultilineTextarea text_;
 	UI::Box buttons_;
 	UI::Button edit_, delete_;


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6031 

**How it works**
Invisible panels do not get variable depth assigned anymore, so it does not make sense to hide the text area during layout.
Also the `box_comment_rows_placeholder_` does not seem to be required at all. Please check whether scrolling with more comments is still working, in the official Add-Ons there are not enough yet to require scrolling.

**Possible regressions**
There may be other layouts not correct, even though I tried to go through them, but the Add-On windows are quite complex and numerous.
