### PR TITLE
Fix `PlayerMessageCommand` Saveloading

### DIFF
--- a/src/logic/playercommand.cc
+++ b/src/logic/playercommand.cc
@@ -1884,8 +1884,8 @@ void PlayerMessageCommand::read(FileRead& fr, EditorGameBase& egbase, MapObjectL
 		if (packet_version == kCurrentPacketVersionPlayerMessageCommand) {
 			PlayerCommand::read(fr, egbase, mol);
 			message_id_ = MessageId(fr.unsigned_32());
-			if (!message_id_) {
-				throw GameDataError("(player %u): message id is null", sender());
+			if (!static_cast<bool>(message_id_)) {
+				verb_log_warn("PlayerMessageCommand (player %u): message ID is null", sender());
 			}
 		} else {
 			throw UnhandledVersionError(


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
During the tournament we encountered a corrupt savegame that failed to load with "FATAL EXCEPTION: command queue: player message: (player 1): message id is null". I could not reproduce the race condition that triggers it; but since it is valid for a message to disappear between sending and executing the command, and existence is also checked by `MessageQueue::set_message_status`, I think `null` is actually valid here.