### PR TITLE
Fix LaunchMPG Layouting Segfault

### DIFF
--- a/src/ui_fsmenu/launch_mpg.cc
+++ b/src/ui_fsmenu/launch_mpg.cc
@@ -119,16 +119,20 @@ void LaunchMPG::layout() {
 	help_button_.set_size(standard_height_, standard_height_);
 	help_button_.set_pos(Vector2i(get_inner_w() - help_button_.get_w(), 0));
 
-	// Reset size to fit left_column_box_, than relayout
-	chat_->set_desired_size(0, 0);
+	// Reset size to fit left_column_box_, then relayout
+	if (chat_ != nullptr) {
+		chat_->set_desired_size(0, 0);
+	}
 	uint32_t h = left_column_box_.get_h() / 2 - 4 * kPadding;
 	// Assign heights to properly layout the scrollable box
 	mpsg_.force_new_dimensions(left_column_box_.get_w(), h, scale_factor * standard_height_);
-	chat_->set_desired_size(0, h);
+	if (chat_ != nullptr) {
+		chat_->set_desired_size(0, h);
+	}
 	LaunchGame::layout();
 
 	// set focus to chat input
-	if (chat_) {
+	if (chat_ != nullptr) {
 		chat_->focus_edit();
 	}
 }


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes a new regression where resizing the Widelands window during an MP game segfaults.

**To reproduce**
1. Play a multiplayer game
2. Resize the Widelands main window
3. Segfault

**New behavior**
By design, the launch game window is only destroyed after the game ends, whereas its chat panel is destroyed earlier, as soon as the game launches. So during layout the chat may no longer exist. This was already checked for in line 135, now we check it in line 123 and 129 as well. 

**Possible regressions**
none
