### PR TITLE
Fix documentation CI dependencies, again

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,8 +73,8 @@ jobs:
         python-version: 3.x
     - name: Generate documentation
       run: |
-        pip install sphinxcontrib-serializinghtml==1.1.5 sphinx
         cd doc/sphinx
+        pip install -r requirements.txt
         mkdir source/_static
         ./extract_rst.py
         sphinx-build -W -b json -d build/doctrees source build/json

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,0 +1,2 @@
+sphinxcontrib-serializinghtml<1.1.6
+sphinx<7.2


### PR DESCRIPTION
Sphinx 7.2 seems to break stuff again, so add a `requirements.txt` with versions that were previously known to work.