### PR TITLE
Fix Food Production objective in first atlantean campaign

### DIFF
--- a/data/campaigns/atl01.wmf/scripting/texts.lua
+++ b/data/campaigns/atl01.wmf/scripting/texts.lua
@@ -53,7 +53,7 @@ obj_make_food_infrastructure = {
    number = 10,
    body = objective_text(_("Food Production"),
       p(_([[Food is very important for mines and military training areas. Establish a well working food environment by building at least one farm, one blackroot farm and a mill. The two kinds of flour together with water from a well will be baked into bread in a bakery, so build a bakery and a well, too.]])) ..
-      p(_([[The other two important food wares are smoked fish and smoked meat. Raw meat is delivered from a hunter. A fisher gets the fish out of the sea while a fish breeder makes sure that a school of fish does not go extinct by breeding more. Make sure that there are always fish left, otherwise the fish breeder won’t be able to breed new ones. The smoking happens in a smokery, you will need at least two of those.]])) ..
+      p(_([[The other two important food wares are smoked fish and smoked meat. Raw meat is delivered from a hunter. A fisher gets the fish out of the sea while a fish breeder makes sure that a school of fish does not go extinct by breeding more. The smoking happens in a smokery, you will need at least two of those.]])) ..
       li(_([[Build a farm and a blackroot farm]])) ..
       li(_([[Build a mill to make cornmeal and blackroot flour]])) ..
       li(_([[Build a well]])) ..


### PR DESCRIPTION
**Type of change**
Bugfix of text description for Food Production objective, in first atlantean campaign.

**New behavior**
Removed sentence which was claiming the fish breeder won’t be able to breed new fishes if fisher catches all. This is not true.