### PR TITLE
Stop ship battles when ship is destroyed

### DIFF
--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1202,6 +1202,11 @@ constexpr uint8_t kPortUnderAttackDefendersSearchRadius = 10;
 constexpr uint32_t kAttackAnimationDuration = 2000;
 
 void Ship::battle_update(Game& game) {
+	if (state_is_sinking()) {
+		battles_.clear();
+		return pop_task(game);
+	}
+
 	Battle& current_battle = battles_.back();
 	Ship* target_ship = current_battle.opponent.get(game);
 	if ((target_ship == nullptr || target_ship->state_is_sinking()) &&


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes the "mirror battle not found" bug from the tournament

**New behavior**
When a ship is destroyed, it now stops fighting immediately even if it has battles left.

**Possible regressions**
The ending of complex ship battles