### PR TITLE
Warship soldier capacity setting enhancements

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1111,10 +1111,6 @@ void Ship::kickout_superfluous_soldiers(Game& game) {
 void Ship::warship_command(Game& game,
                            const WarshipCommand cmd,
                            const std::vector<uint32_t>& parameters) {
-	if (get_ship_type() != ShipType::kWarship) {
-		return;
-	}
-
 	switch (cmd) {
 	case WarshipCommand::kSetCapacity: {
 		assert(parameters.size() == 1);
@@ -1127,6 +1123,10 @@ void Ship::warship_command(Game& game,
 
 	case WarshipCommand::kAttack:
 		assert(!parameters.empty());
+		if (get_ship_type() != ShipType::kWarship) {
+			return;
+		}
+
 		if (parameters.size() == 1) {  // Attacking a ship.
 			if (Ship* target = dynamic_cast<Ship*>(game.objects().get_object(parameters.front()));
 			    target != nullptr) {

--- a/src/wui/shipwindow.cc
+++ b/src/wui/shipwindow.cc
@@ -237,8 +237,9 @@ void ShipWindow::set_button_visibility() {
 		return;
 	}
 
-	const bool show_expedition_controls = ship->state_is_expedition() && !ship->is_refitting();
-	const bool is_warship = ship->get_ship_type() == Widelands::ShipType::kWarship;
+	const bool is_refitting = ship->is_refitting();
+	const bool show_expedition_controls = ship->state_is_expedition() && !is_refitting;
+	const bool is_warship = (ship->get_ship_type() == Widelands::ShipType::kWarship) ^ is_refitting;
 
 	display_->set_visible(!is_warship);
 	warship_capacity_control_->set_visible(is_warship);

--- a/src/wui/soldierlist.cc
+++ b/src/wui/soldierlist.cc
@@ -455,10 +455,8 @@ private:
 
 	InteractiveBase& ibase_;
 	Widelands::MapObject& building_or_ship_;
-	const UI::FontStyle font_style_{UI::FontStyle::kWuiLabel};
 	SoldierPanel soldierpanel_;
 	UI::Radiogroup soldier_preference_;
-	UI::Textarea infotext_;
 
 	UI::Panel* soldier_capacity_control_;
 };
@@ -471,8 +469,7 @@ SoldierList::SoldierList(UI::Panel& parent,
      ibase_(ib),
      building_or_ship_(building_or_ship),
 
-     soldierpanel_(*this, ib.egbase(), building_or_ship),
-     infotext_(this, UI::PanelStyle::kWui, "infotext", UI::FontStyle::kWuiLabel) {
+     soldierpanel_(*this, ib.egbase(), building_or_ship) {
 	upcast(Widelands::MilitarySite, ms, &building_or_ship);
 	upcast(Widelands::Warehouse, wh, &building_or_ship);
 	upcast(Widelands::Ship, ship, &building_or_ship);
@@ -480,28 +477,8 @@ SoldierList::SoldierList(UI::Panel& parent,
 	unset_infotext();
 	add(&soldierpanel_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
 
-	add_space(2);
-
-	add(&infotext_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
-
 	soldierpanel_.set_mouseover([this](const Widelands::Soldier* s) { mouseover(s); });
 	soldierpanel_.set_click([this](const Widelands::Soldier* s) { eject(s); });
-
-	// We don't want translators to translate this twice, so it's a bit involved.
-	int w = UI::g_fh
-	           ->render(as_richtext_paragraph(
-	              format("%s "  // We need some extra space to fix bug 724169
-	                     ,
-	                     format(
-	                        /** TRANSLATORS: Health, Attack, Defense, Evade */
-	                        _("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"), 8, 8, 8,
-	                        8, 8, 8, 8, 8)),
-	              font_style_))
-	           ->width();
-	uint32_t maxtextwidth = std::max(
-	   w, UI::g_fh->render(as_richtext_paragraph(_("Click soldier to send away"), font_style_))
-	         ->width());
-	set_min_desired_breadth(maxtextwidth + 4);
 
 	UI::Box* buttons =
 	   new UI::Box(this, UI::PanelStyle::kWui, "buttons_box", 0, 0, UI::Box::Horizontal);
@@ -571,15 +548,15 @@ void SoldierList::mouseover(const Widelands::Soldier* soldier) {
 		return;
 	}
 
-	infotext_.set_text(format(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
-	                          soldier->get_health_level(), soldier->descr().get_max_health_level(),
-	                          soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
-	                          soldier->get_defense_level(), soldier->descr().get_max_defense_level(),
-	                          soldier->get_evade_level(), soldier->descr().get_max_evade_level()));
+	set_tooltip(format(_("HP: %1$u/%2$u  AT: %3$u/%4$u  DE: %5$u/%6$u  EV: %7$u/%8$u"),
+	                   soldier->get_health_level(), soldier->descr().get_max_health_level(),
+	                   soldier->get_attack_level(), soldier->descr().get_max_attack_level(),
+	                   soldier->get_defense_level(), soldier->descr().get_max_defense_level(),
+	                   soldier->get_evade_level(), soldier->descr().get_max_evade_level()));
 }
 
 void SoldierList::unset_infotext() {
-	infotext_.set_text(can_eject() ? _("Click soldier to send away") : "");
+	set_tooltip(can_eject() ? _("Click soldier to send away") : "");
 }
 
 bool SoldierList::can_eject() const {

--- a/src/wui/soldierlist.cc
+++ b/src/wui/soldierlist.cc
@@ -26,7 +26,6 @@
 #include "base/macros.h"
 #include "graphic/font_handler.h"
 #include "graphic/rendertarget.h"
-#include "graphic/text_layout.h"
 #include "logic/map_objects/tribes/building.h"
 #include "logic/map_objects/tribes/militarysite.h"
 #include "logic/map_objects/tribes/ship.h"


### PR DESCRIPTION
**Type of change**
New feature

**Issue(s) closed**
Fixes #5955

**New behavior**
- While a ship is refitting to warship, already allow changing its soldier capacity and preference.
- The "click soldier to send away" info text is far too wide and makes the window take up unnecessarily much space. Show it as a tooltip instead to make the window narrower (also applies to military- and trainingsites).

**Possible regressions**
Ship UI for various ship types and states
