### PR TITLE
Well-defined shipyards collaboration

### DIFF
--- a/src/logic/map_objects/tribes/production_program.cc
+++ b/src/logic/map_objects/tribes/production_program.cc
@@ -2089,7 +2089,7 @@ void ProductionProgram::ActConstruct::execute(Game& game, ProductionSite& psite)
 	Area<FCoords> area(map.get_fcoords(psite.get_position()), radius);
 	if (map.find_reachable_immovables(game, area, &immovables, cstep, FindImmovableByDescr(descr)) !=
 	    0u) {
-		state.objvar = immovables[0].object;
+		state.objvar = immovables.at(game.logic_rand() % immovables.size()).object;
 
 		psite.working_positions_.at(psite.main_worker_)
 		   .worker.get(game)


### PR DESCRIPTION
**Issue(s) closed**
As observed in today's tournament game. When multiple shipyards are close by, they may or may not collaborate on the same ship-building site, but which site is chosen is currently arbitrary.

**New behavior**
When a shipyard has multiple shipconstructionsites nearby, then on each working cycle a random site to work on is picked.

**Possible regressions**
N/A

**Additional context**
Although not critical, I would like to include this one-liner patch in the next tournament tag @hessenfarmer 