### PR TITLE
Fix more box regressions

### DIFF
--- a/src/ui_fsmenu/multiplayersetupgroup.cc
+++ b/src/ui_fsmenu/multiplayersetupgroup.cc
@@ -681,6 +681,8 @@ MultiPlayerSetupGroup::MultiPlayerSetupGroup(UI::Panel* const launchgame,
      npsb_(new NetworkPlayerSettingsBackend(settings_)),
      launchgame_(launchgame),
      clientbox_(this, UI::PanelStyle::kFsMenu, "client_box", 0, 0, UI::Box::Vertical),
+	 scrollable_clientbox_(
+	    &clientbox_, UI::PanelStyle::kFsMenu, "scrollable_clientbox", 0, 0, UI::Box::Vertical),
      playerbox_(
         this, UI::PanelStyle::kFsMenu, "player_box", 0, 0, UI::Box::Vertical, 0, 0, kPadding),
      scrollable_playerbox_(
@@ -706,9 +708,10 @@ MultiPlayerSetupGroup::MultiPlayerSetupGroup(UI::Panel* const launchgame,
               _("Players"),
               UI::Align::kCenter),
      buth_(buth) {
+	scrollable_clientbox_.set_scrolling(true);
 	clientbox_.add(&clients_, Resizing::kAlign, UI::Align::kCenter);
 	clientbox_.add_space(3 * kPadding);
-	clientbox_.set_scrolling(true);
+	clientbox_.add(&scrollable_clientbox_, Resizing::kExpandBoth);
 
 	scrollable_playerbox_.set_scrolling(true);
 	playerbox_.add(&players_, Resizing::kAlign, UI::Align::kCenter);
@@ -761,8 +764,8 @@ void MultiPlayerSetupGroup::update_clients() {
 	if (number_of_users > multi_player_client_groups_.size()) {
 		for (uint32_t i = multi_player_client_groups_.size(); i < number_of_users; ++i) {
 			multi_player_client_groups_.push_back(
-			   new MultiPlayerClientGroup(launchgame_, &clientbox_, 0, buth_, i, settings_));
-			clientbox_.add(multi_player_client_groups_.at(i), Resizing::kFullSize);
+			   new MultiPlayerClientGroup(launchgame_, &scrollable_clientbox_, 0, buth_, i, settings_));
+			scrollable_clientbox_.add(multi_player_client_groups_.at(i), Resizing::kFullSize);
 		}
 	}
 	for (auto& c : multi_player_client_groups_) {
@@ -795,11 +798,14 @@ void MultiPlayerSetupGroup::force_new_dimensions(uint32_t max_width,
                                                  uint32_t max_height,
                                                  uint32_t standard_element_height) {
 	buth_ = standard_element_height;
-	scrollable_playerbox_.set_max_size(0, max_height - players_.get_h() - 4 * kPadding);
+	uint32_t scroll_height = max_height - players_.get_h() - 4 * kPadding;
+	scrollable_playerbox_.set_max_size(0, scroll_height);
 	// Reset desired size to properly fit into scroll box
 	scrollable_playerbox_.set_desired_size(0, 0);
+
 	clients_.set_desired_size(max_width / 3, clients_.get_h());
-	clientbox_.set_max_size(max_width / 3, max_height);
+	scrollable_clientbox_.set_max_size(max_width / 3, scroll_height);
+	scrollable_clientbox_.set_desired_size(0, 0);
 
 	for (auto& multiPlayerClientGroup : multi_player_client_groups_) {
 		multiPlayerClientGroup->force_new_dimensions(standard_element_height);

--- a/src/ui_fsmenu/multiplayersetupgroup.cc
+++ b/src/ui_fsmenu/multiplayersetupgroup.cc
@@ -681,8 +681,8 @@ MultiPlayerSetupGroup::MultiPlayerSetupGroup(UI::Panel* const launchgame,
      npsb_(new NetworkPlayerSettingsBackend(settings_)),
      launchgame_(launchgame),
      clientbox_(this, UI::PanelStyle::kFsMenu, "client_box", 0, 0, UI::Box::Vertical),
-	 scrollable_clientbox_(
-	    &clientbox_, UI::PanelStyle::kFsMenu, "scrollable_clientbox", 0, 0, UI::Box::Vertical),
+     scrollable_clientbox_(
+        &clientbox_, UI::PanelStyle::kFsMenu, "scrollable_clientbox", 0, 0, UI::Box::Vertical),
      playerbox_(
         this, UI::PanelStyle::kFsMenu, "player_box", 0, 0, UI::Box::Vertical, 0, 0, kPadding),
      scrollable_playerbox_(
@@ -763,8 +763,8 @@ void MultiPlayerSetupGroup::update_clients() {
 
 	if (number_of_users > multi_player_client_groups_.size()) {
 		for (uint32_t i = multi_player_client_groups_.size(); i < number_of_users; ++i) {
-			multi_player_client_groups_.push_back(
-			   new MultiPlayerClientGroup(launchgame_, &scrollable_clientbox_, 0, buth_, i, settings_));
+			multi_player_client_groups_.push_back(new MultiPlayerClientGroup(
+			   launchgame_, &scrollable_clientbox_, 0, buth_, i, settings_));
 			scrollable_clientbox_.add(multi_player_client_groups_.at(i), Resizing::kFullSize);
 		}
 	}

--- a/src/ui_fsmenu/multiplayersetupgroup.cc
+++ b/src/ui_fsmenu/multiplayersetupgroup.cc
@@ -799,6 +799,7 @@ void MultiPlayerSetupGroup::force_new_dimensions(uint32_t max_width,
 	// Reset desired size to properly fit into scroll box
 	scrollable_playerbox_.set_desired_size(0, 0);
 	clients_.set_desired_size(max_width / 3, clients_.get_h());
+	clientbox_.set_max_size(max_width / 3, max_height);
 
 	for (auto& multiPlayerClientGroup : multi_player_client_groups_) {
 		multiPlayerClientGroup->force_new_dimensions(standard_element_height);

--- a/src/ui_fsmenu/multiplayersetupgroup.h
+++ b/src/ui_fsmenu/multiplayersetupgroup.h
@@ -63,7 +63,7 @@ private:
 	std::unique_ptr<Notifications::Subscriber<NoteGameSettings>> subscriber_;
 
 	UI::Panel* launchgame_;
-	UI::Box clientbox_, playerbox_, scrollable_playerbox_;
+	UI::Box clientbox_, scrollable_clientbox_, playerbox_, scrollable_playerbox_;
 	UI::Textarea clients_, players_;
 	int32_t buth_;
 

--- a/src/wui/inputqueuedisplay.cc
+++ b/src/wui/inputqueuedisplay.cc
@@ -244,6 +244,7 @@ InputQueueDisplay::InputQueueDisplay(UI::Panel* parent,
                kButtonSize,
                can_act_ && has_priority_),
      spacer_(&hbox_, UI::PanelStyle::kWui, "spacer", 0, 0, priority_.get_w(), priority_.get_h()),
+	 priority_indicator_(&hbox_, UI::PanelStyle::kWui, "priority_indicator", 0, 0, kButtonSize / 5, kButtonSize),
      slider_was_moved_(nullptr),
      collapsed_(collapsed),
      nr_icons_(queue_ != nullptr            ? queue_->get_max_size() :
@@ -288,7 +289,7 @@ InputQueueDisplay::InputQueueDisplay(UI::Panel* parent,
 
 	// To make sure the fill buttons are aligned even when some queues
 	// have priority buttons and some don't (e.g. in barracks)
-	hbox_.add_space(kButtonSize / 4);
+	hbox_.add(&priority_indicator_);
 	priority_.set_visible(has_priority_);
 	spacer_.set_visible(!has_priority_);
 	hbox_.add(&priority_, UI::Box::Resizing::kAlign, UI::Align::kCenter);
@@ -425,7 +426,7 @@ bool InputQueueDisplay::handle_mousewheel(int32_t x, int32_t y, uint16_t modstat
 		big_step = true;
 	}
 
-	if (get_mouse_position().x < priority_.get_x() - kButtonSize / 4) {
+	if (get_mouse_position().x < priority_indicator_.get_x()) {
 		// Mouse is over desired fill
 
 		if (big_step) {
@@ -743,11 +744,11 @@ void InputQueueDisplay::draw_overlay(RenderTarget& r) {
 	if (has_priority_ && is_collapsed()) {
 		const size_t p = priority_to_index(queue_ != nullptr ? b->get_priority(type_, index_) :
                                                              get_setting()->priority);
-		const int w = kButtonSize / 5;
-		const int x = collapse_.is_visible() ? hbox_.get_x() + collapse_.get_x() - w :
-                                             hbox_.get_x() + hbox_.get_w();
-		r.brighten_rect(Recti(x, hbox_.get_y(), w, kButtonSize), -32);
-		r.fill_rect(Recti(x, hbox_.get_y() + (4 - p) * kButtonSize / 5, w, kButtonSize / 5),
+		const int w = priority_indicator_.get_w();
+		// Add kButtonSize / 4 to the position to align it against the collapse button
+		const int x = hbox_.get_x() + priority_indicator_.get_x() + kButtonSize / 4;
+		r.brighten_rect(Recti(x, hbox_.get_y(), w, kButtonSize), - 32);
+		r.fill_rect(Recti(x, hbox_.get_y() + (4 - p) * w, w, w),
 		            kPriorityColors[p], BlendMode::Copy);
 	}
 

--- a/src/wui/inputqueuedisplay.cc
+++ b/src/wui/inputqueuedisplay.cc
@@ -244,7 +244,8 @@ InputQueueDisplay::InputQueueDisplay(UI::Panel* parent,
                kButtonSize,
                can_act_ && has_priority_),
      spacer_(&hbox_, UI::PanelStyle::kWui, "spacer", 0, 0, priority_.get_w(), priority_.get_h()),
-	 priority_indicator_(&hbox_, UI::PanelStyle::kWui, "priority_indicator", 0, 0, kButtonSize / 5, kButtonSize),
+     priority_indicator_(
+        &hbox_, UI::PanelStyle::kWui, "priority_indicator", 0, 0, kButtonSize / 5, kButtonSize),
      slider_was_moved_(nullptr),
      collapsed_(collapsed),
      nr_icons_(queue_ != nullptr            ? queue_->get_max_size() :
@@ -747,9 +748,8 @@ void InputQueueDisplay::draw_overlay(RenderTarget& r) {
 		const int w = priority_indicator_.get_w();
 		// Add kButtonSize / 4 to the position to align it against the collapse button
 		const int x = hbox_.get_x() + priority_indicator_.get_x() + kButtonSize / 4;
-		r.brighten_rect(Recti(x, hbox_.get_y(), w, kButtonSize), - 32);
-		r.fill_rect(Recti(x, hbox_.get_y() + (4 - p) * w, w, w),
-		            kPriorityColors[p], BlendMode::Copy);
+		r.brighten_rect(Recti(x, hbox_.get_y(), w, kButtonSize), -32);
+		r.fill_rect(Recti(x, hbox_.get_y() + (4 - p) * w, w, w), kPriorityColors[p], BlendMode::Copy);
 	}
 
 	UI::Box::draw_overlay(r);

--- a/src/wui/inputqueuedisplay.cc
+++ b/src/wui/inputqueuedisplay.cc
@@ -744,7 +744,8 @@ void InputQueueDisplay::draw_overlay(RenderTarget& r) {
 		const size_t p = priority_to_index(queue_ != nullptr ? b->get_priority(type_, index_) :
                                                              get_setting()->priority);
 		const int w = kButtonSize / 5;
-		const int x = hbox_.get_x() + collapse_.get_x() - w;
+		const int x = collapse_.is_visible() ? hbox_.get_x() + collapse_.get_x() - w :
+                                             hbox_.get_x() + hbox_.get_w();
 		r.brighten_rect(Recti(x, hbox_.get_y(), w, kButtonSize), -32);
 		r.fill_rect(Recti(x, hbox_.get_y() + (4 - p) * kButtonSize / 5, w, kButtonSize / 5),
 		            kPriorityColors[p], BlendMode::Copy);

--- a/src/wui/inputqueuedisplay.h
+++ b/src/wui/inputqueuedisplay.h
@@ -157,7 +157,7 @@ private:
 	UI::Button b_decrease_desired_fill_, b_increase_desired_fill_, b_decrease_real_fill_,
 	   b_increase_real_fill_, collapse_;
 	UI::PrioritySlider priority_;
-	UI::Panel spacer_;
+	UI::Panel spacer_, priority_indicator_;
 	const Widelands::WarePriority* slider_was_moved_;
 
 	BuildingWindow::CollapsedState* collapsed_;  ///< Owned by the window creating the input queue


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6052 
Fixes #6092 

**New behavior**
- The input queue layout does not depend on invisible item positions
- Readd the max size for the client box

**Additional context**
I noticed that the clientbox scrolls with the header while the player setup box only scrolls the selection groups.
Should this be unified?
