### PR TITLE
Invasion soldiers conquer portspace for the duration of the invasion

### DIFF
--- a/src/logic/map_objects/map_object.h
+++ b/src/logic/map_objects/map_object.h
@@ -275,6 +275,7 @@ public:
 		HeaderPinnedNote = 13,
 		HeaderShipFleetInterface = 14,
 		HeaderFerryFleetInterface = 15,
+		HeaderNavalInvasionBase = 16,
 	};
 
 	/**

--- a/src/logic/map_objects/map_object_type.cc
+++ b/src/logic/map_objects/map_object_type.cc
@@ -43,6 +43,8 @@ std::string to_string(const MapObjectType type) {
 		return "ship_fleet_yard_interface";
 	case MapObjectType::FERRY_FLEET_YARD_INTERFACE:
 		return "ferry_fleet_yard_interface";
+	case MapObjectType::NAVAL_INVASION_BASE:
+		return "naval_invasion_base";
 	case MapObjectType::WORKER:
 		return "worker";
 	case MapObjectType::CARRIER:

--- a/src/logic/map_objects/map_object_type.h
+++ b/src/logic/map_objects/map_object_type.h
@@ -48,6 +48,7 @@ enum class MapObjectType : uint8_t {
 	PINNED_NOTE,                 // Bob -- Pinned Note
 	SHIP_FLEET_YARD_INTERFACE,   // Bob -- Ship Fleet Yard Interface
 	FERRY_FLEET_YARD_INTERFACE,  // Bob -- Ferry Fleet Yard Interface
+	NAVAL_INVASION_BASE,         // Bob -- Naval Invasion Base
 
 	// everything below is at least a BaseImmovable
 	IMMOVABLE = 30,

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1761,7 +1761,8 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 		// The target should be unguarded now, conquer the port space.
 
 		bool has_invasion_base = false;
-		for (Bob* bob = map[state.coords].get_first_bob(); bob != nullptr; bob = bob->get_next_bob()) {
+		for (Bob* bob = map[state.coords].get_first_bob(); bob != nullptr;
+		     bob = bob->get_next_bob()) {
 			if (bob->descr().type() == MapObjectType::NAVAL_INVASION_BASE) {
 				upcast(NavalInvasionBase, invasion, bob);
 				assert(invasion != nullptr);
@@ -2119,7 +2120,8 @@ void NavalInvasionBase::init_auto_task(Game& game) {
 			continue;
 		}
 		if (state->coords != get_position()) {
-			molog(game.get_gametime(), "Soldier %u at different invasion location %dx%d!", soldier->serial(), state->coords.x, state->coords.y);
+			molog(game.get_gametime(), "Soldier %u at different invasion location %dx%d!",
+			      soldier->serial(), state->coords.x, state->coords.y);
 			it = soldiers_.erase(it);
 			continue;
 		}
@@ -2134,15 +2136,16 @@ void NavalInvasionBase::init_auto_task(Game& game) {
 }
 
 void NavalInvasionBase::cleanup(EditorGameBase& egbase) {
-	egbase.unconquer_area(PlayerArea<Area<FCoords>>(owner().player_number(), Area<FCoords>(get_position(), kPortSpaceRadius)));
+	egbase.unconquer_area(PlayerArea<Area<FCoords>>(
+	   owner().player_number(), Area<FCoords>(get_position(), kPortSpaceRadius)));
 
 	Bob::cleanup(egbase);
 }
 
 void NavalInvasionBase::log_general_info(const EditorGameBase& egbase) const {
 	Bob::log_general_info(egbase);
-	molog(egbase.get_gametime(), "Invasion at %3dx%3d with %" PRIuS " soldiers\n",
-	      get_position().x, get_position().y, soldiers_.size());
+	molog(egbase.get_gametime(), "Invasion at %3dx%3d with %" PRIuS " soldiers\n", get_position().x,
+	      get_position().y, soldiers_.size());
 	for (auto soldier : soldiers_) {
 		molog(egbase.get_gametime(), "Soldier %u", soldier.serial());
 	}
@@ -2152,7 +2155,8 @@ void NavalInvasionBase::add_soldier(EditorGameBase& egbase, Soldier* soldier) {
 	assert(soldier != nullptr);
 
 	if (soldiers_.empty()) {
-		egbase.conquer_area(PlayerArea<Area<FCoords>>(owner().player_number(), Area<FCoords>(get_position(), kPortSpaceRadius)));
+		egbase.conquer_area(PlayerArea<Area<FCoords>>(
+		   owner().player_number(), Area<FCoords>(get_position(), kPortSpaceRadius)));
 	}
 
 	soldiers_.insert(soldier);
@@ -2176,8 +2180,7 @@ void NavalInvasionBase::Loader::load_pointers() {
 	}
 }
 
-Bob::Loader*
-NavalInvasionBase::load(EditorGameBase& egbase, MapObjectLoader& mol, FileRead& fr) {
+Bob::Loader* NavalInvasionBase::load(EditorGameBase& egbase, MapObjectLoader& mol, FileRead& fr) {
 	std::unique_ptr<Loader> loader(new Loader);
 
 	try {

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -2207,7 +2207,7 @@ void NavalInvasionBase::save(EditorGameBase& egbase, MapObjectSaver& mos, FileWr
 	Bob::save(egbase, mos, fw);
 
 	fw.unsigned_32(soldiers_.size());
-	for (auto& soldier : soldiers_) {
+	for (const auto& soldier : soldiers_) {
 		fw.unsigned_32(mos.get_object_file_index(*soldier.get(egbase)));
 	}
 }

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1763,7 +1763,8 @@ void Soldier::naval_invasion_update(Game& game, State& state) {
 		bool has_invasion_base = false;
 		for (Bob* bob = map[state.coords].get_first_bob(); bob != nullptr;
 		     bob = bob->get_next_bob()) {
-			if (bob->descr().type() == MapObjectType::NAVAL_INVASION_BASE) {
+			if (bob->descr().type() == MapObjectType::NAVAL_INVASION_BASE &&
+			    bob->get_owner() == get_owner()) {
 				upcast(NavalInvasionBase, invasion, bob);
 				assert(invasion != nullptr);
 				has_invasion_base = true;

--- a/src/logic/map_objects/tribes/soldier.h
+++ b/src/logic/map_objects/tribes/soldier.h
@@ -349,7 +349,7 @@ private:
 	// Pop the current task or, if challenged, start the fighting task.
 	void pop_task_or_fight(Game&);
 
-protected:
+public:
 	static Task const taskAttack;
 	static Task const taskDefense;
 	static Task const taskBattle;
@@ -411,6 +411,55 @@ protected:
 public:
 	void do_save(EditorGameBase&, MapObjectSaver&, FileWrite&) override;
 };
+
+class NavalInvasionBaseDescr : public BobDescr {
+public:
+	NavalInvasionBaseDescr(char const* const init_name, char const* const init_descname)
+	   : BobDescr(init_name,
+	              init_descname,
+	              MapObjectType::NAVAL_INVASION_BASE,
+	              MapObjectDescr::OwnerType::kTribe) {
+	}
+	~NavalInvasionBaseDescr() override = default;
+	[[nodiscard]] Bob& create_object() const override;
+
+private:
+	DISALLOW_COPY_AND_ASSIGN(NavalInvasionBaseDescr);
+};
+
+class NavalInvasionBase : public Bob {
+public:
+	NavalInvasionBase();
+	static NavalInvasionBase*
+	create(EditorGameBase& egbase, Soldier& soldier, const Coords& pos);
+
+	const NavalInvasionBaseDescr& descr() const;
+	void init_auto_task(Game& game) override;
+	void cleanup(EditorGameBase&) override;
+	void log_general_info(const EditorGameBase&) const override;
+
+	void add_soldier(EditorGameBase& egbase, Soldier* soldier);
+
+	void save(EditorGameBase&, MapObjectSaver&, FileWrite&) override;
+	static Loader* load(EditorGameBase&, MapObjectLoader&, FileRead&);
+
+private:
+	std::set<OPtr<Soldier>> soldiers_;
+
+	void check_unconquer();
+
+protected:
+	struct Loader : Bob::Loader {
+		Loader() = default;
+
+		void load(FileRead& fr);
+		void load_pointers() override;
+
+	private:
+		std::set<Serial> soldiers_;
+	};
+};
+
 }  // namespace Widelands
 
 #endif  // end of include guard: WL_LOGIC_MAP_OBJECTS_TRIBES_SOLDIER_H

--- a/src/logic/map_objects/tribes/soldier.h
+++ b/src/logic/map_objects/tribes/soldier.h
@@ -430,8 +430,7 @@ private:
 class NavalInvasionBase : public Bob {
 public:
 	NavalInvasionBase();
-	static NavalInvasionBase*
-	create(EditorGameBase& egbase, Soldier& soldier, const Coords& pos);
+	static NavalInvasionBase* create(EditorGameBase& egbase, Soldier& soldier, const Coords& pos);
 
 	const NavalInvasionBaseDescr& descr() const;
 	void init_auto_task(Game& game) override;

--- a/src/map_io/map_object_packet.cc
+++ b/src/map_io/map_object_packet.cc
@@ -30,6 +30,7 @@
 #include "logic/map_objects/pinned_note.h"
 #include "logic/map_objects/tribes/battle.h"
 #include "logic/map_objects/tribes/ship.h"
+#include "logic/map_objects/tribes/soldier.h"
 #include "logic/map_objects/tribes/worker.h"
 #include "logic/map_objects/world/critter.h"
 #include "map_io/map_object_loader.h"
@@ -107,6 +108,10 @@ void MapObjectPacket::read(FileSystem& fs, EditorGameBase& egbase, MapObjectLoad
 
 			case MapObject::HeaderFerryFleetInterface:
 				loaders.insert(FerryFleetYardInterface::load(egbase, mol, fr));
+				break;
+
+			case MapObject::HeaderNavalInvasionBase:
+				loaders.insert(NavalInvasionBase::load(egbase, mol, fr));
 				break;
 
 			default:

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -864,6 +864,7 @@ int upcasted_map_object_descr_to_lua(lua_State* L, const Widelands::MapObjectDes
 		case Widelands::MapObjectType::PINNED_NOTE:
 		case Widelands::MapObjectType::SHIP_FLEET_YARD_INTERFACE:
 		case Widelands::MapObjectType::FERRY_FLEET_YARD_INTERFACE:
+		case Widelands::MapObjectType::NAVAL_INVASION_BASE:
 			return CAST_TO_LUA(Widelands::MapObjectDescr, LuaMapObjectDescription);
 		default:
 			verb_log_warn("upcasted_map_object_to_lua: unknown type '%s' to cast to, return general "
@@ -942,6 +943,7 @@ int upcasted_map_object_to_lua(lua_State* L, Widelands::MapObject* mo) {
 	case Widelands::MapObjectType::PINNED_NOTE:
 	case Widelands::MapObjectType::SHIP_FLEET_YARD_INTERFACE:
 	case Widelands::MapObjectType::FERRY_FLEET_YARD_INTERFACE:
+	case Widelands::MapObjectType::NAVAL_INVASION_BASE:
 		throw LuaError(
 		   format("upcasted_map_object_to_lua: Unknown %i", static_cast<int>(mo->descr().type())));
 	}
@@ -2404,6 +2406,7 @@ int LuaMapObjectDescription::get_name(lua_State* L) {
         interface to access such objects or descriptions currently exists.
 
         * :const:`battle`, holds information about two soldiers in a fight,
+        * :const:`naval_invasion_base`, links a naval invasion of a port space.
         * :const:`ship_fleet`, holds information for managing ships and ports,
         * :const:`ferry_fleet`, holds information for managing ferries and waterways.
         * :const:`ship_fleet_yard_interface`, links a shipyard to a ship fleet.


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6112, more thoroughly this time

**New behavior**
Bit overkill TBH – we place a new bob type called a `NavalInvasionBase` on the port space which keeps track of how many soldiers are currently actively involved in the invasion. When it is created it conquers the port space surroundings; when the last soldier quits the invasion force by conquering a milsite or death in battle, it releases the conquest again.

**Possible regressions**
Land ownership and saveloading. Will also suffer from bug #6074. But should be much safer than its predecessor #6113.

**Additional context**
- [Probably tournament-critical for round 2](https://www.widelands.org/forum/post/40765/)
- In principle this could also be extended in the future to make invasion forces attackable from militarysites. But not in this branch.