### PR TITLE
Add missing `richtext_escape` for add-ons error message

### DIFF
--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -977,7 +977,7 @@ void AddOnsCtrl::refresh_remotes(const bool showall) {
 		std::string bug = _("a networking bug");
 		std::string err = format(_("Unable to fetch the list of available add-ons from "
 		                           "the server!<br>Error Message: %s"),
-		                         e.what());
+		                         richtext_escape(e.what()));
 		std::shared_ptr<AddOns::AddOnInfo> i = std::make_shared<AddOns::AddOnInfo>();
 		i->unlocalized_descname = title;
 		i->unlocalized_description = err;


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
If the add-ons server sends an error message like `java.lang.NullPointerException: Cannot read the array length because "<parameter2>" is null`, the `<` symbol needs a richtext escape.

Happened a moment ago due to a cornercase bug in the server which I have already fixed there directly.