### PR TITLE
Misc Naval Warfare Segfault/Assert Fixes

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -914,9 +914,16 @@ void Ship::warship_soldier_callback(Game& game,
 	worker->set_location(nullptr);
 	worker->start_task_shipping(game, nullptr);
 
+	// We may temporarily exceed the ship's capacity while swapping heroes and rookies
+	const Quantity old_capacity = ship->capacity_;
+	ship->capacity_ = std::max<Quantity>(old_capacity, ship->items_.size() + 1);
+
 	ship->add_item(game, ShippingItem(*worker));
 	ship->update_warship_soldier_request(false);
 	ship->kickout_superfluous_soldiers(game);
+
+	assert(ship->items_.size() <= old_capacity);
+	ship->capacity_ = old_capacity;
 }
 
 bool Ship::is_attackable_enemy_warship(const Bob& b) const {
@@ -1116,8 +1123,10 @@ void Ship::warship_command(Game& game,
 		assert(parameters.size() == 1);
 		warship_soldier_capacity_ =
 		   std::max(std::min(parameters.back(), get_capacity()), min_warship_soldier_capacity());
-		update_warship_soldier_request(false);
-		kickout_superfluous_soldiers(game);
+		if (get_ship_type() == ShipType::kWarship) {
+			update_warship_soldier_request(false);
+			kickout_superfluous_soldiers(game);
+		}
 		return;
 	}
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
A couple of assorted assertion and segfault fixes around warship soldier capacities.

**To reproduce**
All bugs are reproducible with the replay of the game the-x and I had yesterday but which he asked me not do disclose due to the tournament.
- The first issue is an assert that happens during soldier swapping on a warship with maximal soldier capacity, in debug builds only. The ship can briefly contain more items than it has capacity for, which is not a problem since the extra soldier is kicked out again immediately afterwards.
- The second issue is related to reducing the soldier capacity of a transport ship that is being refitted while carrying some wares and no soldiers. Don't know the exact circumstances that trigger it, but transport ships should simply skip updating their warship soldier requests and kickouts.

**Possible regressions**
Shouldn't be any I think