### PR TITLE
smaller changes in po files by script removing line numbers

### DIFF
--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -62,6 +62,8 @@ set -x
 # Force-pull translations because some would get skipped accidentally
 tx pull -fa
 
+git diff --diff-filter=MA --name-only '*.po' | xargs -r -d '\n' -- sed -i '/^#: / s/:[0-9]*$//' # remove source line numbers from po files
+
 # Update authors file
 python3 utils/update_authors.py
 if [ $? -eq 0 ] ; then


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
Enhancement

**Issue(s) closed**
none -

**Is your feature request related to a problem? Please describe.**
Looking at the history of po files or a commit of translation (see [ar.po in 41ecfa93](/widelands/widelands/commit/3b56cc4094a1d89e18a9c02c97b089dfa4fa1516#diff-86aeb00a79ac1d1a7abdb53dd1abfeec09f716970145055e6032ce1d9964e43f)) shows many files only changing line numbers (plus the pot-date).

**Describe the solution you'd like**
I suggest to remove the line numbers from po files (but keep them in pot files).
Translators still see the location on transifex, no change for them.
If somebody wants to translate locally, the po files with location can be downloaded from transifex or generated with msgmerge xx.pot

**Describe alternatives you've considered**
`tc pull ...` has no argument to fetch the files without locations.

The file path could be deleted as well (as with `msgcat --no-location`).

**Additional context**
`msgcat --add-location=file` also keeps the file only (and msgXXX --add-location), but each file is only listed once

Change of line numbers is still visible in pot files (so 1x).
Translators on transifex will not see any difference.

removes noise from translation, loosely related to #5550

**Implementation steps**
- [x] adapt utils/merge_and_push_translations.sh
- [ ] do the duplicate lines hurt? (When there are several occurrences in one file, the file is listed several times.)
       This is different to `msgcat --add-location=file`.
- [ ] probably remove translation lines from po files in one commit (for less noise later)