### PR TITLE
Fix cornercase hang in ship healthbar drawing calculation

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2363,7 +2363,7 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 		dst->brighten_rect(energy_outer, brighten_factor);
 
 		energy_inner.w = kInnerHealthBarWidth * scale;
-		energy_inner.h = floorf(bonus / kBonusPerBar) * 3 * scale;
+		energy_inner.h = static_cast<int>(bonus / kBonusPerBar) * 3 * scale;
 		dst->fill_rect(energy_inner, color);
 
 		if (const unsigned remainder = bonus % kBonusPerBar; remainder != 0) {

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2368,14 +2368,13 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 
 		if (const unsigned remainder = bonus % kBonusPerBar; remainder != 0) {
 			assert(remainder < kBonusPerBar);
-			health_width = kInnerHealthBarWidth * remainder / kBonusPerBar;
-
 			energy_inner.y += energy_inner.h;
 			energy_complement.y = energy_inner.y;
 
-			energy_inner.w = health_width * scale;
-			energy_complement.x = energy_inner.x + health_width * scale;
-			energy_complement.w = (kInnerHealthBarWidth - health_width) * scale;
+			health_width = kInnerHealthBarWidth * remainder * scale / kBonusPerBar;
+			energy_complement.x = energy_inner.x + health_width;
+			energy_complement.w = energy_inner.w - health_width;
+			energy_inner.w = health_width;
 			energy_inner.h = energy_complement.h;
 
 			dst->fill_rect(energy_inner, color);

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2316,7 +2316,7 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 
 	// The frame gets a slight tint of player color
 	Recti energy_outer(draw_position - Vector2i(kShipHealthBarWidth, 0) * scale,
-	                         kShipHealthBarWidth * 2 * scale, 5 * scale);
+	                   kShipHealthBarWidth * 2 * scale, 5 * scale);
 	dst->fill_rect(energy_outer, color);
 	dst->brighten_rect(energy_outer, brighten_factor);
 
@@ -2360,7 +2360,8 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 		energy_complement.y += 4 * scale;
 
 		energy_outer.y += 7 * scale;
-		energy_outer.h = ((bonus / kBonusPerBar + (bonus % kBonusPerBar != 0 ? 1 : 0)) * 3 + 2) * scale;
+		energy_outer.h =
+		   ((bonus / kBonusPerBar + (bonus % kBonusPerBar != 0 ? 1 : 0)) * 3 + 2) * scale;
 		dst->fill_rect(energy_outer, color);
 		dst->brighten_rect(energy_outer, brighten_factor);
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2352,6 +2352,7 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 	constexpr unsigned kBonusIconSize = 6;
 	constexpr unsigned kMaxRows = 16;
 	const unsigned bonus = get_sea_attack_soldier_bonus(egbase);
+	assert(bonus < 10000);  // Sanity check
 	if (bonus > 0) {
 		unsigned n_cols = std::min(2 * kShipHealthBarWidth / kBonusIconSize, bonus);
 		unsigned n_rows = std::min(kMaxRows - 1, bonus / n_cols);
@@ -2361,7 +2362,13 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 		while (n_cols * n_rows < bonus) {
 			++n_cols;
 		}
+		while (n_cols * (n_rows - 1) > bonus) {
+			--n_rows;
+		}
 		const unsigned last_row_cols = n_cols - (n_cols * n_rows - bonus);
+		assert(n_rows <= kMaxRows);
+		assert(last_row_cols <= n_cols);
+		assert(n_cols < 1000);  // Sanity check
 
 		for (unsigned row = 0; row < n_rows; ++row) {
 			const unsigned cols_in_row = (row + 1 < n_rows ? n_cols : last_row_cols);

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2360,8 +2360,7 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 		energy_complement.y += 4 * scale;
 
 		energy_outer.y += 7 * scale;
-		energy_outer.h =
-		   ((bonus / kBonusPerBar + (bonus % kBonusPerBar != 0 ? 1 : 0)) * 3 + 2) * scale;
+		energy_outer.h = (ceilf(static_cast<float>(bonus) / kBonusPerBar) * 3 + 2) * scale;
 		dst->fill_rect(energy_outer, color);
 		dst->brighten_rect(energy_outer, brighten_factor);
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes https://www.widelands.org/forum/topic/5814/

**To reproduce**
1. Load the savegame from the linked forum post.
2. Game runs very very slowly.

**New behavior**
The problem was an overflow in unsigned integer arithmetic during rendering the soldier bonus icons of a ship's healthbar. 
With very specific amounts of icons, the code that tries to optimize the distribution into s nice shape of rows and columns may end up with one or more empty rows at the bottom, leading to an overflow.
I fixed the bug by removing empty rows and added some sanity checking asserts.