### PR TITLE
Reroute ships on the way to port-under-construction upon port completion

### DIFF
--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -122,6 +122,10 @@ struct Ship : Bob {
 		return destination_coords_;
 	}
 
+	[[nodiscard]] bool get_send_message_at_destination() const {
+		return send_message_at_destination_;
+	}
+
 	// Returns the last visited portdock of this ship or nullptr if there is none or
 	// the last visited was removed.
 	[[nodiscard]] PortDock* get_lastdock(EditorGameBase& egbase) const;

--- a/src/logic/map_objects/tribes/warehouse.cc
+++ b/src/logic/map_objects/tribes/warehouse.cc
@@ -604,7 +604,7 @@ bool Warehouse::init(EditorGameBase& egbase) {
 			              get_position().x, get_position().y);
 		}
 
-		player->remove_detected_port_space(get_position());
+		player->remove_detected_port_space(get_position(), pd);
 	}
 	cleanup_in_progress_ = false;
 	return true;

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -2089,7 +2089,8 @@ bool Player::remove_detected_port_space(const Coords& coords, PortDock* replaced
 				Ship* ship = dynamic_cast<Ship*>(egbase().objects().get_object(serial));
 				if (ship != nullptr &&
 				    ship->get_destination_detected_port_space() == detected_port_spaces_[i].get()) {
-					ship->set_destination(egbase(), replaced_by, false);
+					ship->set_destination(
+					   egbase(), replaced_by, ship->get_send_message_at_destination());
 				}
 			}
 

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -2087,7 +2087,8 @@ bool Player::remove_detected_port_space(const Coords& coords, PortDock* replaced
 		if (detected_port_spaces_[i]->coords == coords) {
 			for (Serial serial : ships()) {
 				Ship* ship = dynamic_cast<Ship*>(egbase().objects().get_object(serial));
-				if (ship != nullptr && ship->get_destination_detected_port_space() == detected_port_spaces_[i].get()) {
+				if (ship != nullptr &&
+				    ship->get_destination_detected_port_space() == detected_port_spaces_[i].get()) {
 					ship->set_destination(egbase(), replaced_by, false);
 				}
 			}

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -2082,9 +2082,16 @@ const DetectedPortSpace& Player::get_detected_port_space(Serial serial) const {
 	throw wexception("Player %u has no detected port space with serial %u", player_number(), serial);
 }
 
-bool Player::remove_detected_port_space(const Coords& coords) {
+bool Player::remove_detected_port_space(const Coords& coords, PortDock* replaced_by) {
 	for (size_t i = 0; i < detected_port_spaces_.size(); ++i) {
 		if (detected_port_spaces_[i]->coords == coords) {
+			for (Serial serial : ships()) {
+				Ship* ship = dynamic_cast<Ship*>(egbase().objects().get_object(serial));
+				if (ship != nullptr && ship->get_destination_detected_port_space() == detected_port_spaces_[i].get()) {
+					ship->set_destination(egbase(), replaced_by, false);
+				}
+			}
+
 			detected_port_spaces_[i] = std::move(detected_port_spaces_.back());
 			detected_port_spaces_.pop_back();
 			return true;

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -584,7 +584,7 @@ public:
 	void detect_port_space(std::unique_ptr<DetectedPortSpace> new_dps);
 	DetectedPortSpace* has_detected_port_space(const Coords& coords);
 	[[nodiscard]] const DetectedPortSpace& get_detected_port_space(Serial serial) const;
-	bool remove_detected_port_space(const Coords& coords);
+	bool remove_detected_port_space(const Coords& coords, PortDock* replaced_by);
 
 	void add_soldier(unsigned h, unsigned a, unsigned d, unsigned e);
 	void remove_soldier(unsigned h, unsigned a, unsigned d, unsigned e);


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6043

**New behavior**
When a `DetectedPortSpace` is replaced with an actual port, reroute any ships currently on the way to that DPS to the newly completed port.