### PR TITLE
Don't require World add-ons to be globally enabled for dependent Maps add-ons

### DIFF
--- a/src/logic/addons.cc
+++ b/src/logic/addons.cc
@@ -173,6 +173,17 @@ bool order_matters(AddOnCategory base, AddOnCategory dependency) {
 	}
 }
 
+bool require_enabled(AddOnCategory base, AddOnCategory dependency) {
+	switch (base) {
+	case AddOnCategory::kMaps:
+	case AddOnCategory::kCampaign:
+		// Maps enable their own world add-ons automatically
+		return dependency != AddOnCategory::kWorld;
+	default:
+		return true;
+	}
+}
+
 static AddOnConflict check_requirements_conflicts(const AddOnRequirements& required_addons) {
 	std::set<std::string> addons_missing;
 	std::map<std::string, std::pair<AddOnVersion, AddOnVersion>> addons_wrong_version;

--- a/src/logic/addons.h
+++ b/src/logic/addons.h
@@ -170,6 +170,7 @@ std::string list_game_relevant_addons();
  * tells whether the dependency must necessarily be listed after the requiring add-on.
  */
 bool order_matters(AddOnCategory base, AddOnCategory dependency);
+bool require_enabled(AddOnCategory base, AddOnCategory dependency);
 
 std::shared_ptr<AddOnInfo> preload_addon(const std::string&);
 

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -1198,7 +1198,8 @@ void AddOnsCtrl::update_dependency_errors() {
 				   format(_("· ‘%1$s’ requires ‘%2$s’ which could not be found"),
 				          addon->first->descname(), requirement));
 			} else {
-				if (!search_result->second) {
+				if (!search_result->second &&
+				    AddOns::require_enabled(addon->first->category, search_result->first->category)) {
 					warn_requirements.push_back(format(_("· ‘%1$s’ requires ‘%2$s’ which is disabled"),
 					                                   addon->first->descname(),
 					                                   search_result->first->descname()));


### PR DESCRIPTION
**Type of change**
Feature enhancement

**Issue(s) closed**
When loading a map, it automatically enables all required World add-ons. Thus, a Maps add-on now does not require its World dependencies to be active, only that they are installed.