### PR TITLE
enhance some documentation

### DIFF
--- a/data/campaigns/emp04.wmf/scripting/tribes/init.lua
+++ b/data/campaigns/emp04.wmf/scripting/tribes/init.lua
@@ -79,7 +79,7 @@
 -- * You will also need to add a ``register.lua`` file that lists the names of all
 --   objects that you are adding or replacing.
 -- * You can also add ``.png`` files to your subdirectories.
--- * Adding helptexts is optional, but will units without a helptext will print a warning on the console.
+-- * Adding helptexts is optional, but units without a helptext will print a warning on the console.
 --
 -- See :ref:`defining_tribe_units` for further details on these files, and :ref:`lua_tribes_tribes_helptexts` on the helptext format.
 

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -4646,7 +4646,7 @@ int LuaMapObject::get_serial(lua_State* L) {
 
          local immovable = wl.Game().map:get_field(20,31).immovable
 
-         -- always check if the immovable still exists
+         -- always check if the immovable was found on the field
          if immovable then
             if immovable.descr.type_name == "warehouse"  -- access MapObjectDescription
                immovable:set_wares("log", 5)


### PR DESCRIPTION
tribes in campains: better sentence, remove superflux "will"
map objects: rephrease sentence to not confuse with attribute `mapobject.exists`