### PR TITLE
Force all textures to 32bit - probably required for Mesa 23.x

### DIFF
--- a/src/graphic/texture.cc
+++ b/src/graphic/texture.cc
@@ -117,9 +117,11 @@ Texture::Texture(SDL_Surface* surface, bool intensity) : owns_texture_(false) {
 	uint8_t bpp = surface->format->BytesPerPixel;
 
 	if ((surface->format->palette != nullptr) || width() != surface->w || height() != surface->h ||
-	    (bpp != 3 && bpp != 4) || is_bgr_surface(*surface->format)) {
+	    (bpp != 4) || is_bgr_surface(*surface->format)) {
 		SDL_Surface* converted = empty_sdl_surface(width(), height());
-		assert(converted);
+		if (converted == nullptr) {
+			throw wexception("Failed to create SDL_Surface");
+		}
 		SDL_SetSurfaceAlphaMod(converted, SDL_ALPHA_OPAQUE);
 		SDL_SetSurfaceBlendMode(converted, SDL_BLENDMODE_NONE);
 		SDL_SetSurfaceAlphaMod(surface, SDL_ALPHA_OPAQUE);
@@ -128,16 +130,15 @@ Texture::Texture(SDL_Surface* surface, bool intensity) : owns_texture_(false) {
 		SDL_FreeSurface(surface);
 		surface = converted;
 		bpp = surface->format->BytesPerPixel;
+		assert(bpp == 4);
 	}
-
-	const GLenum pixels_format = bpp == 4 ? GL_RGBA : GL_RGB;
 
 	SDL_LockSurface(surface);
 
 	Gl::swap_rows(width(), height(), surface->pitch, bpp, static_cast<uint8_t*>(surface->pixels));
 
 	glTexImage2D(GL_TEXTURE_2D, 0, static_cast<GLint>(intensity ? GL_INTENSITY : GL_RGBA), width(),
-	             height(), 0, pixels_format, GL_UNSIGNED_BYTE, surface->pixels);
+	             height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, surface->pixels);
 
 	SDL_UnlockSurface(surface);
 	SDL_FreeSurface(surface);


### PR DESCRIPTION
**Type of change**
Portability fix

**Issue(s) closed**
Fixes garbled soldier level icons and playercolour images in flatpak builds with current runtimes

**To reproduce**
*If it's a bugfix:*
Steps to reproduce the behavior which cause the bug in master but not in your branch:
1. Build Widelands with the freedesktop.org 23.08beta runtime from flathub-beta (maybe other hosts with Mesa 23.x too?)
2. Start or load a game
3. Open the soldier statistics (or look at a Frisian shipyard that belongs to a player)
4. See error

**New behavior**
All textures are converted to 32 bits for passing to OpenGL.

**Possible regressions**
Texture display

**Screenshots**
Without this fix:
![shot0000](https://github.com/widelands/widelands/assets/80712255/fed0cc9c-ff73-430e-8313-9ae3c1b7d63d)

**Additional context**
This bug report is the reason why I suspect Mesa 23.x is at least part of the problem (the other part is current SDL):
 - https://discourse.flathub.org/t/how-to-use-a-specific-mesa-version-in-a-flatpak-manifest/4236
 - https://gitlab.freedesktop.org/mesa/mesa/-/issues/9007

(I first got similar weird colours when I naively converted the SDL surface to RGBA (big endian) instead of ABGR after I identified the 24 vs. 32 bit problem.)