### PR TITLE
commit pure translations separately

### DIFF
--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -106,11 +106,12 @@ set -x
 # use force to make sure really all files get pulled
 tx pull -a -f
 
-runUpdateScripts=1 # run them at least once
+run_update_scripts=at_least_once # run them at least once
 if [ -n "$(git status -s)" ]; then
   update_authors
   update_appdata
   update_statistics
+  run_update_scripts= # they have run now
 
   # Stage translations
   git add 'po/*/*.po' 'data/i18n/locales/*.json' 'xdg/translations/*.json'
@@ -119,8 +120,6 @@ if [ -n "$(git status -s)" ]; then
 
   # commit translations
   git commit -m "Fetched translations and updated data."
-
-  runUpdateScripts= # has run now
 fi
 
 # -----------------------
@@ -154,10 +153,13 @@ if [ -n "$(git status -s)" ]; then
 
   # Undo one-liner diffs of pure timestamps with no other content
   undo_oneliner_diffs
-  runUpdateScripts=2 # run, files have changed
+
+  if [ -z "$run_update_scripts" ] && [ -n "$(git status -s)" ]; then
+    run_update_scripts=for_pot # run again, pot files have changed
+  fi
 fi
 
-if [ -n "$runUpdateScripts" ]; then # if not run yet or pot file has changed
+if [ -n "$run_update_scripts" ]; then # if not run yet or pot files have changed
   update_authors # in case something has changed unexpectedly
   update_appdata # in case something has changed unexpectedly
   update_statistics

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -45,7 +45,7 @@ git checkout master
 git pull "$push_target" master
 
 # Double-check that it's clean
-STATUS="$(git status)"
+STATUS="$(LANG=C git status)"
 echo "${STATUS}"
 if [[ "${STATUS}" != *"nothing to commit, working tree clean"* ]]; then
   echo "git status must be empty to prevent accidental commits etc."

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -43,6 +43,7 @@ fi
 # Checkout master and pull latest version
 git checkout master
 git pull "$push_target" master
+had_commit=''
 
 # Double-check that it's clean
 STATUS="$(LANG=C git status)"

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -171,15 +171,13 @@ if [ -n "$(git status -s)" ]; then
   # Undo one-liner diffs of pure timestamps with no other content
   # for fetched translations (*.po) (in case something plays tricks, see #5937)
   undo_oneliner_diffs
-fi
 
-# in case translations were edited while this script was running
-update_authors
-update_appdata
-# and this also changes by a catalog change
-update_statistics
+  # in case translations were edited while this script was running
+  update_authors
+  update_appdata
+  # and this also changes by a catalog change
+  update_statistics
 
-if [ -n "$(git status -s)" ]; then
   # Stage changes
   # - Translations and templates
   git add 'po/*/*.po' 'po/*/*.pot' 'data/i18n/locales/*.json' 'xdg/translations/*.json' || true

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -137,6 +137,7 @@ if [ -n "$(git status -s)" ]; then
 
   # commit translations
   git commit -m "Fetched translations and updated data."
+  had_commit=yes
 fi
 
 # -----------------------
@@ -184,9 +185,10 @@ else
 
   # Commit
   git commit -m "Updated translations catalogs and statistics."
+  had_commit=yes
 fi
 
-if [ "$(git show --no-patch --format=format:_ FETCH_HEAD HEAD)" != "_" ]; then # check if it is the same commit
+if [ -n "$had_commit" ]; then # if a commit was created
   # push fetched translations and updated catalogs
   git push "$push_target" master
 fi

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -147,5 +147,7 @@ else
   git commit -m "Updated translations catalogs."
 fi
 
-# push fetched translations and updated catalogs
-git push "$push_target" master
+if [ "$(git show --no-patch --format=format:_ FETCH_HEAD HEAD)" != "_" ]; then # check if it is the same commit
+  # push fetched translations and updated catalogs
+  git push "$push_target" master
+fi

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -82,9 +82,7 @@ if [ -n "$(git status -s)" ]; then
 fi
 
 # Pull All translations from Transifex
-# tx pull -a
-# Force-pull translations because some would get skipped accidentally
-tx pull -fa
+tx pull -a --use-git-timestamps
 
 # Update authors file
 if python3 utils/update_authors.py; then

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -20,14 +20,14 @@ fi
 
 # Move up if we're not in the base directory.
 if [ -d "../utils" ]; then
-	pushd ..
+  pushd ..
 fi
 
 # Make sure 'utils/buildcat.py' is there.
 if [ ! -f "utils/buildcat.py" ]; then
-	echo "Unable to find 'utils/buildcat.py'."
-	echo "Make sure you start this script from Widelands' base or utils directory.";
-	exit 1
+  echo "Unable to find 'utils/buildcat.py'."
+  echo "Make sure you start this script from Widelands' base or utils directory.";
+  exit 1
 fi
 
 # Ensure that our git is clean

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -90,9 +90,9 @@ update_statistics() {
 gitAddGeneratedFiles() {
   # Stage changes
   # - Authors
-  git add data/txts/*.lua || true
+  git add 'data/txts/*.lua' || true
   # - Locale data
-  git add data/i18n/*.lua || true
+  git add 'data/i18n/*.lua' || true
   # - Appdata
   git add xdg/org.widelands.Widelands.appdata.xml xdg/org.widelands.Widelands.desktop || true
   # - Statistics
@@ -113,7 +113,7 @@ if [ -n "$(git status -s)" ]; then
   update_statistics
 
   # Stage translations
-  git add po/*/*.po data/i18n/locales/*.json xdg/translations/*.json
+  git add 'po/*/*.po' 'data/i18n/locales/*.json' 'xdg/translations/*.json'
   # and generated files
   gitAddGeneratedFiles
 
@@ -168,7 +168,7 @@ if [ -z "$(git status -s)" ]; then
 else
   # Stage changes
   # - Translations and templates
-  git add po/*/*.po po/*/*.pot data/i18n/locales/*.json xdg/translations/*.json || true
+  git add 'po/*/*.po' 'po/*/*.pot' 'data/i18n/locales/*.json' 'xdg/translations/*.json' || true
   # - generated files
   gitAddGeneratedFiles
 

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -131,8 +131,8 @@ python3 utils/buildcat.py
 undo_oneliner_diffs() {
   # Undo one-liner diffs of pure timestamps with no other content
   set +x
-  git diff --numstat po/ | sed -En 's/^1\t1\t//p' | while IFS= read -r entry; do
-    if ! git diff "$entry" | grep '^[+-][^+-]' | grep -qv '^[+-]"POT-Creation-Date:'
+  for entry in $(git diff --numstat po/ | sed -En 's/^1\t1\t//p'); do
+    if [ -z "$(git diff "$entry" | grep '^[+-][^+-]' | grep -v '^[+-]"POT-Creation-Date:')" ]
     then # no other diff line remaining
       echo "Skipping changes to $entry"
       git checkout "$entry"

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -63,11 +63,11 @@ python3 utils/buildcat.py
 undo_oneliner_diffs() {
   # Undo one-liner diffs of pure timestamps with no other content
   set +x
-  for entry in $(git diff --numstat po/ | sed -En 's/^1\t1\t//p'); do
-    if [ -z "$(git diff "$entry" | grep '^[+-][^+-]' | grep -v '^[+-]"POT-Creation-Date:')" ]
-    then
+  git diff --numstat po/ | sed -En 's/^1\t1\t//p' | while IFS= read -r entry; do
+    if ! git diff "$entry" | grep '^[+-][^+-]' | grep -qv '^[+-]"POT-Creation-Date:'
+    then # no other diff line remaining
       echo "Skipping changes to $entry"
-      git checkout $entry
+      git checkout "$entry"
     fi
   done
   set -x
@@ -87,8 +87,7 @@ fi
 tx pull -fa
 
 # Update authors file
-python3 utils/update_authors.py
-if [ $? -eq 0 ] ; then
+if python3 utils/update_authors.py; then
   echo "Updated authors";
 else
   echo "Failed updating authors";
@@ -96,8 +95,7 @@ else
 fi
 
 # Update appdata
-python3 utils/update_appdata.py
-if [ $? -eq 0 ] ; then
+if python3 utils/update_appdata.py; then
   echo "Updated appdata";
 else
   echo "Failed updating appdata";
@@ -105,8 +103,7 @@ else
 fi
 
 # Update statistics
-python3 utils/update_translation_stats.py
-if [ $? -eq 0 ] ; then
+if python3 utils/update_translation_stats.py; then
   echo "Updated translation stats";
 else
   echo "Failed to update translation stats";

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -55,6 +55,9 @@ fi
 
 echo "Working tree is clean, continuing"
 
+# -----------------------
+# functions:
+
 update_authors() {
   # Update authors file
   if python3 utils/update_authors.py; then
@@ -116,6 +119,10 @@ undo_oneliner_diffs() {
 # Print all commands.
 set -x
 
+# ------------------------------------------------
+# translations from transifex (*.po, *.json)
+# and changes from git (since last script run)
+
 # Pull All translations from Transifex
 # use force to make sure really all files get pulled
 tx pull -a -f
@@ -142,6 +149,7 @@ if [ -n "$(git status -s)" ]; then
 fi
 
 # -----------------------
+# Source catalogs:
 
 # Update source catalogs
 python3 utils/buildcat.py
@@ -163,16 +171,15 @@ if [ -n "$(git status -s)" ]; then
   # Undo one-liner diffs of pure timestamps with no other content
   # for fetched translations (*.po) (in case something plays tricks, see #5937)
   undo_oneliner_diffs
-
 fi
 
-update_authors # in case something has changed unexpectedly
-update_appdata # in case something has changed unexpectedly
+# in case translations were edited while this script was running
+update_authors
+update_appdata
+# and this also changes by a catalog change
 update_statistics
 
-if [ -z "$(git status -s)" ]; then
-  echo "Run completed, nothing to commit."
-else
+if [ -n "$(git status -s)" ]; then
   # Stage changes
   # - Translations and templates
   git add 'po/*/*.po' 'po/*/*.pot' 'data/i18n/locales/*.json' 'xdg/translations/*.json' || true

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -146,6 +146,8 @@ if [ -n "$(git status -s)" ]; then
   # commit translations
   git commit -m "Fetched translations and updated data."
   had_commit=yes
+else
+  echo "No changes in translations and data."
 fi
 
 # -----------------------
@@ -187,9 +189,13 @@ if [ -n "$(git status -s)" ]; then
   # Commit
   git commit -m "Updated translations catalogs and statistics."
   had_commit=yes
+else
+  echo "No changes in translations catalogs."
 fi
 
 if [ -n "$had_commit" ]; then # if a commit was created
   # push fetched translations and updated catalogs
   git push "$push_target" master
+else
+  echo "Nothing changed, skipped git push."
 fi

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -58,8 +58,8 @@ echo "Working tree is clean, continuing"
 set -x
 
 # Pull All translations from Transifex
-# use git timestamps because the timestamps on disk are too new
-tx pull -a --use-git-timestamps
+# use force to make sure really all files get pulled
+tx pull -a -f
 
 if [ -n "$(git status -s)" ]; then
   # Stage and commit translations
@@ -91,11 +91,11 @@ if [ -n "$(git status -s)" ]; then
   # Push source catalogs to Transifex
   tx push -s
   sleep 65 # wait for translation files to be updated
-fi
 
-# Pull All translations from Transifex
-# (timestamps on disk are old enough this time)
-tx pull -a
+  # Pull All translations from Transifex
+  # use force to make sure really all files get pulled
+  tx pull -a -f
+fi
 
 # Update authors file
 if python3 utils/update_authors.py; then

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -63,7 +63,7 @@ tx pull -a -f
 
 if [ -n "$(git status -s)" ]; then
   # Stage and commit translations
-  git add po/*/*.po data/i18n/locales/*.json xdg/translations/*.json || true
+  git add po/*/*.po data/i18n/locales/*.json xdg/translations/*.json
   git commit -m "Fetched translations."
 fi
 

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -95,6 +95,9 @@ if [ -n "$(git status -s)" ]; then
   # Pull All translations from Transifex
   # use force to make sure really all files get pulled
   tx pull -a -f
+
+  # Undo one-liner diffs of pure timestamps with no other content
+  undo_oneliner_diffs
 fi
 
 # Update authors file
@@ -124,9 +127,6 @@ fi
 # Fix formatting for Lua
 python3 utils/fix_formatting.py --lua --dir data/i18n
 python3 utils/fix_formatting.py --lua --dir data/txts
-
-# Undo one-liner diffs of pure timestamps with no other content
-undo_oneliner_diffs
 
 if [ -z "$(git status -s)" ]; then
   echo "Run completed, nothing to commit."

--- a/utils/merge_and_push_translations.sh
+++ b/utils/merge_and_push_translations.sh
@@ -124,12 +124,12 @@ tx pull -a -f
 # for fetched translations (*.po) (in case something plays tricks, see #5937)
 undo_oneliner_diffs
 
-run_update_scripts=at_least_once # run them at least once
+# These may have changes either from git or from transifex
+update_authors
+update_appdata
+
 if [ -n "$(git status -s)" ]; then
-  update_authors
-  update_appdata
   update_statistics
-  run_update_scripts= # they have run now
 
   # Stage translations
   git add 'po/*/*.po' 'data/i18n/locales/*.json' 'xdg/translations/*.json'
@@ -164,16 +164,11 @@ if [ -n "$(git status -s)" ]; then
   # for fetched translations (*.po) (in case something plays tricks, see #5937)
   undo_oneliner_diffs
 
-  if [ -z "$run_update_scripts" ] && [ -n "$(git status -s)" ]; then
-    run_update_scripts=for_pot # run again, pot files have changed
-  fi
 fi
 
-if [ -n "$run_update_scripts" ]; then # if not run yet or pot files have changed
-  update_authors # in case something has changed unexpectedly
-  update_appdata # in case something has changed unexpectedly
-  update_statistics
-fi
+update_authors # in case something has changed unexpectedly
+update_appdata # in case something has changed unexpectedly
+update_statistics
 
 if [ -z "$(git status -s)" ]; then
   echo "Run completed, nothing to commit."


### PR DESCRIPTION
**Type of change**
Enhancement

**Issue(s) closed**
replaces #6040 

**To reproduce**
Try to review the translations in 0c2abcc5b6. Quite difficult because there are many line changes as well. 

**New behavior**
Edits of translations are committed separately from updating the files from the code.
This allows to review the translations much simpler.

**How it works**
*For features and functional changes:*
- Fetch the translations from transifex
- commit those if there are any (with a identifiable commit message)
- update the translation template files (.pot)
- push them to transifex
- fetch the updated translations
- (update other files like statistics and authors)
- commit translations files and their templates (with changes related to each other)

**Possible regressions**
- a bit more noise because the same translation file might be committed twice in a row
- no other known

**Additional context**
not sure about the commit messages: `Fetched translations.` and `Updated translations catalogs.`
(before `Fetched translations and updated catalogs.`)

I included some clean-up as well (related to #6063) because having edits and cleanup of one file in separate pr results in merge conflicts.