### PR TITLE
Building Stats Menu checks if saveloaded selection is still available

### DIFF
--- a/src/wui/building_statistics_menu.cc
+++ b/src/wui/building_statistics_menu.cc
@@ -830,7 +830,14 @@ UI::Window& BuildingStatisticsMenu::load(FileRead& fr, InteractiveBase& ib) {
 			m.tab_panel_.activate(fr.unsigned_8());
 			const std::string sel = fr.string();
 			if (!sel.empty()) {
-				m.set_current_building_type(ib.egbase().descriptions().safe_building_index(sel));
+				Widelands::DescriptionIndex idx = ib.egbase().descriptions().safe_building_index(sel);
+				/* Check if the button for the building still exists. There are valid cases where
+				 * it might not, since some buildings are only selectable here under specific
+				 * circumstances and vanish after closing and reopening the window.
+				*/
+				if (m.building_buttons_.at(idx) != nullptr) {
+					m.set_current_building_type(idx);
+				}
 			}
 			m.last_building_index_ = fr.signed_32();
 			return m;

--- a/src/wui/building_statistics_menu.cc
+++ b/src/wui/building_statistics_menu.cc
@@ -834,7 +834,7 @@ UI::Window& BuildingStatisticsMenu::load(FileRead& fr, InteractiveBase& ib) {
 				/* Check if the button for the building still exists. There are valid cases where
 				 * it might not, since some buildings are only selectable here under specific
 				 * circumstances and vanish after closing and reopening the window.
-				*/
+				 */
 				if (m.building_buttons_.at(idx) != nullptr) {
 					m.set_current_building_type(idx);
 				}


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6037

**New behavior**
The issue is about a valid case where the building stats menu tries to select an entry that no longer exist. Do not select any building type in this case.

**Possible regressions**
N/A
