### PR TITLE
Fix documentation CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
         python-version: 3.x
     - name: Generate documentation
       run: |
-        pip install sphinx
+        pip install sphinxcontrib-serializinghtml==1.1.5 sphinx
         cd doc/sphinx
         mkdir source/_static
         ./extract_rst.py


### PR DESCRIPTION
`sphinxcontrib-serializinghtml` v1.1.6 breaks the workflow, force version 1.1.5