### PR TITLE
Safeguard pathfinding with a mutex

### DIFF
--- a/src/base/mutex.h
+++ b/src/base/mutex.h
@@ -43,6 +43,7 @@ public:
 		kObjects,              ///< MapObjects are being modified.
 		kCommands,             ///< The game's command queue is being modified.
 		kMessages,             ///< In-game messages are being modified.
+		kPathfinding,          ///< Pathfinding searches across the map.
 		kIBaseVisualizations,  ///< The InteractiveBase's overlays are being updated.
 		kI18N,                 ///< The gettext backend.
 		kLua,                  ///< Lua scripts.

--- a/src/logic/map.cc
+++ b/src/logic/map.cc
@@ -1042,9 +1042,10 @@ void Map::find_reachable(const EditorGameBase& egbase,
                          const Area<FCoords>& area,
                          const CheckStep& checkstep,
                          functorT& functor) const {
-	std::vector<Coords> queue;
+	MutexLock m(MutexLock::ID::kPathfinding);
 	std::shared_ptr<Pathfields> pathfields = pathfieldmgr_->allocate();
 
+	std::vector<Coords> queue;
 	queue.push_back(area);
 
 	while (!queue.empty()) {
@@ -2210,6 +2211,7 @@ int32_t Map::findpath(Coords instart,
 	}
 
 	// Actual pathfinding
+	MutexLock m(MutexLock::ID::kPathfinding);
 	std::shared_ptr<Pathfields> pathfields = pathfieldmgr_->allocate();
 	Pathfield::Queue Open(type);
 	Pathfield* curpf = &pathfields->fields[start.field - fields_.get()];


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Possibly fixes #6102

It's a non-reproducible race condition with simultaneous pathfinding from UI, probably road building, and game logic. Results in an assert in debug builds and undefined behaviour (usually permanent hangup, but possibly also a spurious desync or crash) in release builds. 

This might also be the cause of the uninvestigated road building crash mentioned in the tournament forum thread.

Since the bug is very hard to trigger I can't be sure my analysis is correct, and even that this fixes it. Let's hope for the best and open a new issue if the problem resurfaces.