### PR TITLE
Options window cleanup

### DIFF
--- a/data/templates/default/init.lua
+++ b/data/templates/default/init.lua
@@ -698,7 +698,7 @@ return {
       fsmenu_translation_info = {
          color = fs_font_color,
          face = fs_font_face,
-         size = fs_font_size - 2,
+         size = fs_font_size,
          bold = true,
          shadow = true
       },

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -272,7 +272,7 @@ void GameClient::do_run(RecvPacket& packet) {
 
 	Widelands::Game game;
 	game.set_write_replay(d->should_write_replay);
-	game.set_write_syncstream(get_config_bool("write_syncstreams", true));
+	game.set_write_syncstream(g_write_syncstreams);
 	game.logic_rand_seed(packet.unsigned_32());
 
 	game.enabled_addons().clear();

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -507,7 +507,7 @@ void GameHost::run_callback() {
 	game_->logic_rand_seed(rng_seed);
 	game_->set_ai_training_mode(get_config_bool("ai_training", false));
 	game_->set_auto_speed(get_config_bool("auto_speed", false));
-	game_->set_write_syncstream(get_config_bool("write_syncstreams", true));
+	game_->set_write_syncstream(g_write_syncstreams);
 
 	if (capsule_ != nullptr) {
 		capsule_->set_visible(false);

--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -18,8 +18,8 @@
 
 #include "ui_basic/checkbox.h"
 
-#include <cassert>
 #include <SDL_mouse.h>
+#include <cassert>
 
 #include "graphic/font_handler.h"
 #include "graphic/rendertarget.h"

--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -18,8 +18,9 @@
 
 #include "ui_basic/checkbox.h"
 
-#include <SDL_mouse.h>
 #include <cassert>
+
+#include <SDL_mouse.h>
 
 #include "graphic/font_handler.h"
 #include "graphic/rendertarget.h"

--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -88,11 +88,7 @@ void Statebox::layout() {
 		int w = get_w();
 		int h = kStateboxSize;
 		int pic_width = kStateboxSize;
-		if (pic_graphics_ != nullptr) {
-			w = std::max(pic_graphics_->width(), w);
-			h = pic_graphics_->height();
-			pic_width = pic_graphics_->width();
-		}
+		assert(flags_ & Has_Custom_Picture == 0);
 		rendered_text_ = label_text_.empty() ?
                           nullptr :
                           UI::g_fh->render(as_richtext_paragraph(

--- a/src/ui_basic/checkbox.cc
+++ b/src/ui_basic/checkbox.cc
@@ -18,6 +18,7 @@
 
 #include "ui_basic/checkbox.h"
 
+#include <cassert>
 #include <SDL_mouse.h>
 
 #include "graphic/font_handler.h"
@@ -88,7 +89,7 @@ void Statebox::layout() {
 		int w = get_w();
 		int h = kStateboxSize;
 		int pic_width = kStateboxSize;
-		assert(flags_ & Has_Custom_Picture == 0);
+		assert((flags_ & Has_Custom_Picture) == 0);
 		rendered_text_ = label_text_.empty() ?
                           nullptr :
                           UI::g_fh->render(as_richtext_paragraph(

--- a/src/ui_basic/checkbox.h
+++ b/src/ui_basic/checkbox.h
@@ -68,6 +68,8 @@ struct Statebox : public Panel {
 	}
 	void set_state(bool on, bool send_signal = true);
 
+	void layout() override;
+
 	// Drawing and event handlers
 	void draw(RenderTarget&) override;
 	void draw_overlay(RenderTarget&) override;
@@ -82,7 +84,6 @@ protected:
 	std::vector<Recti> focus_overlay_rects() override;
 
 private:
-	void layout() override;
 	virtual void button_clicked() = 0;
 
 	enum Flags {

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -351,7 +351,7 @@ int Panel::do_run() {
 	app.set_mouse_lock(false);  // more paranoia :-)
 
 	// With the default of 30FPS, the game will be drawn every 33ms.
-	constexpr kMaxFPS = 30;
+	constexpr uint32_t kMaxFPS = 30;
 	constexpr uint32_t kDrawDelay = 1000 / kMaxFPS;
 
 	static InputCallback input_callback = {Panel::ui_mousepress, Panel::ui_mouserelease,

--- a/src/ui_basic/panel.cc
+++ b/src/ui_basic/panel.cc
@@ -351,7 +351,8 @@ int Panel::do_run() {
 	app.set_mouse_lock(false);  // more paranoia :-)
 
 	// With the default of 30FPS, the game will be drawn every 33ms.
-	const uint32_t draw_delay = 1000 / std::max(5, get_config_int("maxfps", 30));
+	constexpr kMaxFPS = 30;
+	constexpr uint32_t kDrawDelay = 1000 / kMaxFPS;
 
 	static InputCallback input_callback = {Panel::ui_mousepress, Panel::ui_mouserelease,
 	                                       Panel::ui_mousemove,  Panel::ui_key,
@@ -411,7 +412,7 @@ int Panel::do_run() {
 				do_redraw_now();
 			}
 
-			next_time = start_time + draw_delay;
+			next_time = start_time + kDrawDelay;
 		}
 
 		const int32_t delay = next_time - SDL_GetTicks();
@@ -435,7 +436,7 @@ int Panel::do_run() {
 				do_redraw_now(true, _("Game ending – please wait…"));
 			}
 
-			next_time = start_time + draw_delay;
+			next_time = start_time + kDrawDelay;
 			const int32_t delay = next_time - SDL_GetTicks();
 			if (delay > 0) {
 				SDL_Delay(delay);

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -261,13 +261,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
           _("Compress Widelands data files (maps, replays, and savegames)"),
           "",
           0),
-     write_syncstreams_(&box_saving_,
-                        UI::PanelStyle::kFsMenu,
-                        "syncstreams",
-                        Vector2i::zero(),
-                        _("Write syncstreams in network games to debug desyncs"),
-                        "",
-                        0),
      // New Game options
      show_buildhelp_(&box_newgame_,
                      UI::PanelStyle::kFsMenu,
@@ -401,7 +394,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	box_saving_.add(&sb_rolling_autosave_, UI::Box::Resizing::kFullSize);
 	box_saving_.add(&sb_replay_lifetime_, UI::Box::Resizing::kFullSize);
 	box_saving_.add(&zip_, UI::Box::Resizing::kFullSize);
-	box_saving_.add(&write_syncstreams_, UI::Box::Resizing::kFullSize);
 
 	// New Games
 	box_newgame_.add(&show_buildhelp_, UI::Box::Resizing::kFullSize);
@@ -483,7 +475,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 
 	// Saving options
 	zip_.set_state(opt.zip);
-	write_syncstreams_.set_state(opt.write_syncstreams);
 
 	// Game options
 	auto_roadbuild_mode_.set_state(opt.auto_roadbuild_mode);
@@ -790,7 +781,6 @@ OptionsCtrl::OptionsStruct Options::get_values() {
 	os_.rolling_autosave = sb_rolling_autosave_.get_value();
 	os_.replay_lifetime = sb_replay_lifetime_.get_value();
 	os_.zip = zip_.get_state();
-	os_.write_syncstreams = write_syncstreams_.get_state();
 
 	// Game options
 	os_.auto_roadbuild_mode = auto_roadbuild_mode_.get_state();
@@ -869,7 +859,6 @@ OptionsCtrl::OptionsStruct OptionsCtrl::options_struct(uint32_t active_tab) {
 	opt.rolling_autosave = opt_section_.get_int("rolling_autosave", 5);
 	opt.replay_lifetime = opt_section_.get_int("replay_lifetime", 0);
 	opt.zip = !opt_section_.get_bool("nozip", false);
-	opt.write_syncstreams = opt_section_.get_bool("write_syncstreams", true);
 
 	// Game options
 	opt.auto_roadbuild_mode = opt_section_.get_bool("auto_roadbuild_mode", true);
@@ -916,7 +905,6 @@ void OptionsCtrl::save_options() {
 	opt_section_.set_int("rolling_autosave", opt.rolling_autosave);
 	opt_section_.set_int("replay_lifetime", opt.replay_lifetime);
 	opt_section_.set_bool("nozip", !opt.zip);
-	opt_section_.set_bool("write_syncstreams", opt.write_syncstreams);
 
 	// Game options
 	opt_section_.set_bool("auto_roadbuild_mode", opt.auto_roadbuild_mode);

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -161,7 +161,7 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
      translation_info_(
         &box_interface_hbox_, "translation_info", 0, 0, 100, 20, UI::PanelStyle::kFsMenu),
 
-     // Windows options
+     // Window options
      dock_windows_to_edges_(&box_interface_,
                             UI::PanelStyle::kFsMenu,
                             "dock_to_edges",
@@ -169,14 +169,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
                             _("Dock windows to edges"),
                             "",
                             0),
-     animate_map_panning_(&box_interface_,
-                          UI::PanelStyle::kFsMenu,
-                          "animate_map_panning",
-                          Vector2i::zero(),
-                          _("Animate automatic map movements"),
-                          "",
-                          0),
-
      sb_dis_panel_(&box_interface_,
                    "panel_snap_distance",
                    0,
@@ -341,6 +333,14 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
                       "invert_movement",
                       Vector2i::zero(),
                       _("Invert click-and-drag map movement direction")),
+     animate_map_panning_(&box_ingame_,
+                          UI::PanelStyle::kFsMenu,
+                          "animate_map_panning",
+                          Vector2i::zero(),
+                          _("Animate automatic map movements"),
+                          "",
+                          0),
+
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
      training_wheels_box_(&box_ingame_, UI::PanelStyle::kFsMenu, 0, 0, UI::Box::Horizontal),
      training_wheels_(&training_wheels_box_,
@@ -389,7 +389,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	box_interface_.add(&tooltip_accessibility_mode_, UI::Box::Resizing::kFullSize);
 
 	box_interface_.add(&dock_windows_to_edges_, UI::Box::Resizing::kFullSize);
-	box_interface_.add(&animate_map_panning_, UI::Box::Resizing::kFullSize);
 	box_interface_.add(&sb_dis_panel_);
 	box_interface_.add(&sb_dis_border_);
 	box_interface_.add(&configure_keyboard_);
@@ -420,8 +419,9 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	box_ingame_.add(&numpad_diagonalscrolling_, UI::Box::Resizing::kFullSize);
 	box_ingame_.add(&edge_scrolling_, UI::Box::Resizing::kFullSize);
 	box_ingame_.add(&invert_movement_, UI::Box::Resizing::kFullSize);
-	box_ingame_.add_space(kPadding);
+	box_ingame_.add(&animate_map_panning_, UI::Box::Resizing::kFullSize);
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
+	box_ingame_.add_space(kPadding);
 	box_ingame_.add(&training_wheels_box_, UI::Box::Resizing::kFullSize);
 	training_wheels_box_.add(&training_wheels_, UI::Box::Resizing::kFullSize);
 	training_wheels_box_.add_inf_space();
@@ -478,9 +478,8 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	sdl_cursor_.set_state(opt.sdl_cursor);
 	tooltip_accessibility_mode_.set_state(opt.tooltip_accessibility_mode);
 
-	// Windows options
+	// Window options
 	dock_windows_to_edges_.set_state(opt.dock_windows_to_edges);
-	animate_map_panning_.set_state(opt.animate_map_panning);
 
 	// Saving options
 	zip_.set_state(opt.zip);
@@ -494,6 +493,7 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	numpad_diagonalscrolling_.set_state(opt.numpad_diagonalscrolling);
 	edge_scrolling_.set_state(opt.edge_scrolling);
 	invert_movement_.set_state(opt.invert_movement);
+	animate_map_panning_.set_state(opt.animate_map_panning);
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
 	training_wheels_.set_state(opt.training_wheels);
 #endif
@@ -780,9 +780,8 @@ OptionsCtrl::OptionsStruct Options::get_values() {
 	os_.sdl_cursor = sdl_cursor_.get_state();
 	os_.tooltip_accessibility_mode = tooltip_accessibility_mode_.get_state();
 
-	// Windows options
+	// Window options
 	os_.dock_windows_to_edges = dock_windows_to_edges_.get_state();
-	os_.animate_map_panning = animate_map_panning_.get_state();
 	os_.panel_snap_distance = sb_dis_panel_.get_value();
 	os_.border_snap_distance = sb_dis_border_.get_value();
 
@@ -801,6 +800,7 @@ OptionsCtrl::OptionsStruct Options::get_values() {
 	os_.numpad_diagonalscrolling = numpad_diagonalscrolling_.get_state();
 	os_.edge_scrolling = edge_scrolling_.get_state();
 	os_.invert_movement = invert_movement_.get_state();
+	os_.animate_map_panning = animate_map_panning_.get_state();
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
 	os_.training_wheels = training_wheels_.get_state();
 #endif
@@ -859,9 +859,8 @@ OptionsCtrl::OptionsStruct OptionsCtrl::options_struct(uint32_t active_tab) {
 	opt.sdl_cursor = opt_section_.get_bool("sdl_cursor", true);
 	opt.tooltip_accessibility_mode = opt_section_.get_bool("tooltip_accessibility_mode", false);
 
-	// Windows options
+	// Window options
 	opt.dock_windows_to_edges = opt_section_.get_bool("dock_windows_to_edges", false);
-	opt.animate_map_panning = opt_section_.get_bool("animate_map_panning", true);
 	opt.panel_snap_distance = opt_section_.get_int("panel_snap_distance", 0);
 	opt.border_snap_distance = opt_section_.get_int("border_snap_distance", 0);
 
@@ -880,6 +879,7 @@ OptionsCtrl::OptionsStruct OptionsCtrl::options_struct(uint32_t active_tab) {
 	opt.numpad_diagonalscrolling = opt_section_.get_bool("numpad_diagonalscrolling", false);
 	opt.edge_scrolling = opt_section_.get_bool("edge_scrolling", false);
 	opt.invert_movement = opt_section_.get_bool("invert_movement", false);
+	opt.animate_map_panning = opt_section_.get_bool("animate_map_panning", true);
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
 	opt.training_wheels = opt_section_.get_bool("training_wheels", true);
 #endif
@@ -906,9 +906,8 @@ void OptionsCtrl::save_options() {
 	opt_section_.set_bool("sdl_cursor", opt.sdl_cursor);
 	opt_section_.set_bool("tooltip_accessibility_mode", opt.tooltip_accessibility_mode);
 
-	// Windows options
+	// Window options
 	opt_section_.set_bool("dock_windows_to_edges", opt.dock_windows_to_edges);
-	opt_section_.set_bool("animate_map_panning", opt.animate_map_panning);
 	opt_section_.set_int("panel_snap_distance", opt.panel_snap_distance);
 	opt_section_.set_int("border_snap_distance", opt.border_snap_distance);
 
@@ -927,6 +926,7 @@ void OptionsCtrl::save_options() {
 	opt_section_.set_bool("numpad_diagonalscrolling", opt.numpad_diagonalscrolling);
 	opt_section_.set_bool("edge_scrolling", opt.edge_scrolling);
 	opt_section_.set_bool("invert_movement", opt.invert_movement);
+	opt_section_.set_bool("animate_map_panning", opt.animate_map_panning);
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
 	opt_section_.set_bool("training_wheels", opt.training_wheels);
 #endif

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -153,17 +153,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
                  _("Use system mouse cursor"),
                  "",
                  0),
-     sb_maxfps_(&box_interface_,
-                "max_fps",
-                0,
-                0,
-                0,
-                0,
-                opt.maxfps,
-                0,
-                99,
-                UI::PanelStyle::kFsMenu,
-                _("Maximum FPS:")),
      tooltip_accessibility_mode_(&box_interface_,
                                  UI::PanelStyle::kFsMenu,
                                  "tooltip_accessibility_mode",
@@ -397,7 +386,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 
 	box_interface_.add(&box_interface_hbox_, UI::Box::Resizing::kFullSize);
 	box_interface_.add(&sdl_cursor_, UI::Box::Resizing::kFullSize);
-	box_interface_.add(&sb_maxfps_);
 	box_interface_.add(&tooltip_accessibility_mode_, UI::Box::Resizing::kFullSize);
 
 	box_interface_.add(&dock_windows_to_edges_, UI::Box::Resizing::kFullSize);
@@ -591,8 +579,6 @@ void Options::layout() {
 		translation_info_.set_size(
 		   language_dropdown_.get_w(),
 		   language_dropdown_.get_h() + resolution_dropdown_.get_h() + kPadding);
-		sb_maxfps_.set_unit_width(unit_w);
-		sb_maxfps_.set_desired_size(tab_panel_width, sb_maxfps_.get_h());
 
 		sb_dis_panel_.set_unit_width(unit_w);
 		sb_dis_panel_.set_desired_size(tab_panel_width, sb_dis_panel_.get_h());
@@ -792,7 +778,6 @@ OptionsCtrl::OptionsStruct Options::get_values() {
 		}
 	}
 	os_.sdl_cursor = sdl_cursor_.get_state();
-	os_.maxfps = sb_maxfps_.get_value();
 	os_.tooltip_accessibility_mode = tooltip_accessibility_mode_.get_state();
 
 	// Windows options
@@ -871,7 +856,6 @@ OptionsCtrl::OptionsStruct OptionsCtrl::options_struct(uint32_t active_tab) {
 	opt.yres = opt_section_.get_int("yres", kDefaultResolutionH);
 	opt.maximized = opt_section_.get_bool("maximized", false);
 	opt.fullscreen = opt_section_.get_bool("fullscreen", false);
-	opt.maxfps = opt_section_.get_int("maxfps", 25);
 	opt.sdl_cursor = opt_section_.get_bool("sdl_cursor", true);
 	opt.tooltip_accessibility_mode = opt_section_.get_bool("tooltip_accessibility_mode", false);
 
@@ -919,7 +903,6 @@ void OptionsCtrl::save_options() {
 	opt_section_.set_int("yres", opt.yres);
 	opt_section_.set_bool("maximized", opt.maximized);
 	opt_section_.set_bool("fullscreen", opt.fullscreen);
-	opt_section_.set_int("maxfps", opt.maxfps);
 	opt_section_.set_bool("sdl_cursor", opt.sdl_cursor);
 	opt_section_.set_bool("tooltip_accessibility_mode", opt.tooltip_accessibility_mode);
 

--- a/src/ui_fsmenu/options.cc
+++ b/src/ui_fsmenu/options.cc
@@ -146,14 +146,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
                           UI::DropdownType::kTextual,
                           UI::PanelStyle::kFsMenu,
                           UI::ButtonStyle::kFsMenuMenu),
-
-     inputgrab_(&box_interface_,
-                UI::PanelStyle::kFsMenu,
-                "input_grab",
-                Vector2i::zero(),
-                _("Grab Input"),
-                "",
-                0),
      sdl_cursor_(&box_interface_,
                  UI::PanelStyle::kFsMenu,
                  "sdl_cursor",
@@ -404,7 +396,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	box_interface_hbox_.add(&translation_info_, UI::Box::Resizing::kExpandBoth);
 
 	box_interface_.add(&box_interface_hbox_, UI::Box::Resizing::kFullSize);
-	box_interface_.add(&inputgrab_, UI::Box::Resizing::kFullSize);
 	box_interface_.add(&sdl_cursor_, UI::Box::Resizing::kFullSize);
 	box_interface_.add(&sb_maxfps_);
 	box_interface_.add(&tooltip_accessibility_mode_, UI::Box::Resizing::kFullSize);
@@ -496,7 +487,6 @@ Options::Options(MainMenu& fsmm, OptionsCtrl::OptionsStruct opt)
 	// Interface options
 	add_screen_resolutions(opt);
 
-	inputgrab_.set_state(opt.inputgrab);
 	sdl_cursor_.set_state(opt.sdl_cursor);
 	tooltip_accessibility_mode_.set_state(opt.tooltip_accessibility_mode);
 
@@ -801,7 +791,6 @@ OptionsCtrl::OptionsStruct Options::get_values() {
 			os_.yres = res.yres;
 		}
 	}
-	os_.inputgrab = inputgrab_.get_state();
 	os_.sdl_cursor = sdl_cursor_.get_state();
 	os_.maxfps = sb_maxfps_.get_value();
 	os_.tooltip_accessibility_mode = tooltip_accessibility_mode_.get_state();
@@ -882,7 +871,6 @@ OptionsCtrl::OptionsStruct OptionsCtrl::options_struct(uint32_t active_tab) {
 	opt.yres = opt_section_.get_int("yres", kDefaultResolutionH);
 	opt.maximized = opt_section_.get_bool("maximized", false);
 	opt.fullscreen = opt_section_.get_bool("fullscreen", false);
-	opt.inputgrab = opt_section_.get_bool("inputgrab", false);
 	opt.maxfps = opt_section_.get_int("maxfps", 25);
 	opt.sdl_cursor = opt_section_.get_bool("sdl_cursor", true);
 	opt.tooltip_accessibility_mode = opt_section_.get_bool("tooltip_accessibility_mode", false);
@@ -931,7 +919,6 @@ void OptionsCtrl::save_options() {
 	opt_section_.set_int("yres", opt.yres);
 	opt_section_.set_bool("maximized", opt.maximized);
 	opt_section_.set_bool("fullscreen", opt.fullscreen);
-	opt_section_.set_bool("inputgrab", opt.inputgrab);
 	opt_section_.set_int("maxfps", opt.maxfps);
 	opt_section_.set_bool("sdl_cursor", opt.sdl_cursor);
 	opt_section_.set_bool("tooltip_accessibility_mode", opt.tooltip_accessibility_mode);
@@ -967,7 +954,6 @@ void OptionsCtrl::save_options() {
 	// Language options
 	opt_section_.set_string("language", opt.language);
 
-	WLApplication::get().set_input_grab(opt.inputgrab);
 	g_mouse_cursor->set_use_sdl(opt_dialog_->get_values().sdl_cursor);
 	i18n::set_locale(opt.language);
 	UI::g_fh->reinitialize_fontset(i18n::get_locale());

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -49,12 +49,12 @@ public:
 		bool maximized;
 		bool fullscreen;
 		bool sdl_cursor;
+		bool tooltip_accessibility_mode;
 
 		// Windows options
 		bool dock_windows_to_edges;
 		int32_t panel_snap_distance;
 		int32_t border_snap_distance;
-		bool animate_map_panning;
 
 		// Saving options
 		int32_t autosave;          // autosave interval in minutes
@@ -71,7 +71,7 @@ public:
 		bool numpad_diagonalscrolling;
 		bool edge_scrolling;
 		bool invert_movement;
-		bool tooltip_accessibility_mode;
+		bool animate_map_panning;
 		int32_t display_flags;
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
 		bool training_wheels;
@@ -158,7 +158,6 @@ private:
 	UI::MultilineTextarea translation_info_;
 
 	UI::Checkbox dock_windows_to_edges_;
-	UI::Checkbox animate_map_panning_;
 	UI::SpinBox sb_dis_panel_;
 	UI::SpinBox sb_dis_border_;
 
@@ -190,6 +189,7 @@ private:
 	UI::Checkbox numpad_diagonalscrolling_;
 	UI::Checkbox edge_scrolling_;
 	UI::Checkbox invert_movement_;
+	UI::Checkbox animate_map_panning_;
 
 #if 0  // TODO(Nordfriese): Re-add training wheels code after v1.0
 	UI::Box training_wheels_box_;

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -155,6 +155,9 @@ private:
 	UI::Checkbox sdl_cursor_;
 	UI::Checkbox tooltip_accessibility_mode_;
 	UI::MultilineTextarea translation_info_;
+	// Empty panel for layouting
+	// TODO(tothxa): Replace with infinite space if box layouting quirks get fixed
+	UI::Panel translation_padding_;
 
 	UI::Checkbox dock_windows_to_edges_;
 	UI::SpinBox sb_dis_panel_;

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -48,7 +48,6 @@ public:
 		int32_t yres;
 		bool maximized;
 		bool fullscreen;
-		bool inputgrab;
 		uint32_t maxfps;
 		bool sdl_cursor;
 
@@ -155,7 +154,6 @@ private:
 	// Interface options
 	UI::Dropdown<std::string> language_dropdown_;
 	UI::Dropdown<ScreenResolution> resolution_dropdown_;
-	UI::Checkbox inputgrab_;
 	UI::Checkbox sdl_cursor_;
 	UI::SpinBox sb_maxfps_;
 	UI::Checkbox tooltip_accessibility_mode_;

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -61,7 +61,6 @@ public:
 		int32_t rolling_autosave;  // number of file to use for rolling autosave
 		int32_t replay_lifetime;   // number of weeks to keep replays around
 		bool zip;
-		bool write_syncstreams;
 
 		// Game options
 		bool auto_roadbuild_mode;
@@ -171,7 +170,6 @@ private:
 	UI::SpinBox sb_rolling_autosave_;
 	UI::SpinBox sb_replay_lifetime_;
 	UI::Checkbox zip_;
-	UI::Checkbox write_syncstreams_;
 
 	// New Game options
 	UI::Checkbox show_buildhelp_;

--- a/src/ui_fsmenu/options.h
+++ b/src/ui_fsmenu/options.h
@@ -48,7 +48,6 @@ public:
 		int32_t yres;
 		bool maximized;
 		bool fullscreen;
-		uint32_t maxfps;
 		bool sdl_cursor;
 
 		// Windows options
@@ -155,7 +154,6 @@ private:
 	UI::Dropdown<std::string> language_dropdown_;
 	UI::Dropdown<ScreenResolution> resolution_dropdown_;
 	UI::Checkbox sdl_cursor_;
-	UI::SpinBox sb_maxfps_;
 	UI::Checkbox tooltip_accessibility_mode_;
 	UI::MultilineTextarea translation_info_;
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -465,17 +465,6 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 	// register it once.
 	UI::Panel::register_click();
 
-	// Disable mouse grabbing
-	// TODO(tothxa): keep around until tested without it
-	/*
-	if (g_gr != nullptr) {
-	   SDL_Window* sdl_window = g_gr->get_sdlwindow();
-	   if (sdl_window != nullptr) {
-	      SDL_SetWindowGrab(sdl_window, SDL_FALSE);
-	   }
-	}
-	*/
-
 	// Make sure we didn't forget to read any global option
 	check_config_used();
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -465,7 +465,16 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 	// register it once.
 	UI::Panel::register_click();
 
-	set_input_grab(get_config_bool("inputgrab", false));
+	// Disable mouse grabbing
+	// TODO(tothxa): keep around until tested without it
+	/*
+	if (g_gr != nullptr) {
+		SDL_Window* sdl_window = g_gr->get_sdlwindow();
+		if (sdl_window != nullptr) {
+			SDL_SetWindowGrab(sdl_window, SDL_FALSE);
+		}
+	}
+	*/
 
 	// Make sure we didn't forget to read any global option
 	check_config_used();
@@ -1081,32 +1090,6 @@ void WLApplication::warp_mouse(const Vector2i position) {
 				return;
 			}
 		}
-	}
-}
-
-/**
- * Changes input grab mode.
- *
- * This makes sure that the mouse cannot leave our window (and also that we get
- * mouse/keyboard input nearly unmodified, but we don't really care about that).
- *
- * \note This also cuts out any mouse-speed modifications that a generous window
- * manager might be doing.
- */
-void WLApplication::set_input_grab(bool grab) {
-	if (g_gr == nullptr) {
-		return;
-	}
-	SDL_Window* sdl_window = g_gr->get_sdlwindow();
-	if (grab) {
-		if (sdl_window != nullptr) {
-			SDL_SetWindowGrab(sdl_window, SDL_TRUE);
-		}
-	} else {
-		if (sdl_window != nullptr) {
-			SDL_SetWindowGrab(sdl_window, SDL_FALSE);
-		}
-		warp_mouse(mouse_position_);  // TODO(unknown): is this redundant?
 	}
 }
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -469,10 +469,10 @@ WLApplication::WLApplication(int const argc, char const* const* const argv)
 	// TODO(tothxa): keep around until tested without it
 	/*
 	if (g_gr != nullptr) {
-		SDL_Window* sdl_window = g_gr->get_sdlwindow();
-		if (sdl_window != nullptr) {
-			SDL_SetWindowGrab(sdl_window, SDL_FALSE);
-		}
+	   SDL_Window* sdl_window = g_gr->get_sdlwindow();
+	   if (sdl_window != nullptr) {
+	      SDL_SetWindowGrab(sdl_window, SDL_FALSE);
+	   }
 	}
 	*/
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1547,6 +1547,11 @@ void WLApplication::handle_commandline_parameters() {
 		set_config_bool("auto_speed", false);
 	}
 
+	if (commandline_.count("write_syncstreams") != 0u) {
+		g_write_syncstreams = true;
+		commandline_.erase("write_syncstreams");
+	}
+
 	if (commandline_.count("version") != 0u) {
 		throw ParameterError(CmdLineVerbosity::None);  // No message on purpose
 	}

--- a/src/wlapplication.h
+++ b/src/wlapplication.h
@@ -122,14 +122,7 @@ struct InputCallback {
 ///
 /// Forking does not work on windows, but nobody cares enough to investigate.
 /// It is only a debugging convenience anyway.
-///
-///
-/// \par The mouse cursor
-///
-/// Ordinarily, relative coordinates break down when the cursor leaves the
-/// window. This means we have to grab the mouse, then relative coords are
-/// always available.
-// TODO(unknown): Actually do grab the mouse when it is locked
+
 // TODO(unknown): Graphics are currently not handled by WLApplication, and it is
 // non essential for playback anyway. Additionally, we will want several
 // rendering backends (software and OpenGL). Maybe the graphics backend loader
@@ -159,7 +152,6 @@ struct WLApplication {
 
 	// @{
 	void warp_mouse(Vector2i);
-	void set_input_grab(bool grab);
 
 	/// The mouse's current coordinates
 	[[nodiscard]] Vector2i get_mouse_position() const {

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -144,16 +144,7 @@ void fill_parameter_vector() {
 		_("Show in-game chat with transparent background."), true},
 	  {"", "toolbar_pos", _("[...]"), _("Bitmask to set the toolbar location and mode."), true},
 	  /// Networking
-	  {_("Networking:"), "write_syncstreams",
-		/** TRANSLATORS: You may translate true/false, also as on/off or yes/no, but */
-		/** TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the widelands textdomain. */
-		/** TRANSLATORS: * marks the default value */
-		_("[true*|false]"),
-		/** TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are used in multiplayer
-		 */
-		/** TRANSLATORS: games to make sure that there is no mismatch between the players. */
-		_("Create syncstream dump files to help debug network games."), false},
-	  {"", "metaserver", _("URI"), _("Connect to a different metaserver for internet gaming."),
+	  {_("Networking:"), "metaserver", _("URI"), _("Connect to a different metaserver for internet gaming."),
 		false},
 	  {"", "metaserverport", _("n"),
 		/** TRANSLATORS: `n` references a numerical placeholder */
@@ -169,6 +160,11 @@ void fill_parameter_vector() {
 		_("Connect to a different server address from the add-ons manager."), false},
 	  {"", "addon_server_port", _("n"),
 		_("Connect to a different server port from the add-ons manager."), false},
+	  {"", "write_syncstreams", "",
+		/** TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are used in multiplayer
+		 */
+		/** TRANSLATORS: games to make sure that there is no mismatch between the players. */
+		_("Create syncstream dump files to help debug network games."), true},
 
 	  /// Interface options
 	  {_("Graphic options:"), "fullscreen", _("[true|false*]"),

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -185,7 +185,6 @@ void fill_parameter_vector() {
 		_("y"),
 		/** TRANSLATORS: `y` references a window height placeholder */
 		_("Height `y` of the window in pixel."), false},
-	  {"", "inputgrab", _("[true|false*]"), _("Whether to grab the mouse input."), true},
 	  {"", "sdl_cursor", _("[true*|false]"), _("Whether to use the mouse cursor provided by SDL."),
 		true},
 	  {"", "tooltip_accessibility_mode", _("[true|false*]"), _("Whether to use sticky tooltips."),

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -189,9 +189,6 @@ void fill_parameter_vector() {
 		true},
 	  {"", "tooltip_accessibility_mode", _("[true|false*]"), _("Whether to use sticky tooltips."),
 		true},
-	  {"", "maxfps", _("n"),
-		/** TRANSLATORS: `n` references a numerical placeholder */
-		_("Maximal optical framerate `n` of the game."), true},
 	  {"", "theme", _("DIRNAME"),
 		_("The path to the active UI theme, relative to the Widelands home directory."), false},
 	  /// Window options

--- a/src/wlapplication_messages.cc
+++ b/src/wlapplication_messages.cc
@@ -144,8 +144,8 @@ void fill_parameter_vector() {
 		_("Show in-game chat with transparent background."), true},
 	  {"", "toolbar_pos", _("[...]"), _("Bitmask to set the toolbar location and mode."), true},
 	  /// Networking
-	  {_("Networking:"), "metaserver", _("URI"), _("Connect to a different metaserver for internet gaming."),
-		false},
+	  {_("Networking:"), "metaserver", _("URI"),
+		_("Connect to a different metaserver for internet gaming."), false},
 	  {"", "metaserverport", _("n"),
 		/** TRANSLATORS: `n` references a numerical placeholder */
 		_("Port number `n` of the metaserver for internet gaming."), false},

--- a/src/wlapplication_options.cc
+++ b/src/wlapplication_options.cc
@@ -31,6 +31,8 @@
 #include "io/filesystem/disk_filesystem.h"
 #include "logic/filesystem_constants.h"
 
+bool g_write_syncstreams = false;
+
 static Profile g_options(Profile::err_log);
 
 static std::string config_file;

--- a/src/wlapplication_options.h
+++ b/src/wlapplication_options.h
@@ -26,6 +26,9 @@
 
 #include "io/profile.h"
 
+/* Command line option */
+extern bool g_write_syncstreams;
+
 /*
  * Further explanations for all functions and its return values
  * can be found in io/profile.cc

--- a/src/wui/CMakeLists.txt
+++ b/src/wui/CMakeLists.txt
@@ -4,6 +4,7 @@ wl_library(wui_sound_options
     sound_options.h
   DEPENDS
     base
+    graphic_fonthandler
     graphic_styles
     graphic_text_layout
     sound

--- a/src/wui/CMakeLists.txt
+++ b/src/wui/CMakeLists.txt
@@ -4,7 +4,6 @@ wl_library(wui_sound_options
     sound_options.h
   DEPENDS
     base
-    graphic
     graphic_fonthandler
     graphic_styles
     graphic_text_layout

--- a/src/wui/CMakeLists.txt
+++ b/src/wui/CMakeLists.txt
@@ -4,6 +4,7 @@ wl_library(wui_sound_options
     sound_options.h
   DEPENDS
     base
+    graphic
     graphic_fonthandler
     graphic_styles
     graphic_text_layout

--- a/src/wui/sound_options.cc
+++ b/src/wui/sound_options.cc
@@ -57,12 +57,7 @@ public:
 	             const std::string& title,
 	             SoundType type,
 	             FxId representative_fx = kNoSoundEffect)
-	   : UI::Box(parent,
-	             slider_to_panel_style(style),
-	             name,
-	             0,
-	             0,
-	             UI::Box::Horizontal),
+	   : UI::Box(parent, slider_to_panel_style(style), name, 0, 0, UI::Box::Horizontal),
 	     volume_(this,
 	             "volume",
 	             0,
@@ -145,12 +140,7 @@ private:
 }  // namespace
 
 SoundOptions::SoundOptions(UI::Panel& parent, UI::SliderStyle style)
-   : UI::Box(&parent,
-             slider_to_panel_style(style),
-             "sound_options",
-             0,
-             0,
-             UI::Box::Vertical),
+   : UI::Box(&parent, slider_to_panel_style(style), "sound_options", 0, 0, UI::Box::Vertical),
      custom_songset_(
         this,
         panel_style_,

--- a/src/wui/sound_options.cc
+++ b/src/wui/sound_options.cc
@@ -33,6 +33,7 @@ namespace {
 class SoundControl : public UI::Box {
 private:
 	static constexpr int kSliderWidth = 200;
+	static constexpr int kLabelWidth = 250;
 	static constexpr int kCursorWidth = 28;
 	static constexpr int kSpacing = 16;
 
@@ -69,7 +70,7 @@ public:
 	             /** TRANSLATORS: Tooltip for volume slider in sound options */
 	             _("Changes the volume. Click to hear a sample."),
 	             kCursorWidth),
-	     enable_(this, panel_style_, "enable", Vector2i::zero(), title),
+	     enable_(this, panel_style_, "enable", Vector2i::zero(), title, "", kLabelWidth),
 	     type_(type),
 	     fx_(representative_fx) {
 		set_inner_spacing(kSpacing);

--- a/src/wui/sound_options.cc
+++ b/src/wui/sound_options.cc
@@ -157,12 +157,9 @@ SoundOptions::SoundOptions(UI::Panel& parent, UI::SliderStyle style)
 
 	// TODO(tothxa): This shouldn't be duplicated, but de-duplicating seems harder than it's worth.
 	const std::vector<std::string> labels = {
-		pgettext("sound_options", "Music"),
-		pgettext("sound_options", "Chat Messages"),
-		pgettext("sound_options", "Game Messages"),
-		pgettext("sound_options", "User Interface"),
-		pgettext("sound_options", "Ambient Sounds")
-	};
+	   pgettext("sound_options", "Music"), pgettext("sound_options", "Chat Messages"),
+	   pgettext("sound_options", "Game Messages"), pgettext("sound_options", "User Interface"),
+	   pgettext("sound_options", "Ambient Sounds")};
 
 	const UI::FontStyleInfo& font_style = g_style_manager->font_style(
 	   style == UI::SliderStyle::kFsMenu ? UI::FontStyle::kFsMenuLabel : UI::FontStyle::kWuiLabel);
@@ -191,7 +188,8 @@ SoundOptions::SoundOptions(UI::Panel& parent, UI::SliderStyle style)
 	   this, style, max_w, "ui", pgettext("sound_options", "User Interface"), SoundType::kUI));
 
 	add(new SoundControl(
-	   this, style, max_w, "ambient", pgettext("sound_options", "Ambient Sounds"), SoundType::kAmbient,
+	   this, style, max_w, "ambient", pgettext("sound_options", "Ambient Sounds"),
+	   SoundType::kAmbient,
 	   SoundHandler::register_fx(SoundType::kAmbient, "sound/create_construction_site")));
 
 	add(&custom_songset_);

--- a/src/wui/sound_options.cc
+++ b/src/wui/sound_options.cc
@@ -18,6 +18,7 @@
 #include "wui/sound_options.h"
 
 #include "base/i18n.h"
+#include "graphic/font_handler.h"
 #include "graphic/text_layout.h"
 #include "sound/sound_handler.h"
 #include "ui_basic/checkbox.h"
@@ -72,8 +73,13 @@ public:
 	     type_(type),
 	     fx_(representative_fx) {
 		set_inner_spacing(kSpacing);
-		add(&volume_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
-		add(&enable_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
+		if (UI::g_fh->fontset()->is_rtl()) {
+			add(&volume_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
+			add(&enable_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
+		} else {
+			add(&enable_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
+			add(&volume_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
+		}
 
 		if (SoundHandler::is_backend_disabled()) {
 			enable_.set_enabled(false);

--- a/src/wui/sound_options.cc
+++ b/src/wui/sound_options.cc
@@ -17,9 +17,10 @@
 
 #include "wui/sound_options.h"
 
+#include <vector>
+
 #include "base/i18n.h"
 #include "graphic/font_handler.h"
-#include "graphic/style_manager.h"
 #include "graphic/text_layout.h"
 #include "sound/sound_handler.h"
 #include "ui_basic/checkbox.h"
@@ -29,16 +30,19 @@
 namespace {
 
 constexpr int kPadding = 4;
+constexpr int kSliderWidth = 200;
+constexpr int kSliderHeight = 16;
+constexpr int kCursorWidth = 28;
+constexpr int kSpacing = 32;
+
+UI::PanelStyle slider_to_panel_style(UI::SliderStyle style) {
+	return style == UI::SliderStyle::kFsMenu ? UI::PanelStyle::kFsMenu : UI::PanelStyle::kWui;
+}
 
 /**
  * UI elements to set sound properties for 1 type of sounds.
  */
 class SoundControl : public UI::Box {
-private:
-	static constexpr int kSliderWidth = 200;
-	static constexpr int kCursorWidth = 28;
-	static constexpr int kSliderSpacing = 16;
-
 public:
 	/**
 	 * @brief SoundControl Creates a new sound control box
@@ -49,13 +53,12 @@ public:
 	 */
 	SoundControl(UI::Box* parent,
 	             UI::SliderStyle style,
-	             int checkbox_width,
 	             const std::string& name,
 	             const std::string& title,
 	             SoundType type,
 	             FxId representative_fx = kNoSoundEffect)
 	   : UI::Box(parent,
-	             style == UI::SliderStyle::kFsMenu ? UI::PanelStyle::kFsMenu : UI::PanelStyle::kWui,
+	             slider_to_panel_style(style),
 	             name,
 	             0,
 	             0,
@@ -65,7 +68,7 @@ public:
 	             0,
 	             0,
 	             kSliderWidth,
-	             kSliderSpacing,
+	             kSliderHeight,
 	             0,
 	             g_sh->get_max_volume(),
 	             g_sh->get_volume(type),
@@ -73,30 +76,39 @@ public:
 	             /** TRANSLATORS: Tooltip for volume slider in sound options */
 	             _("Changes the volume. Click to hear a sample."),
 	             kCursorWidth),
-	     enable_(this, panel_style_, "enable", Vector2i::zero(), title, "", checkbox_width),
+	     enable_(this, panel_style_, "enable", Vector2i::zero(), title),
 	     type_(type),
 	     fx_(representative_fx) {
 		set_inner_spacing(kPadding);
 		if (UI::g_fh->fontset()->is_rtl()) {
-			add(&volume_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
-			add(&enable_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
+			add(&volume_, UI::Box::Resizing::kAlign, UI::Align::kRight);
+			add(&enable_, UI::Box::Resizing::kAlign, UI::Align::kRight);
 		} else {
-			add(&enable_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
-			add(&volume_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
+			add(&enable_, UI::Box::Resizing::kAlign, UI::Align::kLeft);
+			add(&volume_, UI::Box::Resizing::kAlign, UI::Align::kLeft);
 		}
 
 		if (SoundHandler::is_backend_disabled()) {
 			enable_.set_enabled(false);
-			volume_.set_enabled(false);
+			volume_.set_visible(false);
 		} else {
 			enable_.set_state(g_sh->is_sound_enabled(type));
-			volume_.set_enabled(g_sh->is_sound_enabled(type));
+			volume_.set_visible(g_sh->is_sound_enabled(type));
 
 			enable_.changedto.connect([this](bool on) { enable_changed(on); });
 			volume_.changedto.connect([this](int32_t value) { volume_changed(value); });
 			volume_.clicked.connect([this] { play_sound_sample(); });
 		}
 		set_thinks(false);
+	}
+
+	int checkbox_width() {
+		enable_.layout();
+		return enable_.get_w();
+	}
+
+	void set_checkbox_width(const int w) {
+		enable_.set_size(w, enable_.get_h());
 	}
 
 private:
@@ -111,7 +123,7 @@ private:
 	/// the volume slider accordingly
 	void enable_changed(bool on) {
 		enable_.set_state(on);
-		volume_.set_enabled(on);
+		volume_.set_visible(on);
 		g_sh->set_enable_sound(type_, on);
 	}
 
@@ -130,13 +142,11 @@ private:
 	const FxId fx_;
 };
 
-constexpr int kSpacing = 12;
-
 }  // namespace
 
 SoundOptions::SoundOptions(UI::Panel& parent, UI::SliderStyle style)
    : UI::Box(&parent,
-             style == UI::SliderStyle::kFsMenu ? UI::PanelStyle::kFsMenu : UI::PanelStyle::kWui,
+             slider_to_panel_style(style),
              "sound_options",
              0,
              0,
@@ -155,42 +165,35 @@ SoundOptions::SoundOptions(UI::Panel& parent, UI::SliderStyle style)
 
 	set_inner_spacing(kSpacing);
 
-	// TODO(tothxa): This shouldn't be duplicated, but de-duplicating seems harder than it's worth.
-	const std::vector<std::string> labels = {
-	   pgettext("sound_options", "Music"), pgettext("sound_options", "Chat Messages"),
-	   pgettext("sound_options", "Game Messages"), pgettext("sound_options", "User Interface"),
-	   pgettext("sound_options", "Ambient Sounds")};
+	std::vector<SoundControl*> controls;
+	controls.emplace_back(new SoundControl(
+	   this, style, "music", pgettext("sound_options", "Music"), SoundType::kMusic));
 
-	const UI::FontStyleInfo& font_style = g_style_manager->font_style(
-	   style == UI::SliderStyle::kFsMenu ? UI::FontStyle::kFsMenuLabel : UI::FontStyle::kWuiLabel);
+	controls.emplace_back(new SoundControl(
+	   this, style, "chat", pgettext("sound_options", "Chat Messages"), SoundType::kChat,
+	   SoundHandler::register_fx(SoundType::kChat, "sound/lobby_chat")));
+
+	controls.emplace_back(new SoundControl(
+	   this, style, "messages", pgettext("sound_options", "Game Messages"), SoundType::kMessage,
+	   SoundHandler::register_fx(SoundType::kMessage, "sound/message")));
+
+	controls.emplace_back(new SoundControl(
+	   this, style, "ui", pgettext("sound_options", "User Interface"), SoundType::kUI));
+
+	controls.emplace_back(new SoundControl(
+	   this, style, "ambient", pgettext("sound_options", "Ambient Sounds"), SoundType::kAmbient,
+	   SoundHandler::register_fx(SoundType::kAmbient, "sound/create_construction_site")));
 
 	int max_w = 0;
-	for (const std::string& label : labels) {
-		const int w = text_width(label, font_style);
-		if (w > max_w) {
+	for (SoundControl* control : controls) {
+		add(control);
+		if (const int w = control->checkbox_width(); w > max_w) {
 			max_w = w;
 		}
 	}
-	max_w += kStateboxSize + kPadding;
-
-	add(new SoundControl(
-	   this, style, max_w, "music", pgettext("sound_options", "Music"), SoundType::kMusic));
-
-	add(new SoundControl(this, style, max_w, "chat", pgettext("sound_options", "Chat Messages"),
-	                     SoundType::kChat,
-	                     SoundHandler::register_fx(SoundType::kChat, "sound/lobby_chat")));
-
-	add(new SoundControl(this, style, max_w, "messages", pgettext("sound_options", "Game Messages"),
-	                     SoundType::kMessage,
-	                     SoundHandler::register_fx(SoundType::kMessage, "sound/message")));
-
-	add(new SoundControl(
-	   this, style, max_w, "ui", pgettext("sound_options", "User Interface"), SoundType::kUI));
-
-	add(new SoundControl(
-	   this, style, max_w, "ambient", pgettext("sound_options", "Ambient Sounds"),
-	   SoundType::kAmbient,
-	   SoundHandler::register_fx(SoundType::kAmbient, "sound/create_construction_site")));
+	for (SoundControl* control : controls) {
+		control->set_checkbox_width(max_w);
+	}
 
 	add(&custom_songset_);
 	custom_songset_.set_state(g_sh->use_custom_songset());
@@ -201,7 +204,7 @@ SoundOptions::SoundOptions(UI::Panel& parent, UI::SliderStyle style)
 	// the MultilineTextarea is not added to the Box. So, we create and add it even if its text is
 	// empty.
 	UI::MultilineTextarea* sound_warning =
-	   new UI::MultilineTextarea(this, "warning", 0, 0, 100, 0, UI::PanelStyle::kWui, "",
+	   new UI::MultilineTextarea(this, "warning", 0, 0, 100, 0, slider_to_panel_style(style), "",
 	                             UI::Align::kLeft, UI::MultilineTextarea::ScrollMode::kNoScrolling);
 	add(sound_warning, UI::Box::Resizing::kExpandBoth);
 


### PR DESCRIPTION
**Type of change**
Cleanup

**Issue(s) closed**
Fixes #4733

Also fixed a bug in `Statebox::layout()` that prevented setting the width of checkboxes to exactly fit the text.

**Possible regressions**
 * Setting options, especially writing syncstreams and mouse grabbing issues.
 * Checkbox layouting.

**Additional context**
The translation stats space fix has some ugly workarounds for issues like #6036