### PR TITLE
Emergency saving enhancements

### DIFF
--- a/data/txts/tips/crash.lua
+++ b/data/txts/tips/crash.lua
@@ -1,0 +1,12 @@
+include "scripting/richtext.lua"
+include "txts/help/common_helptexts.lua"
+
+push_textdomain("texts")
+tips = {
+   {
+      text = _("Widelands is creating an emergency save, so you can continue playing exactly where the game closed."),
+      seconds = 60
+   },
+}
+pop_textdomain()
+return tips

--- a/src/network/gameclient.cc
+++ b/src/network/gameclient.cc
@@ -352,11 +352,11 @@ void GameClient::do_run(RecvPacket& packet) {
 		d->run_game(igb);
 
 	} catch (const WLWarning& e) {
-		WLApplication::emergency_save(&capsule_.menu(), game, e.what(), 1, true, false);
+		WLApplication::emergency_save(&capsule_.menu(), game, e.what(), 1, false, false);
 		d->game = nullptr;
 	} catch (const std::exception& e) {
 		FsMenu::MainMenu& parent = capsule_.menu();  // make includes script happy
-		WLApplication::emergency_save(&parent, game, e.what());
+		WLApplication::emergency_save(&parent, game, e.what(), 1, false);
 		d->game = nullptr;
 		disconnect("CLIENT_CRASHED");
 		if (d->internet_) {

--- a/src/network/gamehost.cc
+++ b/src/network/gamehost.cc
@@ -624,7 +624,7 @@ void GameHost::run_callback() {
 	} catch (const std::exception& e) {
 		FsMenu::MainMenu* parent =
 		   capsule_ != nullptr ? &capsule_->menu() : nullptr;  // make includes script happy
-		WLApplication::emergency_save(parent, *game_, e.what(), player_number);
+		WLApplication::emergency_save(parent, *game_, e.what(), player_number, false);
 		clear_computer_players();
 
 		while (!d->clients.empty()) {

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1671,7 +1671,8 @@ void WLApplication::emergency_save(UI::Panel* panel,
 	try {
 		if (!game.has_loader_ui()) {
 			// Shouldn't have one yet, but in an emergency situation, don't make any assumptions.
-			game.create_loader_ui({"crash"}, true, game.map().get_background_theme(), game.map().get_background(), true);
+			game.create_loader_ui(
+			   {"crash"}, true, game.map().get_background_theme(), game.map().get_background(), true);
 			added_loader = true;
 		}
 

--- a/src/wlapplication.cc
+++ b/src/wlapplication.cc
@@ -1667,7 +1667,14 @@ void WLApplication::emergency_save(UI::Panel* panel,
 		}
 	}
 
+	bool added_loader = false;
 	try {
+		if (!game.has_loader_ui()) {
+			// Shouldn't have one yet, but in an emergency situation, don't make any assumptions.
+			game.create_loader_ui({"crash"}, true, game.map().get_background_theme(), game.map().get_background(), true);
+			added_loader = true;
+		}
+
 		if (replace_ctrl) {
 			game.set_game_controller(
 			   std::make_shared<SinglePlayerGameController>(game, true, playernumber));
@@ -1690,6 +1697,10 @@ void WLApplication::emergency_save(UI::Panel* panel,
 			   UI::WLMessageBox::MBoxType::kOk);
 			m.run<UI::Panel::Returncodes>();
 		}
+	}
+
+	if (added_loader) {
+		game.remove_loader_ui();
 	}
 }
 

--- a/src/wui/buildingwindow.cc
+++ b/src/wui/buildingwindow.cc
@@ -143,8 +143,6 @@ void BuildingWindow::init(bool avoid_fastclick, bool workarea_preview_wanted) {
 	} else {
 		hide_workarea(true);
 	}
-
-	throw wexception("NOCOM for testing");
 }
 
 // Stop everybody from thinking to avoid segfaults

--- a/src/wui/buildingwindow.cc
+++ b/src/wui/buildingwindow.cc
@@ -143,6 +143,8 @@ void BuildingWindow::init(bool avoid_fastclick, bool workarea_preview_wanted) {
 	} else {
 		hide_workarea(true);
 	}
+
+	throw wexception("NOCOM for testing");
 }
 
 // Stop everybody from thinking to avoid segfaults


### PR DESCRIPTION
**Type of change**
Feature enhancement

**Issue(s) closed**
- Emergency saves from network games are now saved as network savegames instead of singleplayer savegames. This way you can actually reload your MP game from the emergency save, which currently is not possible.
- During the emergency save, show a game saving progress screen like for manual saves.

**Possible regressions**
Emergency saving
