### PR TITLE
Fix naval battle stacking in complex situations

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2385,6 +2385,9 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 	dst->fill_rect(energy_complement, complement_color);
 
 	// Now soldier strength bonus bars
+	if (ship_type_ != ShipType::kWarship) {
+		return;
+	}
 	const unsigned bonus = get_sea_attack_soldier_bonus(egbase);
 	if (bonus > 0) {
 		assert(bonus < 2000);  // Sanity check

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1191,7 +1191,8 @@ constexpr uint32_t kAttackAnimationDuration = 2000;
 void Ship::battle_update(Game& game) {
 	Battle& current_battle = battles_.back();
 	Ship* target_ship = current_battle.opponent.get(game);
-	if ((target_ship == nullptr || target_ship->state_is_sinking()) && !static_cast<bool>(current_battle.attack_coords)) {
+	if ((target_ship == nullptr || target_ship->state_is_sinking()) &&
+	    !static_cast<bool>(current_battle.attack_coords)) {
 		molog(game.get_gametime(), "[battle] Enemy disappeared, cancel");
 		battles_.pop_back();
 		start_task_idle(game, descr().main_animation(), 100);
@@ -1209,7 +1210,8 @@ void Ship::battle_update(Game& game) {
 		for (size_t i = nr_enemy_battles; i > 0; --i) {
 			Battle* candidate = &target_ship->battles_.at(i - 1);
 			if (candidate->opponent.get(game) == this) {
-				if (candidate->is_first != current_battle.is_first && candidate->phase == current_battle.phase) {
+				if (candidate->is_first != current_battle.is_first &&
+				    candidate->phase == current_battle.phase) {
 					// Found it
 					other_battle = candidate;
 					break;
@@ -1228,7 +1230,8 @@ void Ship::battle_update(Game& game) {
 		}
 
 		if (other_battle == nullptr) {
-			throw wexception("Warship %s could not find mirror battle against %s", get_shipname().c_str(), target_ship->get_shipname().c_str());
+			throw wexception("Warship %s could not find mirror battle against %s",
+			                 get_shipname().c_str(), target_ship->get_shipname().c_str());
 		}
 	}
 

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -938,6 +938,10 @@ bool Ship::can_be_attacked() const {
 	return get_ship_type() == ShipType::kWarship;
 }
 
+bool Ship::can_attack() const {
+	return get_ship_type() == ShipType::kWarship && !has_battle();
+}
+
 bool Ship::can_refit(const ShipType type) const {
 	return !is_refitting() && !has_battle() && type != ship_type_;
 }
@@ -1126,7 +1130,7 @@ void Ship::warship_command(Game& game,
 
 	case WarshipCommand::kAttack:
 		assert(!parameters.empty());
-		if (get_ship_type() != ShipType::kWarship) {
+		if (!can_attack()) {
 			return;
 		}
 

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -212,6 +212,13 @@ struct Ship : Bob {
 		        ship_state_ != ShipStates::kSinkAnimation &&
 		        ship_state_ != ShipStates::kExpeditionColonizing);
 	}
+	/// \returns whether the ship is currently sinking
+	[[nodiscard]] bool state_is_sinking() const {
+		return (ship_state_ == ShipStates::kSinkRequest || ship_state_ == ShipStates::kSinkAnimation);
+	}
+	[[nodiscard]] bool is_expedition_or_warship() const {
+		return expedition_ != nullptr;
+	}
 
 	/// \returns (in expedition mode only!) whether the next field in direction \arg dir is swimmable
 	[[nodiscard]] bool exp_dir_swimmable(Direction dir) const {

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -279,6 +279,7 @@ struct Ship : Bob {
 	[[nodiscard]] unsigned get_sea_attack_soldier_bonus(const EditorGameBase& egbase) const;
 
 	[[nodiscard]] bool can_be_attacked() const;
+	[[nodiscard]] bool can_attack() const;
 	[[nodiscard]] bool is_attackable_enemy_warship(const Bob&) const;
 	[[nodiscard]] uint32_t get_hitpoints() const {
 		return hitpoints_;

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -181,7 +181,7 @@ std::vector<Widelands::Bob*> AttackWindow::get_max_attackers() {
 		Widelands::Ship* warship =
 		   dynamic_cast<Widelands::Ship*>(egbase.objects().get_object(ship_serial));
 		assert(warship != nullptr);
-		if (warship->get_ship_type() == Widelands::ShipType::kWarship) {
+		if (warship->can_attack()) {
 			if (ship != nullptr) {  // Ship-to-ship combat
 				if (warship->has_attack_target(ship)) {
 					result_vector.push_back(warship);

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -256,7 +256,7 @@ InteractivePlayer::InteractivePlayer(Widelands::Game& g,
 	shipnotes_subscriber_ =
 	   Notifications::subscribe<Widelands::NoteShip>([this](const Widelands::NoteShip& note) {
 		   if (note.ship->owner().player_number() == player_number() &&
-		       !note.ship->state_is_transport() && !note.ship->exp_port_spaces().empty() &&
+		       note.ship->is_expedition_or_warship() && !note.ship->exp_port_spaces().empty() &&
 		       note.action == Widelands::NoteShip::Action::kWaitingForCommand &&
 		       (note.ship->get_ship_state() == Widelands::ShipStates::kExpeditionPortspaceFound ||
 		        note.ship->get_ship_type() == Widelands::ShipType::kWarship)) {
@@ -476,7 +476,7 @@ void InteractivePlayer::think() {
 	// Cleanup found port spaces if the ship sailed on or was destroyed
 	for (auto it = expedition_port_spaces_.begin(); it != expedition_port_spaces_.end();) {
 		Widelands::Ship* ship = it->first.get(egbase());
-		if (ship == nullptr || ship->state_is_transport() ||
+		if (ship == nullptr || !ship->is_expedition_or_warship() ||
 		    std::find(ship->exp_port_spaces().begin(), ship->exp_port_spaces().end(), it->second) ==
 		       ship->exp_port_spaces().end()) {
 			it = expedition_port_spaces_.erase(it);


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Might fix #6067 
Additionally fixes the one battle-related crash we got during the tournament; and another previously undiscovered, tangentially related crash I found while testing this, which we would have found in the tournament game if it hadn't crashed for another reason first :)

**New behavior**
The battle stack can be in a strange and unpredictable order when multiple attacks happen at the same time. This is an inherent implication of the current battle code design. This patch allows ships to engage in battle even if the defendant has other battles with higher priority that didn't start yet. 

Warships can now be attacked at any time.

If it still crashes, there is now a higher chance that it will be caught cleanly with an error dialog and emergency save.

**Possible regressions**
Ship battles, especially regarding naval invasions with defending ships around the landing site, attacks with multiple ships at once, attacking a ship that is currently fighting, and attacking multiple enemies with the same ship.

**Additional context**
**I could only test this quite briefly, this needs very thorough testing.** It is also possible that there might be other complications that cannot be solved at all with the current (quite simplistic) approach, in which case a bigger redesign of the ship battle system might be necessary. 
I wouldn't have proposed this branch for merging yet due to lack of in-depth stresstesting, but since the tournament is postponed until those problems are solved I'd like to ask for some help with testing this in the hope that it really does solve all flavours of this bug.