### PR TITLE
Fix false positives in add-ons packager change detection

### DIFF
--- a/src/ui_fsmenu/addons/packager.cc
+++ b/src/ui_fsmenu/addons/packager.cc
@@ -316,26 +316,25 @@ void AddOnsPackager::addon_selected() {
 		return;
 	}
 
-	box_right_subbox_header_hbox_.set_visible(true);
-
 	update_in_progress_ = true;
+
+	box_right_subbox_header_hbox_.set_visible(true);
 	name_.set_text(selected->get_descname());
 	descr_.set_text(selected->get_description());
 	author_.set_text(selected->get_author());
 	version_.set_text(selected->get_version());
 	min_wl_version_.set_text(selected->get_min_wl_version());
 	max_wl_version_.set_text(selected->get_max_wl_version());
-	update_in_progress_ = false;
 
-	if (addon_boxes_.count(selected->get_category()) == 0) {
-		return;
+	if (auto it = addon_boxes_.find(selected->get_category()); it != addon_boxes_.end()) {
+		AddOnsPackagerBox* box = it->second.get();
+		box_right_addon_specific_.add(box, UI::Box::Resizing::kExpandBoth);
+		box->set_visible(true);
+		box->load_addon(selected);
+		layout();
 	}
 
-	AddOnsPackagerBox* box = addon_boxes_[selected->get_category()].get();
-	box_right_addon_specific_.add(box, UI::Box::Resizing::kExpandBoth);
-	box->set_visible(true);
-	box->load_addon(selected);
-	layout();
+	update_in_progress_ = false;
 }
 
 void AddOnsPackager::current_addon_edited() {


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes a bug reported in https://www.widelands.org/forum/topic/5812

**To reproduce**
1. Install a few map set add-ons (if you don't have some already)
2. Open the add-ons packager
3. Select a few map add-ons in the left column without modifying them
4. Close the packager. Every add-on you selected will be marked as having changes.

**New behavior**
Give the UI-self-update protection variable a bigger scope so selecting an add-on doesn't mark it as changed.