### PR TITLE
Game client win condition duration bugfix

### DIFF
--- a/src/ui_basic/spinbox.cc
+++ b/src/ui_basic/spinbox.cc
@@ -367,7 +367,7 @@ void SpinBox::change_value(int32_t const value) {
 /**
  * manually sets the used value to a given value
  */
-void SpinBox::set_value(int32_t const value) {
+void SpinBox::set_value(int32_t const value, const bool trigger_signal) {
 	if (sbi_->value == value) {
 		return;
 	}
@@ -385,7 +385,9 @@ void SpinBox::set_value(int32_t const value) {
 		sbi_->value = value;
 	}
 	update();
-	changed();
+	if (trigger_signal) {
+		changed();
+	}
 }
 
 void SpinBox::set_value_list(const std::vector<int32_t>& values) {
@@ -399,7 +401,7 @@ void SpinBox::set_value_list(const std::vector<int32_t>& values) {
 /**
  * sets the interval the value may lay in and fixes the value, if outside.
  */
-void SpinBox::set_interval(int32_t const min, int32_t const max) {
+void SpinBox::set_interval(int32_t const min, int32_t const max, const bool trigger_signal_if_changed) {
 	assert(min <= max);
 	sbi_->max = max;
 	sbi_->min = min;
@@ -413,7 +415,7 @@ void SpinBox::set_interval(int32_t const min, int32_t const max) {
 	}
 	calculate_big_step();
 	update();
-	if (changed_val) {
+	if (changed_val && trigger_signal_if_changed) {
 		changed();
 	}
 }

--- a/src/ui_basic/spinbox.cc
+++ b/src/ui_basic/spinbox.cc
@@ -401,7 +401,9 @@ void SpinBox::set_value_list(const std::vector<int32_t>& values) {
 /**
  * sets the interval the value may lay in and fixes the value, if outside.
  */
-void SpinBox::set_interval(int32_t const min, int32_t const max, const bool trigger_signal_if_changed) {
+void SpinBox::set_interval(int32_t const min,
+                           int32_t const max,
+                           const bool trigger_signal_if_changed) {
 	assert(min <= max);
 	sbi_->max = max;
 	sbi_->min = min;

--- a/src/ui_basic/spinbox.h
+++ b/src/ui_basic/spinbox.h
@@ -66,11 +66,11 @@ public:
 
 	Notifications::Signal<> changed;
 
-	void set_value(int32_t);
+	void set_value(int32_t, bool trigger_signal = true);
 	// For spinboxes of type kValueList. The vector needs to be sorted in ascending order,
 	// otherwise you will confuse the user.
 	void set_value_list(const std::vector<int32_t>&);
-	void set_interval(int32_t min, int32_t max);
+	void set_interval(int32_t min, int32_t max, bool trigger_signal_if_changed = true);
 	int32_t get_value() const;
 	void add_replacement(int32_t, const std::string&);
 	const std::vector<UI::Button*>& get_buttons() {

--- a/src/ui_fsmenu/launch_mpg.cc
+++ b/src/ui_fsmenu/launch_mpg.cc
@@ -309,7 +309,8 @@ void LaunchMPG::refresh() {
 			win_condition_dropdown_.set_tooltip(_(t->get_string("description")));
 			win_condition_duration_.set_visible(t->has_key("configurable_time") &&
 			                                    t->get_bool("configurable_time"));
-			win_condition_duration_.set_value(settings_.get_win_condition_duration());
+			const int32_t duration = settings_.get_win_condition_duration();
+			win_condition_duration_.set_interval(duration, duration, false);
 		} catch (LuaScriptNotExistingError&) {
 			win_condition_dropdown_.set_label(_("Error"));
 			win_condition_dropdown_.set_tooltip(


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes two bugs related to changing the win condition duration on the client during MP game setup.

**To reproduce**
1. Host a game and select a win condition with configurable duration
2. Join with a client
3. First bug: The client can click the buttons to change the win condition duration. Doing so disconnects with an "unreachable code was reached" error dialog.
4. Second bug: Changing the duration on the host after the client has joined also disconnects the client with the Unreachable Code error dialog.

**New behavior**
The duration spinbox is disabled for the gameclient, and the update from the host triggers no `changed()` signals on the client

**Possible regressions**
Setting win condition durations

**Additional context**
May be tournament-relevant if we have timed win conditions in future rounds.