### PR TITLE
Fix chat player color indices if some players are not in the game

### DIFF
--- a/src/wui/interactive_base.cc
+++ b/src/wui/interactive_base.cc
@@ -1760,11 +1760,14 @@ UI::UniqueWindow& InteractiveBase::show_ship_window(Widelands::Ship* ship) {
 }
 
 ChatColorForPlayer InteractiveBase::color_functor() const {
-	return [this](int player_number) {
-		return (player_number > 0 &&
-		        player_number <= egbase().player_manager()->get_number_of_players()) ?
-                &egbase().player(player_number).get_playercolor() :
-                nullptr;
+	return [this](int player_number) -> const RGBColor* {
+		if (player_number > 0 && player_number <= kMaxPlayers) {
+			const Widelands::Player* player = egbase().get_player(player_number);
+			if (player != nullptr) {
+				return &player->get_playercolor();
+			}
+		}
+		return nullptr;
 	};
 }
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes an issue where chat player colours are wrong.

**To reproduce**
1. Start an MP game on a map for 3 players where the first slot is set to Closed, the second slot is taken by the host, and the third slot is occupied by a client.
2. Chat messages from the p3 client are rendered as if p3 is a spectator.

**New behavior**
All players' chat is in the correct player colours.

**Possible regressions**
Chat colouring

**Additional context**
Yesterday playing with the-x I once got a segfault on starting an MP game when the-x (host) launched the game at exactly the same time when I (client) sent a chat message. That situation is not reproducible, but I think it might be fixed by this patch as well.