### PR TITLE
Fix editbox horizontal scrolling mouse clicks regression

### DIFF
--- a/src/ui_basic/textinput.cc
+++ b/src/ui_basic/textinput.cc
@@ -458,6 +458,7 @@ bool AbstractTextInputPanel::handle_mousewheel(int32_t x, int32_t y, uint16_t mo
 }
 
 void AbstractTextInputPanel::set_caret_to_cursor_pos(int32_t x, int32_t y) {
+	x += d_->scrolloffset;
 	y += d_->scrollbar.get_scrollpos();
 
 	unsigned previous_line_index = d_->ww.offset_of_line_at(y);


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes a regression with clicking into editboxes that scroll horizontally.

**To reproduce**
1. In any single-line editbox, enter a very long text so it scrolls horizontally.
2. Move the caret to the right.
3. Click into the editbox with the mouse to move the caret or to select text.

**New behavior**
Add the scrolling offset in the cursorpos-to-caretpos calculation.