### PR TITLE
Fail gracefully in LAN setup when network access restricted

### DIFF
--- a/src/ui_fsmenu/main.cc
+++ b/src/ui_fsmenu/main.cc
@@ -26,6 +26,7 @@
 #include "base/i18n.h"
 #include "base/log.h"
 #include "base/random.h"
+#include "base/warning.h"
 #include "build_info.h"
 #include "editor/editorinteractive.h"
 #include "graphic/graphic.h"
@@ -233,8 +234,12 @@ void MainMenu::main_loop() {
 		try {
 			run<int>();
 			return;  // We only get here though normal termination by the user.
+		} catch (const WLWarning& e) {
+			// WLWarning is reserved for bad circumstances that are (most likely) not a bug.
+			show_messagebox(e.title(), e.what());
 		} catch (const std::exception& e) {
-			// This is the outermost wrapper within the GUI and should not normally be reachable.
+			// This is the outermost wrapper within the GUI and should only very rarely be reached.
+			// Most likely we got here through a bug in Widelands.
 			show_messagebox(
 			   _("Error!"),
 			   format(

--- a/src/ui_fsmenu/netsetup_lan.cc
+++ b/src/ui_fsmenu/netsetup_lan.cc
@@ -142,7 +142,6 @@ NetSetupLAN::NetSetupLAN(MenuCapsule& fsmm)
 	table_.add_column(90, _("State"));
 	table_.selected.connect([this](int32_t i) { game_selected(i); });
 	table_.double_clicked.connect([this](int32_t i) { game_doubleclicked(i); });
-	discovery_.set_callback(discovery_callback, this);
 
 	joingame_.set_enabled(false);
 	layout();
@@ -164,7 +163,17 @@ void NetSetupLAN::think() {
 	TwoColumnsBasicNavigationMenu::think();
 	change_playername();
 
-	discovery_.run();
+	try {
+		if (discovery_ == nullptr) {
+			discovery_.reset(new LanGameFinder());
+			discovery_->set_callback(discovery_callback, this);
+		}
+
+		discovery_->run();
+	} catch (...) {
+		return_to_main_menu();
+		throw;
+	}
 }
 
 bool NetSetupLAN::get_host_address(NetAddress* addr) {
@@ -270,7 +279,7 @@ void NetSetupLAN::discovery_callback(int32_t const type,
 		static_cast<NetSetupLAN*>(userdata)->game_updated(game);
 		break;
 	default:
-		abort();
+		NEVER_HERE();
 	}
 }
 

--- a/src/ui_fsmenu/netsetup_lan.h
+++ b/src/ui_fsmenu/netsetup_lan.h
@@ -82,7 +82,7 @@ private:
 
 	UI::Button joingame_, hostgame_;
 
-	LanGameFinder discovery_;
+	std::unique_ptr<LanGameFinder> discovery_;
 };
 }  // namespace FsMenu
 #endif  // end of include guard: WL_UI_FSMENU_NETSETUP_LAN_H


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6075

**To reproduce**
1. Start Widelands with all network access restricted, e.g. on Linux with `sudo unshare -n ./widelands`
2. Go to LAN → Direct IP
3. An error message informs you that Widelands can't access the network. This is correct.
4. Dismiss the error message → Segfault

**New behavior**
Return to the main menu without crashing

**Possible regressions**
LAN gaming
