### PR TITLE
Better protect invasion portspaces

### DIFF
--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1628,6 +1628,7 @@ void Soldier::start_task_naval_invasion(Game& game, const Coords& coords) {
 void Soldier::naval_invasion_update(Game& game, State& state) {
 	constexpr int kPortSpaceRadius = 2;
 	constexpr int kPortSpaceGeneralAreaRadius = 5;
+	constexpr int kConquerInfluence = 100;
 
 	std::string signal = get_signal();
 	if (!signal.empty()) {
@@ -1761,8 +1762,16 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 		do {
 			if (mr.location().field->get_owned_by() != owner().player_number()) {
 				molog(game.get_gametime(), "[naval_invasion] Conquering port area\n");
-				game.conquer_area(PlayerArea<Area<FCoords>>(
-				   owner().player_number(), Area<FCoords>(portspace_fcoords, kPortSpaceRadius)));
+				PlayerArea<Area<FCoords>> area(
+				   owner().player_number(), Area<FCoords>(portspace_fcoords, kPortSpaceRadius));
+
+				game.conquer_area(area);
+
+				MapRegion<PlayerArea<Area<FCoords>>> mr(map, area);
+				do {
+					get_owner()->military_influence(map.get_index(mr.location())) += kConquerInfluence;
+				} while (mr.advance(map));
+
 				return start_task_idle(game, descr().get_animation("idle", this), 1000);
 			}
 		} while (mr.advance(map));

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1767,10 +1767,11 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 
 				game.conquer_area(area);
 
-				MapRegion<PlayerArea<Area<FCoords>>> mr(map, area);
+				MapRegion<PlayerArea<Area<FCoords>>> region(map, area);
 				do {
-					get_owner()->military_influence(map.get_index(mr.location())) += kConquerInfluence;
-				} while (mr.advance(map));
+					get_owner()->military_influence(map.get_index(region.location())) +=
+					   kConquerInfluence;
+				} while (region.advance(map));
 
 				return start_task_idle(game, descr().get_animation("idle", this), 1000);
 			}


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Should fix #6112

**New behavior**
Invasion soldiers grant their port space a lot of extra influence so it remains conquered even when a new militarysite is built nearby.

Since invasion soldiers are not (and will never be) real militarysites, this is a one-time, permanent grant. Meaning it may remain in place after the invasion has completed. This is bad design, but IMO we should just have that now, evaluate in the Tournament how it performs in practice, and then reconsider what else might better be changed.

**Possible regressions**
Land ownership around invasion port spaces. Please test carefully, conquest code is very fiddly and fragile.
