### PR TITLE
Custom Ship & Warehouse Naming Lists

### DIFF
--- a/src/logic/CMakeLists.txt
+++ b/src/logic/CMakeLists.txt
@@ -280,6 +280,7 @@ wl_library(logic
     graphic
     graphic_color
     graphic_playercolor
+    graphic_text_layout
     io_fileread
     io_filesystem
     io_profile

--- a/src/logic/CMakeLists.txt
+++ b/src/logic/CMakeLists.txt
@@ -280,7 +280,6 @@ wl_library(logic
     graphic
     graphic_color
     graphic_playercolor
-    graphic_text_layout
     io_fileread
     io_filesystem
     io_profile

--- a/src/logic/filesystem_constants.h
+++ b/src/logic/filesystem_constants.h
@@ -89,4 +89,7 @@ const std::string kConfigFile = "config";
 
 const std::string kEconomyProfilesDir = "tribes/economy_profiles";
 
+const std::string kCustomShipNamesFile = "ship_names";
+const std::string kCustomWarehouseNamesFile = "warehouse_names";
+
 #endif  // end of include guard: WL_LOGIC_FILESYSTEM_CONSTANTS_H

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1100,7 +1100,7 @@ void Ship::draw(const EditorGameBase& egbase,
 		   statistics_string, g_style_manager->building_statistics_style().medium_color());
 	}
 
-	do_draw_info(info_to_draw, shipname_, statistics_string,
+	do_draw_info(info_to_draw, richtext_escape(shipname_), statistics_string,
 	             calc_drawpos(egbase, point_on_dst, scale), scale, dst);
 }
 

--- a/src/logic/map_objects/tribes/warehouse.cc
+++ b/src/logic/map_objects/tribes/warehouse.cc
@@ -31,6 +31,7 @@
 #include "economy/ship_fleet.h"
 #include "economy/warehousesupply.h"
 #include "economy/wares_queue.h"
+#include "graphic/text_layout.h"
 #include "logic/editor_game_base.h"
 #include "logic/game.h"
 #include "logic/map_objects/findbob.h"
@@ -1443,7 +1444,7 @@ InputQueue& Warehouse::inputqueue(DescriptionIndex index, WareWorker type, const
 }
 
 void Warehouse::update_statistics_string(std::string* str) {
-	*str = get_warehouse_name();
+	*str = richtext_escape(get_warehouse_name());
 }
 
 std::unique_ptr<const BuildingSettings> Warehouse::create_building_settings() const {

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -2320,7 +2320,8 @@ std::pair<std::set<std::string>, std::set<std::string>> read_custom_warehouse_sh
 				try {
 					line = fr.read_line();
 				} catch (const std::exception& e) {
-					log_warn("Naming list in '%s' file is malformed: %s", filenames[i]->c_str(), e.what());
+					log_warn(
+					   "Naming list in '%s' file is malformed: %s", filenames[i]->c_str(), e.what());
 					break;
 				}
 				if (line == nullptr) {

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -35,7 +35,6 @@
 #include "economy/flag.h"
 #include "economy/road.h"
 #include "economy/waterway.h"
-#include "graphic/text_layout.h"
 #include "io/fileread.h"
 #include "io/filewrite.h"
 #include "logic/cmd_delete_message.h"

--- a/src/logic/player.cc
+++ b/src/logic/player.cc
@@ -35,6 +35,7 @@
 #include "economy/flag.h"
 #include "economy/road.h"
 #include "economy/waterway.h"
+#include "graphic/text_layout.h"
 #include "io/fileread.h"
 #include "io/filewrite.h"
 #include "logic/cmd_delete_message.h"
@@ -2319,7 +2320,7 @@ std::pair<std::set<std::string>, std::set<std::string>> read_custom_warehouse_sh
 			std::string name(line);
 			trim(name);
 			if (!name.empty()) {
-				result.first.insert(name);
+				result.first.insert(richtext_escape(name));
 			}
 		}
 	}
@@ -2334,7 +2335,7 @@ std::pair<std::set<std::string>, std::set<std::string>> read_custom_warehouse_sh
 			std::string name(line);
 			trim(name);
 			if (!name.empty()) {
-				result.second.insert(name);
+				result.second.insert(richtext_escape(name));
 			}
 		}
 	}

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <memory>
+#include <set>
 
 #include "base/macros.h"
 #include "economy/economy.h"
@@ -565,6 +566,9 @@ public:
 	void reserve_shipname(const std::string& name);
 	void reserve_warehousename(const std::string& name);
 
+	void set_shipnames(const std::set<std::string>& names);
+	void set_warehousenames(const std::set<std::string>& names);
+
 	void add_soldier(unsigned h, unsigned a, unsigned d, unsigned e);
 	void remove_soldier(unsigned h, unsigned a, unsigned d, unsigned e);
 	uint32_t count_soldiers() const;
@@ -643,8 +647,8 @@ private:
 	std::vector<uint8_t> further_initializations_;   // used in shared kingdom mode
 	std::vector<uint8_t> further_shared_in_player_;  //  ''  ''   ''     ''     ''
 
-	std::list<std::string> remaining_shipnames_;
-	std::list<std::string> remaining_warehousenames_;
+	std::vector<std::string> remaining_shipnames_;
+	std::vector<std::string> remaining_warehousenames_;
 
 	PlayerBuildingStats building_stats_;
 	std::vector<SoldierStatistics> soldier_stats_;
@@ -740,6 +744,8 @@ struct NotePlayerDetailsEvent {
 void find_former_buildings(const Descriptions& descriptions,
                            DescriptionIndex bi,
                            FormerBuildings* former_buildings);
+
+std::pair<std::set<std::string>, std::set<std::string>> read_custom_warehouse_ship_names();
 }  // namespace Widelands
 
 #endif  // end of include guard: WL_LOGIC_PLAYER_H

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -111,6 +111,7 @@ struct GameClientImpl {
 	bool disconnect_called_;
 
 	void send_hello() const;
+	void send_custom_naming_lists() const;
 	void send_player_command(Widelands::PlayerCommand* /*pc*/) const;
 
 	void run_game(InteractiveGameBase* igb);
@@ -132,6 +133,23 @@ void GameClientImpl::send_player_command(Widelands::PlayerCommand* pc) const {
 	s.unsigned_8(NETCMD_PLAYERCOMMAND);
 	s.unsigned_32(game->get_gametime().get());
 	pc->serialize(s);
+	net->send(s);
+}
+
+void GameClientImpl::send_custom_naming_lists() const {
+	SendPacket s;
+	s.unsigned_8(NETCMD_CUSTOM_NAMING_LISTS);
+
+	auto names = Widelands::read_custom_warehouse_ship_names();
+	s.unsigned_32(names.first.size());
+	for (const std::string& name : names.first) {
+		s.string(name);
+	}
+	s.unsigned_32(names.second.size());
+	for (const std::string& name : names.second) {
+		s.string(name);
+	}
+
 	net->send(s);
 }
 
@@ -249,6 +267,7 @@ GameClient::~GameClient() {
 
 void GameClient::run() {
 	d->send_hello();
+	d->send_custom_naming_lists();
 	d->settings.multiplayer = true;
 	d->modal = new FsMenu::LaunchMPG(capsule_, *this, *this, *this, d->internet_);
 
@@ -291,6 +310,21 @@ void GameClient::do_run(RecvPacket& packet) {
 		}
 	}
 
+	std::map<Widelands::PlayerNumber, std::pair<std::set<std::string>, std::set<std::string>>> custom_naming_lists;
+	for (;;) {
+		Widelands::PlayerNumber number = packet.unsigned_8();
+		if (number == 0) {
+			break;
+		}
+
+		for (size_t i = packet.unsigned_32(); i > 0; --i) {
+			custom_naming_lists[number].first.insert(packet.string());
+		}
+		for (size_t i = packet.unsigned_32(); i > 0; --i) {
+			custom_naming_lists[number].second.insert(packet.string());
+		}
+	}
+
 	capsule_.set_visible(false);
 	try {
 		std::vector<std::string> tipstexts{"general_game", "multiplayer"};
@@ -302,10 +336,18 @@ void GameClient::do_run(RecvPacket& packet) {
 
 		d->game = &game;
 		InteractiveGameBase* igb = d->init_game(this, loader_ui);
+
+		for (const auto& lists : custom_naming_lists) {
+			Widelands::Player* player = game.get_safe_player(lists.first);
+			player->set_shipnames(lists.second.first);
+			player->set_warehousenames(lists.second.second);
+		}
+
 		if (d->panel_whose_mutex_needs_resetting_on_game_start != nullptr) {
 			d->panel_whose_mutex_needs_resetting_on_game_start->clear_current_think_mutex();
 			d->panel_whose_mutex_needs_resetting_on_game_start = nullptr;
 		}
+
 		d->run_game(igb);
 
 	} catch (const WLWarning& e) {

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -310,7 +310,8 @@ void GameClient::do_run(RecvPacket& packet) {
 		}
 	}
 
-	std::map<Widelands::PlayerNumber, std::pair<std::set<std::string>, std::set<std::string>>> custom_naming_lists;
+	std::map<Widelands::PlayerNumber, std::pair<std::set<std::string>, std::set<std::string>>>
+	   custom_naming_lists;
 	for (;;) {
 		Widelands::PlayerNumber number = packet.unsigned_8();
 		if (number == 0) {

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -266,6 +266,9 @@ struct Client {
 	/// relative
 	/// to when the last answer of the client was received.
 	time_t lastdelta;
+
+	std::set<std::string> custom_ship_names;
+	std::set<std::string> custom_warehouse_names;
 };
 
 struct GameHostImpl {
@@ -498,10 +501,42 @@ void GameHost::run_callback() {
 	SendPacket packet;
 	packet.unsigned_8(NETCMD_LAUNCH);
 	packet.unsigned_32(rng_seed);
+
 	packet.unsigned_32(game_->enabled_addons().size());
 	for (const auto& a : game_->enabled_addons()) {
 		packet.string(a->internal_name);
 	}
+
+	std::map<Widelands::PlayerNumber, std::pair<std::set<std::string>, std::set<std::string>>> custom_naming_lists;
+	if (!d->settings.savegame) {  // Naming lists don't make sense in savegames
+		int playernumber = d->settings.playernum + 1;
+		if (playernumber > 0) {
+			custom_naming_lists.emplace(playernumber, Widelands::read_custom_warehouse_ship_names());
+		}
+
+		for (Client& client : d->clients) {
+			playernumber = client.playernum + 1;
+			if (playernumber > 0) {
+				// Merge instead of overwrite - multiple clients can share a player
+				custom_naming_lists[playernumber].first.insert(client.custom_ship_names.begin(), client.custom_ship_names.end());
+				custom_naming_lists[playernumber].second.insert(client.custom_warehouse_names.begin(), client.custom_warehouse_names.end());
+			}
+		}
+
+		for (const auto& lists : custom_naming_lists) {
+			packet.unsigned_8(lists.first);
+			packet.unsigned_32(lists.second.first.size());
+			for (const std::string& name : lists.second.first) {
+				packet.string(name);
+			}
+			packet.unsigned_32(lists.second.second.size());
+			for (const std::string& name : lists.second.second) {
+				packet.string(name);
+			}
+		}
+	}
+	packet.unsigned_8(0);  // End of naming lists section
+
 	broadcast(packet);
 
 	game_->logic_rand_seed(rng_seed);
@@ -550,6 +585,13 @@ void GameHost::run_callback() {
 		} else {  // savegame
 			game_->init_savegame(d->settings);
 		}
+
+		for (const auto& lists : custom_naming_lists) {
+			Widelands::Player* player = game_->get_safe_player(lists.first);
+			player->set_shipnames(lists.second.first);
+			player->set_warehousenames(lists.second.second);
+		}
+
 		d->pseudo_networktime = game_->get_gametime();
 		d->time.reset(d->pseudo_networktime);
 		d->lastframe = SDL_GetTicks();
@@ -2264,7 +2306,7 @@ void GameHost::handle_nettime(uint32_t const client_num, RecvPacket& r) {
 	receive_client_time(client_num, Time(r.unsigned_32()));
 }
 
-void GameHost::handle_playercommmand(uint32_t const client_num, Client& client, RecvPacket& r) {
+void GameHost::handle_playercommand(uint32_t const client_num, Client& client, RecvPacket& r) {
 	if (d->game == nullptr) {
 		throw DisconnectException("PLAYERCMD_WO_GAME");
 	}
@@ -2277,6 +2319,17 @@ void GameHost::handle_playercommmand(uint32_t const client_num, Client& client, 
 		throw DisconnectException("PLAYERCMD_FOR_OTHER");
 	}
 	do_send_player_command(plcmd);
+}
+
+void GameHost::handle_custom_naming_lists(Client& client, RecvPacket& r) {
+	client.custom_ship_names.clear();
+	client.custom_warehouse_names.clear();
+	for (size_t i = r.unsigned_32(); i > 0; --i) {
+		client.custom_ship_names.insert(r.string());
+	}
+	for (size_t i = r.unsigned_32(); i > 0; --i) {
+		client.custom_warehouse_names.insert(r.string());
+	}
 }
 
 void GameHost::handle_syncreport(uint32_t const client_num, Client& client, RecvPacket& r) {
@@ -2372,7 +2425,9 @@ void GameHost::handle_packet(uint32_t const client_num, RecvPacket& r) {
 	case NETCMD_TIME:
 		return handle_nettime(client_num, r);
 	case NETCMD_PLAYERCOMMAND:
-		return handle_playercommmand(client_num, client, r);
+		return handle_playercommand(client_num, client, r);
+	case NETCMD_CUSTOM_NAMING_LISTS:
+		return handle_custom_naming_lists(client, r);
 	case NETCMD_SYNCREPORT:
 		return handle_syncreport(client_num, client, r);
 	case NETCMD_CHAT:

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -507,7 +507,8 @@ void GameHost::run_callback() {
 		packet.string(a->internal_name);
 	}
 
-	std::map<Widelands::PlayerNumber, std::pair<std::set<std::string>, std::set<std::string>>> custom_naming_lists;
+	std::map<Widelands::PlayerNumber, std::pair<std::set<std::string>, std::set<std::string>>>
+	   custom_naming_lists;
 	if (!d->settings.savegame) {  // Naming lists don't make sense in savegames
 		int playernumber = d->settings.playernum + 1;
 		if (playernumber > 0) {
@@ -518,8 +519,10 @@ void GameHost::run_callback() {
 			playernumber = client.playernum + 1;
 			if (playernumber > 0) {
 				// Merge instead of overwrite - multiple clients can share a player
-				custom_naming_lists[playernumber].first.insert(client.custom_ship_names.begin(), client.custom_ship_names.end());
-				custom_naming_lists[playernumber].second.insert(client.custom_warehouse_names.begin(), client.custom_warehouse_names.end());
+				custom_naming_lists[playernumber].first.insert(
+				   client.custom_ship_names.begin(), client.custom_ship_names.end());
+				custom_naming_lists[playernumber].second.insert(
+				   client.custom_warehouse_names.begin(), client.custom_warehouse_names.end());
 			}
 		}
 

--- a/src/network/gamehost.h
+++ b/src/network/gamehost.h
@@ -169,7 +169,8 @@ private:
 	void handle_changeinit(const Client& client, RecvPacket& r);
 	void handle_changeposition(const Client& client, RecvPacket& r);
 	void handle_nettime(uint32_t client_num, RecvPacket& r);
-	void handle_playercommmand(uint32_t client_num, Client& client, RecvPacket& r);
+	void handle_playercommand(uint32_t client_num, Client& client, RecvPacket& r);
+	void handle_custom_naming_lists(Client& client, RecvPacket& r);
 	void handle_syncreport(uint32_t client_num, Client& client, RecvPacket& r);
 	void handle_chat(Client& client, RecvPacket& r);
 	void handle_speed(Client& client, RecvPacket& r);

--- a/src/network/network_protocol.h
+++ b/src/network/network_protocol.h
@@ -27,7 +27,7 @@ enum {
 	 * The current version of the in-game network protocol. Client and host
 	 * protocol versions must match.
 	 */
-	NETWORK_PROTOCOL_VERSION = 31,
+	NETWORK_PROTOCOL_VERSION = 32,
 
 	/**
 	 * The default interval (in milliseconds) in which the host issues
@@ -217,6 +217,12 @@ enum : uint8_t {
 	 * \li unsigned_32 Random number generator seed
 	 * \li unsigned_32 Number of enabled add-ons
 	 * \li Each enabled add-on's internal name
+	 * \li Custom naming lists for all players. Each naming list consists of:
+	 *   \li unsigned_8: Player number (0 terminates the list of naming lists).
+	 *   \li unsigned_32: Number `S` of ship names
+	 *   \li `S` × string: Each ship name
+	 *   \li unsigned_32: Number `W` of warehouse names
+	 *   \li `W` × string: Each warehouse name
 	 *
 	 * The client must load the map and setup the game. As soon as the game
 	 * is fully loaded, it must behave as if a \ref NETCMD_WAIT command had
@@ -460,6 +466,19 @@ enum : uint8_t {
 	 * \li signed_32: win condition duration in minutes
 	 */
 	NETCMD_WIN_CONDITION_DURATION = 36,
+
+	/**
+	 * Sent by the client to inform the host of the client's custom naming lists for ships and
+	 * warehouses. The lists are distributed by the host to the clients later in the LAUNCH command.
+	 * Zero-size naming lists are ignored and signify to use the defaults.
+	 *
+	 * Attached data is:
+	 * \li unsigned_32: Number `S` of ship names
+	 * \li `S` × string: Each ship name
+	 * \li unsigned_32: Number `W` of warehouse names
+	 * \li `W` × string: Each warehouse name
+	 */
+	NETCMD_CUSTOM_NAMING_LISTS = 37,
 
 	/**
 	 * Sent by the metaserver to a freshly opened game to check connectability

--- a/src/ui_basic/table.cc
+++ b/src/ui_basic/table.cc
@@ -410,10 +410,10 @@ bool Table<void*>::handle_tooltip() {
 			const int column_w = columns_[c].width;
 			Vector2i point(column_x, y);
 			if (is_mouse_in(cursor_pos, point, column_w)) {
-				const std::string& entry_string = er.get_string(c);
+				const std::string entry_string = richtext_escape(er.get_string(c));
 				FontStyleInfo& font_style = get_column_fontstyle(er);
 				std::shared_ptr<const UI::RenderedText> rendered_text =
-				   UI::g_fh->render(as_richtext_paragraph(richtext_escape(entry_string), font_style));
+				   UI::g_fh->render(as_richtext_paragraph(entry_string, font_style));
 
 				if (rendered_text->width() > column_w) {
 					return Panel::draw_tooltip(entry_string, panel_style_);

--- a/src/ui_fsmenu/launch_spg.cc
+++ b/src/ui_fsmenu/launch_spg.cc
@@ -176,6 +176,12 @@ void LaunchSPG::clicked_ok() {
 			game_->set_game_controller(
 			   std::make_shared<SinglePlayerGameController>(*game_, true, playernumber));
 			game_->init_newgame(sp->settings());
+
+			auto custom_names = Widelands::read_custom_warehouse_ship_names();
+			Widelands::Player* player = game_->get_safe_player(playernumber);
+			player->set_shipnames(custom_names.first);
+			player->set_warehousenames(custom_names.second);
+
 			game_->run(Widelands::Game::StartGameType::kMap, "", "single_player");
 		}
 	} catch (const std::exception& e) {

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -761,6 +761,12 @@ void WLApplication::init_and_run_game_from_template() {
 
 	game.set_game_controller(std::make_shared<SinglePlayerGameController>(game, true, playernumber));
 	game.init_newgame(settings->settings());
+
+	auto custom_names = Widelands::read_custom_warehouse_ship_names();
+	Widelands::Player* player = game.get_safe_player(playernumber);
+	player->set_shipnames(custom_names.first);
+	player->set_warehousenames(custom_names.second);
+
 	try {
 		game.run(Widelands::Game::StartGameType::kMap, script_to_run_, "single_player");
 	} catch (const std::exception& e) {

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -90,7 +90,8 @@ InfoToDraw filter_info_to_draw(InfoToDraw info_to_draw,
                                const Widelands::Player& player) {
 	InfoToDraw result = info_to_draw;
 	const Widelands::Player* owner = object->get_owner();
-	if (owner != nullptr && !player.see_all() && player.is_hostile(*owner)) {
+	if (owner != nullptr && !player.see_all() && player.is_hostile(*owner) &&
+	    object->descr().type() != Widelands::MapObjectType::WAREHOUSE) {
 		result = static_cast<InfoToDraw>(result & ~InfoToDraw::kStatistics);
 	}
 	return result;


### PR DESCRIPTION
**Type of change**
New feature

**Issue(s) closed**
Requested a while ago via chat, and I think this is a very desirable feature. Now that you can name your ships and warehouses, some players may have a list of their own favourite names. This branch allows you to specify tribe-agnostic custom naming lists for ships and/or warehouses, which, if present, replace the default lists. This feature is multiplayer- and replay-compatible.

Additionally this PR fixes the minor glitch that you can see the names of other players' ships but not their warehouses.

**How it works**
Place files `warehouse_names` and/or `ship_names` in your Widelands home directory. Like the console history in #5944 these are plain one-entry-per-line listings. If these files are not present or don't contain any entries, the tribe-specific default names are used.

**Possible regressions**
Ship/warehouse naming, and their consistency across MP/replays