### PR TITLE
Make AttackPanel/Window robust against object deletion

### DIFF
--- a/src/ui_fsmenu/main.cc
+++ b/src/ui_fsmenu/main.cc
@@ -765,8 +765,8 @@ void MainMenu::draw(RenderTarget& r) {
 
 		if (system_clock_) {
 			clock_.set_text(realtimestring());
-			r.fill_rect(Recti(0, 0, clock_.get_w() + 2 * padding_, clock_.get_h() + 2 * padding_),
-			            bg, BlendMode::Default);
+			r.fill_rect(Recti(0, 0, clock_.get_w() + 2 * padding_, clock_.get_h() + 2 * padding_), bg,
+			            BlendMode::Default);
 		} else {
 			clock_.set_text(std::string());
 		}

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -793,8 +793,7 @@ UI::Window& AttackWindow::load(FileRead& fr, InteractiveBase& ib, Widelands::Map
 				a->do_not_conquer_->set_state(destroy == 0);
 			}
 
-			for (const Widelands::OPtr<Widelands::Bob> s :
-			     a->attack_panel_.attacking_soldiers_->get_soldiers()) {
+			for (const auto& s : a->attack_panel_.attacking_soldiers_->get_soldiers()) {
 				a->attack_panel_.attacking_soldiers_->remove(s);
 				a->attack_panel_.remaining_soldiers_->add(s);
 			}
@@ -834,8 +833,7 @@ void AttackWindow::save(FileWrite& fw, Widelands::MapObjectSaver& mos) const {
 	fw.unsigned_8(do_not_conquer_ && !do_not_conquer_->get_state() ? 1 : 0);
 
 	fw.unsigned_32(attack_panel_.attacking_soldiers_->get_soldiers().size());
-	for (const Widelands::OPtr<Widelands::Bob> s :
-	     attack_panel_.attacking_soldiers_->get_soldiers()) {
+	for (const auto& s : attack_panel_.attacking_soldiers_->get_soldiers()) {
 		fw.unsigned_32(mos.get_object_file_index_or_zero(s.get(iplayer_.egbase())));
 	}
 }

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -185,7 +185,7 @@ std::vector<Widelands::OPtr<Widelands::Bob>> AttackWindow::get_max_attackers() {
 		if (warship->can_attack()) {
 			if (ship != nullptr) {  // Ship-to-ship combat
 				if (warship->has_attack_target(ship)) {
-					result_vector.push_back(warship);
+					result_vector.emplace_back(warship);
 				}
 			} else {  // Ship-to-land invasion
 				const std::vector<Widelands::Coords>& spaces = warship->exp_port_spaces();

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -110,12 +110,13 @@ AttackWindow::AttackWindow(InteractivePlayer& parent,
 	initialization_complete();
 }
 
-AttackPanel::AttackPanel(UI::Panel& parent,
-                         InteractivePlayer& iplayer,
-                         bool can_attack,
-                         const Widelands::Coords* target_coordinates,
-                         AttackType attack_type,
-                         std::function<std::vector<Widelands::OPtr<Widelands::Bob>>()> get_max_attackers)
+AttackPanel::AttackPanel(
+   UI::Panel& parent,
+   InteractivePlayer& iplayer,
+   bool can_attack,
+   const Widelands::Coords* target_coordinates,
+   AttackType attack_type,
+   std::function<std::vector<Widelands::OPtr<Widelands::Bob>>()> get_max_attackers)
    : UI::Box(&parent, UI::PanelStyle::kWui, "attack_panel", 0, 0, UI::Box::Vertical),
      iplayer_(iplayer),
      target_coordinates_(target_coordinates),
@@ -354,7 +355,8 @@ void AttackPanel::update(bool action_on_panel) {
 	more_soldiers_->set_title(std::to_string(max_attackers));
 }
 
-void AttackPanel::init_slider(const std::vector<Widelands::OPtr<Widelands::Bob>>& all_attackers, bool can_attack) {
+void AttackPanel::init_slider(const std::vector<Widelands::OPtr<Widelands::Bob>>& all_attackers,
+                              bool can_attack) {
 	const size_t max_attackers = all_attackers.size();
 
 	soldiers_text_.reset(&add_text(
@@ -390,7 +392,8 @@ void AttackPanel::init_slider(const std::vector<Widelands::OPtr<Widelands::Bob>>
 	more_soldiers_->set_enabled(max_attackers > 0);
 }
 
-void AttackPanel::init_soldier_lists(const std::vector<Widelands::OPtr<Widelands::Bob>>& all_attackers) {
+void AttackPanel::init_soldier_lists(
+   const std::vector<Widelands::OPtr<Widelands::Bob>>& all_attackers) {
 	attacking_soldiers_.reset(new ListOfSoldiers(this, this, 0, 0, 30, 30));
 	remaining_soldiers_.reset(new ListOfSoldiers(this, this, 0, 0, 30, 30));
 	attacking_soldiers_->set_complement(remaining_soldiers_.get());
@@ -613,7 +616,8 @@ void AttackPanel::ListOfSoldiers::handle_mousein(bool /*inside*/) {
 bool AttackPanel::ListOfSoldiers::handle_mousemove(
    uint8_t /*state*/, int32_t x, int32_t y, int32_t /*xdiff*/, int32_t /*ydiff*/) {
 	MutexLock m(MutexLock::ID::kObjects);
-	if (const Widelands::Bob* mo = soldier_at(x, y).get(attack_box_->iplayer_.egbase()); mo != nullptr) {
+	if (const Widelands::Bob* mo = soldier_at(x, y).get(attack_box_->iplayer_.egbase());
+	    mo != nullptr) {
 		if (mo->descr().type() == Widelands::MapObjectType::SHIP) {
 			upcast(const Widelands::Ship, ship, mo);
 			set_tooltip(format(_("%1$s  HP: %2$u/%3$u  AT: +%4$u%%"), ship->get_shipname(),
@@ -657,7 +661,8 @@ void AttackPanel::ListOfSoldiers::update_desired_size() {
 	set_desired_size(e.w * kSoldierIconWidth, e.h * kSoldierIconHeight);
 }
 
-const Widelands::OPtr<Widelands::Bob> AttackPanel::ListOfSoldiers::soldier_at(int32_t x, int32_t y) const {
+const Widelands::OPtr<Widelands::Bob> AttackPanel::ListOfSoldiers::soldier_at(int32_t x,
+                                                                              int32_t y) const {
 	if (x < 0 || y < 0 || soldiers_.empty()) {
 		return nullptr;
 	}
@@ -691,15 +696,22 @@ void AttackPanel::ListOfSoldiers::sort() {
 	MutexLock m(MutexLock::ID::kObjects);
 
 	const Widelands::Map& map = attack_box_->iplayer_.egbase().map();
-	std::sort(
-	   soldiers_.begin(), soldiers_.end(), [this, &map](const Widelands::OPtr<Widelands::Bob> pa, const Widelands::OPtr<Widelands::Bob> pb) {
-		   const Widelands::Bob* obja = pa.get(attack_box_->iplayer_.egbase());
-		   const Widelands::Bob* objb = pb.get(attack_box_->iplayer_.egbase());
-		   const uint32_t dista = obja != nullptr ? map.calc_distance(obja->get_position(), *attack_box_->target_coordinates_) : std::numeric_limits<uint32_t>::max();
-		   const uint32_t distb = objb != nullptr ? map.calc_distance(objb->get_position(), *attack_box_->target_coordinates_) : std::numeric_limits<uint32_t>::max();
+	std::sort(soldiers_.begin(), soldiers_.end(),
+	          [this, &map](const Widelands::OPtr<Widelands::Bob> pa,
+	                       const Widelands::OPtr<Widelands::Bob> pb) {
+		          const Widelands::Bob* obja = pa.get(attack_box_->iplayer_.egbase());
+		          const Widelands::Bob* objb = pb.get(attack_box_->iplayer_.egbase());
+		          const uint32_t dista =
+		             obja != nullptr ?
+                      map.calc_distance(obja->get_position(), *attack_box_->target_coordinates_) :
+                      std::numeric_limits<uint32_t>::max();
+		          const uint32_t distb =
+		             objb != nullptr ?
+                      map.calc_distance(objb->get_position(), *attack_box_->target_coordinates_) :
+                      std::numeric_limits<uint32_t>::max();
 
-		   return dista < distb;
-	   });
+		          return dista < distb;
+	          });
 }
 
 void AttackPanel::ListOfSoldiers::draw(RenderTarget& dst) {
@@ -723,20 +735,21 @@ void AttackPanel::ListOfSoldiers::draw(RenderTarget& dst) {
 				assert(soldier != nullptr);
 
 				dst.fill_rect(Recti(location, kSoldierIconWidth, kSoldierIconHeight),
-					          get_soldier_color(soldier), BlendMode::Default);
+				              get_soldier_color(soldier), BlendMode::Default);
 
 				soldier->draw_info_icon(location, 1.0f, Widelands::Soldier::InfoMode::kInBuilding,
-					                    InfoToDraw::kSoldierLevels, &dst);
+				                        InfoToDraw::kSoldierLevels, &dst);
 
 				if (soldier->is_shipping()) {
 					constexpr float kOffset = 0.35f;
 					constexpr float kSize = 0.5f;
 					constexpr float kAlpha = 0.9f;
 					const Image* anchor = g_image_cache->get("images/wui/overlays/port_hint.png");
-					dst.blitrect_scale(
-					   Rectf((column + kOffset) * kSoldierIconWidth, (row + kOffset) * kSoldierIconHeight,
-						     kSoldierIconWidth * kSize, kSoldierIconHeight * kSize),
-					   anchor, Recti(0, 0, anchor->width(), anchor->height()), kAlpha, BlendMode::Default);
+					dst.blitrect_scale(Rectf((column + kOffset) * kSoldierIconWidth,
+					                         (row + kOffset) * kSoldierIconHeight,
+					                         kSoldierIconWidth * kSize, kSoldierIconHeight * kSize),
+					                   anchor, Recti(0, 0, anchor->width(), anchor->height()), kAlpha,
+					                   BlendMode::Default);
 				}
 			}
 		}
@@ -780,7 +793,8 @@ UI::Window& AttackWindow::load(FileRead& fr, InteractiveBase& ib, Widelands::Map
 				a->do_not_conquer_->set_state(destroy == 0);
 			}
 
-			for (const Widelands::OPtr<Widelands::Bob> s : a->attack_panel_.attacking_soldiers_->get_soldiers()) {
+			for (const Widelands::OPtr<Widelands::Bob> s :
+			     a->attack_panel_.attacking_soldiers_->get_soldiers()) {
 				a->attack_panel_.attacking_soldiers_->remove(s);
 				a->attack_panel_.remaining_soldiers_->add(s);
 			}
@@ -820,7 +834,8 @@ void AttackWindow::save(FileWrite& fw, Widelands::MapObjectSaver& mos) const {
 	fw.unsigned_8(do_not_conquer_ && !do_not_conquer_->get_state() ? 1 : 0);
 
 	fw.unsigned_32(attack_panel_.attacking_soldiers_->get_soldiers().size());
-	for (const Widelands::OPtr<Widelands::Bob> s : attack_panel_.attacking_soldiers_->get_soldiers()) {
+	for (const Widelands::OPtr<Widelands::Bob> s :
+	     attack_panel_.attacking_soldiers_->get_soldiers()) {
 		fw.unsigned_32(mos.get_object_file_index_or_zero(s.get(iplayer_.egbase())));
 	}
 }

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -115,7 +115,7 @@ AttackPanel::AttackPanel(UI::Panel& parent,
                          bool can_attack,
                          const Widelands::Coords* target_coordinates,
                          AttackType attack_type,
-                         std::function<std::vector<Widelands::Bob*>()> get_max_attackers)
+                         std::function<std::vector<Widelands::OPtr<Widelands::Bob>>()> get_max_attackers)
    : UI::Box(&parent, UI::PanelStyle::kWui, "attack_panel", 0, 0, UI::Box::Vertical),
      iplayer_(iplayer),
      target_coordinates_(target_coordinates),
@@ -126,7 +126,7 @@ AttackPanel::AttackPanel(UI::Panel& parent,
      linebox_(this, UI::PanelStyle::kWui, "line_box", 0, 0, UI::Box::Horizontal),
      columnbox_(&linebox_, UI::PanelStyle::kWui, "column_box", 0, 0, UI::Box::Vertical) {
 
-	const std::vector<Widelands::Bob*> all_attackers = get_max_attackers_();
+	const std::vector<Widelands::OPtr<Widelands::Bob>> all_attackers = get_max_attackers_();
 
 	init_slider(all_attackers, can_attack);
 	init_soldier_lists(all_attackers);
@@ -140,7 +140,7 @@ AttackWindow::~AttackWindow() {
 	living_attack_windows_.erase(serial_);
 }
 
-std::vector<Widelands::Bob*> AttackWindow::get_max_attackers() {
+std::vector<Widelands::OPtr<Widelands::Bob>> AttackWindow::get_max_attackers() {
 	MutexLock m(MutexLock::ID::kObjects);
 	const Widelands::EditorGameBase& egbase = iplayer_.egbase();
 	Widelands::Building* building = get_building();
@@ -149,7 +149,7 @@ std::vector<Widelands::Bob*> AttackWindow::get_max_attackers() {
 		die();  // The target object no longer exists.
 		return {};
 	}
-	std::vector<Widelands::Bob*> result_vector;
+	std::vector<Widelands::OPtr<Widelands::Bob>> result_vector;
 
 	// First try land-based attack
 	if (building != nullptr) {
@@ -296,7 +296,7 @@ void AttackPanel::update(bool action_on_panel) {
 	assert(attacking_soldiers_.get());
 	assert(remaining_soldiers_.get());
 
-	std::vector<Widelands::Bob*> all_attackers = get_max_attackers_();
+	std::vector<Widelands::OPtr<Widelands::Bob>> all_attackers = get_max_attackers_();
 	const int max_attackers = all_attackers.size();
 
 	// Update number of available soldiers
@@ -330,13 +330,13 @@ void AttackPanel::update(bool action_on_panel) {
 		const int32_t lacking = soldiers_slider_->get_value() - attacking_soldiers_->count_soldiers();
 		if (lacking > 0) {
 			for (int32_t i = 0; i < lacking; ++i) {
-				const Widelands::Bob* s = remaining_soldiers_->get_soldier();
+				const Widelands::OPtr<Widelands::Bob> s = remaining_soldiers_->get_soldier();
 				remaining_soldiers_->remove(s);
 				attacking_soldiers_->add(s);
 			}
 		} else if (lacking < 0) {
 			for (int32_t i = 0; i > lacking; --i) {
-				const Widelands::Bob* s = attacking_soldiers_->get_soldier();
+				const Widelands::OPtr<Widelands::Bob> s = attacking_soldiers_->get_soldier();
 				attacking_soldiers_->remove(s);
 				remaining_soldiers_->add(s);
 			}
@@ -354,7 +354,7 @@ void AttackPanel::update(bool action_on_panel) {
 	more_soldiers_->set_title(std::to_string(max_attackers));
 }
 
-void AttackPanel::init_slider(const std::vector<Widelands::Bob*>& all_attackers, bool can_attack) {
+void AttackPanel::init_slider(const std::vector<Widelands::OPtr<Widelands::Bob>>& all_attackers, bool can_attack) {
 	const size_t max_attackers = all_attackers.size();
 
 	soldiers_text_.reset(&add_text(
@@ -390,7 +390,7 @@ void AttackPanel::init_slider(const std::vector<Widelands::Bob*>& all_attackers,
 	more_soldiers_->set_enabled(max_attackers > 0);
 }
 
-void AttackPanel::init_soldier_lists(const std::vector<Widelands::Bob*>& all_attackers) {
+void AttackPanel::init_soldier_lists(const std::vector<Widelands::OPtr<Widelands::Bob>>& all_attackers) {
 	attacking_soldiers_.reset(new ListOfSoldiers(this, this, 0, 0, 30, 30));
 	remaining_soldiers_.reset(new ListOfSoldiers(this, this, 0, 0, 30, 30));
 	attacking_soldiers_->set_complement(remaining_soldiers_.get());
@@ -554,7 +554,7 @@ size_t AttackPanel::count_soldiers() const {
 std::vector<Widelands::Serial> AttackPanel::soldiers() const {
 	std::vector<Widelands::Serial> result;
 	for (const auto& s : attacking_soldiers_->get_soldiers()) {
-		result.push_back(s->serial());
+		result.push_back(s.serial());
 	}
 	return result;
 }
@@ -585,7 +585,7 @@ bool AttackPanel::ListOfSoldiers::handle_mousepress(uint8_t btn, int32_t x, int3
 			other_->add(s);
 		}
 	} else {
-		const Widelands::Bob* soldier = soldier_at(x, y);
+		const Widelands::OPtr<Widelands::Bob> soldier = soldier_at(x, y);
 		if (soldier == nullptr) {
 			return UI::Panel::handle_mousepress(btn, x, y);
 		}
@@ -612,7 +612,8 @@ void AttackPanel::ListOfSoldiers::handle_mousein(bool /*inside*/) {
 
 bool AttackPanel::ListOfSoldiers::handle_mousemove(
    uint8_t /*state*/, int32_t x, int32_t y, int32_t /*xdiff*/, int32_t /*ydiff*/) {
-	if (const Widelands::Bob* mo = soldier_at(x, y); mo != nullptr) {
+	MutexLock m(MutexLock::ID::kObjects);
+	if (const Widelands::Bob* mo = soldier_at(x, y).get(attack_box_->iplayer_.egbase()); mo != nullptr) {
 		if (mo->descr().type() == Widelands::MapObjectType::SHIP) {
 			upcast(const Widelands::Ship, ship, mo);
 			set_tooltip(format(_("%1$s  HP: %2$u/%3$u  AT: +%4$u%%"), ship->get_shipname(),
@@ -656,7 +657,7 @@ void AttackPanel::ListOfSoldiers::update_desired_size() {
 	set_desired_size(e.w * kSoldierIconWidth, e.h * kSoldierIconHeight);
 }
 
-const Widelands::Bob* AttackPanel::ListOfSoldiers::soldier_at(int32_t x, int32_t y) const {
+const Widelands::OPtr<Widelands::Bob> AttackPanel::ListOfSoldiers::soldier_at(int32_t x, int32_t y) const {
 	if (x < 0 || y < 0 || soldiers_.empty()) {
 		return nullptr;
 	}
@@ -672,13 +673,13 @@ const Widelands::Bob* AttackPanel::ListOfSoldiers::soldier_at(int32_t x, int32_t
 	return static_cast<unsigned int>(index) < soldiers_.size() ? soldiers_[index] : nullptr;
 }
 
-void AttackPanel::ListOfSoldiers::add(const Widelands::Bob* s) {
+void AttackPanel::ListOfSoldiers::add(const Widelands::OPtr<Widelands::Bob> s) {
 	soldiers_.push_back(s);
 	sort();
 	update_desired_size();
 }
 
-void AttackPanel::ListOfSoldiers::remove(const Widelands::Bob* s) {
+void AttackPanel::ListOfSoldiers::remove(const Widelands::OPtr<Widelands::Bob> s) {
 	const auto it = std::find(soldiers_.begin(), soldiers_.end(), s);
 	assert(it != soldiers_.end());
 	soldiers_.erase(it);
@@ -687,11 +688,17 @@ void AttackPanel::ListOfSoldiers::remove(const Widelands::Bob* s) {
 }
 
 void AttackPanel::ListOfSoldiers::sort() {
+	MutexLock m(MutexLock::ID::kObjects);
+
+	const Widelands::Map& map = attack_box_->iplayer_.egbase().map();
 	std::sort(
-	   soldiers_.begin(), soldiers_.end(), [this](const Widelands::Bob* a, const Widelands::Bob* b) {
-		   const Widelands::Map& map = attack_box_->iplayer_.egbase().map();
-		   return map.calc_distance(a->get_position(), *attack_box_->target_coordinates_) <
-		          map.calc_distance(b->get_position(), *attack_box_->target_coordinates_);
+	   soldiers_.begin(), soldiers_.end(), [this, &map](const Widelands::OPtr<Widelands::Bob> pa, const Widelands::OPtr<Widelands::Bob> pb) {
+		   const Widelands::Bob* obja = pa.get(attack_box_->iplayer_.egbase());
+		   const Widelands::Bob* objb = pb.get(attack_box_->iplayer_.egbase());
+		   const uint32_t dista = obja != nullptr ? map.calc_distance(obja->get_position(), *attack_box_->target_coordinates_) : std::numeric_limits<uint32_t>::max();
+		   const uint32_t distb = objb != nullptr ? map.calc_distance(objb->get_position(), *attack_box_->target_coordinates_) : std::numeric_limits<uint32_t>::max();
+
+		   return dista < distb;
 	   });
 }
 
@@ -700,31 +707,37 @@ void AttackPanel::ListOfSoldiers::draw(RenderTarget& dst) {
 	int32_t column = 0;
 	int32_t row = 0;
 	for (uint32_t i = 0; i < nr_soldiers; ++i) {
-		Vector2i location(column * kSoldierIconWidth, row * kSoldierIconHeight);
+		MutexLock m(MutexLock::ID::kObjects);
+		const Widelands::Bob* bob = soldiers_[i].get(attack_box_->iplayer_.egbase());
+		if (bob != nullptr) {
+			Vector2i location(column * kSoldierIconWidth, row * kSoldierIconHeight);
 
-		if (soldiers_[i]->descr().type() == Widelands::MapObjectType::SHIP) {
-			upcast(const Widelands::Ship, ship, soldiers_[i]);
+			if (bob->descr().type() == Widelands::MapObjectType::SHIP) {
+				upcast(const Widelands::Ship, ship, bob);
+				assert(ship != nullptr);
 
-			ship->draw_healthbar(attack_box_->iplayer_.egbase(), &dst, location.cast<float>(), 1.f);
+				ship->draw_healthbar(attack_box_->iplayer_.egbase(), &dst, location.cast<float>(), 1.f);
 
-		} else {
-			upcast(const Widelands::Soldier, soldier, soldiers_[i]);
+			} else {
+				upcast(const Widelands::Soldier, soldier, bob);
+				assert(soldier != nullptr);
 
-			dst.fill_rect(Recti(location, kSoldierIconWidth, kSoldierIconHeight),
-			              get_soldier_color(soldier), BlendMode::Default);
+				dst.fill_rect(Recti(location, kSoldierIconWidth, kSoldierIconHeight),
+					          get_soldier_color(soldier), BlendMode::Default);
 
-			soldier->draw_info_icon(location, 1.0f, Widelands::Soldier::InfoMode::kInBuilding,
-			                        InfoToDraw::kSoldierLevels, &dst);
+				soldier->draw_info_icon(location, 1.0f, Widelands::Soldier::InfoMode::kInBuilding,
+					                    InfoToDraw::kSoldierLevels, &dst);
 
-			if (soldier->is_shipping()) {
-				constexpr float kOffset = 0.35f;
-				constexpr float kSize = 0.5f;
-				constexpr float kAlpha = 0.9f;
-				const Image* anchor = g_image_cache->get("images/wui/overlays/port_hint.png");
-				dst.blitrect_scale(
-				   Rectf((column + kOffset) * kSoldierIconWidth, (row + kOffset) * kSoldierIconHeight,
-				         kSoldierIconWidth * kSize, kSoldierIconHeight * kSize),
-				   anchor, Recti(0, 0, anchor->width(), anchor->height()), kAlpha, BlendMode::Default);
+				if (soldier->is_shipping()) {
+					constexpr float kOffset = 0.35f;
+					constexpr float kSize = 0.5f;
+					constexpr float kAlpha = 0.9f;
+					const Image* anchor = g_image_cache->get("images/wui/overlays/port_hint.png");
+					dst.blitrect_scale(
+					   Rectf((column + kOffset) * kSoldierIconWidth, (row + kOffset) * kSoldierIconHeight,
+						     kSoldierIconWidth * kSize, kSoldierIconHeight * kSize),
+					   anchor, Recti(0, 0, anchor->width(), anchor->height()), kAlpha, BlendMode::Default);
+				}
 			}
 		}
 
@@ -767,19 +780,23 @@ UI::Window& AttackWindow::load(FileRead& fr, InteractiveBase& ib, Widelands::Map
 				a->do_not_conquer_->set_state(destroy == 0);
 			}
 
-			for (const Widelands::Bob* s : a->attack_panel_.attacking_soldiers_->get_soldiers()) {
+			for (const Widelands::OPtr<Widelands::Bob> s : a->attack_panel_.attacking_soldiers_->get_soldiers()) {
 				a->attack_panel_.attacking_soldiers_->remove(s);
 				a->attack_panel_.remaining_soldiers_->add(s);
 			}
 			for (size_t i = fr.unsigned_32(); i != 0u; --i) {
-				const Widelands::Bob* s = &mol.get<Widelands::Bob>(fr.unsigned_32());
+				const Widelands::Serial bob_serial = fr.unsigned_32();
+				if (bob_serial == 0) {
+					continue;
+				}
+				const Widelands::OPtr<Widelands::Bob> s = &mol.get<Widelands::Bob>(bob_serial);
 				if (a->attack_panel_.remaining_soldiers_->contains(s)) {
 					a->attack_panel_.remaining_soldiers_->remove(s);
 					a->attack_panel_.attacking_soldiers_->add(s);
 				}
 				/* Since the attack window only updates a soldier list every 500 ms, it is
-				 * possible for the saved list of soldiers to send to contain a soldier
-				 * who is no longer available. Skip this situation silently.
+				 * possible for the saved list of soldiers to send to contain a soldier who is
+				 * no longer available or even no longer exists. Skip this situation silently.
 				 */
 			}
 
@@ -803,7 +820,7 @@ void AttackWindow::save(FileWrite& fw, Widelands::MapObjectSaver& mos) const {
 	fw.unsigned_8(do_not_conquer_ && !do_not_conquer_->get_state() ? 1 : 0);
 
 	fw.unsigned_32(attack_panel_.attacking_soldiers_->get_soldiers().size());
-	for (const Widelands::Bob* s : attack_panel_.attacking_soldiers_->get_soldiers()) {
-		fw.unsigned_32(mos.get_object_file_index(*s));
+	for (const Widelands::OPtr<Widelands::Bob> s : attack_panel_.attacking_soldiers_->get_soldiers()) {
+		fw.unsigned_32(mos.get_object_file_index_or_zero(s.get(iplayer_.egbase())));
 	}
 }

--- a/src/wui/attack_window.h
+++ b/src/wui/attack_window.h
@@ -41,7 +41,7 @@ public:
 	            bool can_attack,
 	            const Widelands::Coords* target_coordinates,
 	            AttackType attack_type,
-	            std::function<std::vector<Widelands::Bob*>()> get_max_attackers);
+	            std::function<std::vector<Widelands::OPtr<Widelands::Bob>>()> get_max_attackers);
 
 	size_t count_soldiers() const;
 	std::vector<Widelands::Serial> soldiers() const;
@@ -65,8 +65,8 @@ private:
 	UI::Textarea&
 	add_text(UI::Box& parent, const std::string& str, UI::Align alignment, UI::FontStyle style);
 
-	void init_slider(const std::vector<Widelands::Bob*>&, bool can_attack);
-	void init_soldier_lists(const std::vector<Widelands::Bob*>&);
+	void init_slider(const std::vector<Widelands::OPtr<Widelands::Bob>>&, bool can_attack);
+	void init_soldier_lists(const std::vector<Widelands::OPtr<Widelands::Bob>>&);
 
 	void update(bool);
 	void send_less_soldiers();
@@ -89,19 +89,19 @@ private:
 		void handle_mousein(bool) override;
 		bool handle_mousemove(uint8_t, int32_t, int32_t, int32_t, int32_t) override;
 
-		const Widelands::Bob* soldier_at(int32_t x, int32_t y) const;
-		void add(const Widelands::Bob*);
-		void remove(const Widelands::Bob*);
+		const Widelands::OPtr<Widelands::Bob> soldier_at(int32_t x, int32_t y) const;
+		void add(const Widelands::OPtr<Widelands::Bob>);
+		void remove(const Widelands::OPtr<Widelands::Bob>);
 		void sort();
-		bool contains(const Widelands::Bob* soldier) const {
+		bool contains(const Widelands::OPtr<Widelands::Bob> soldier) const {
 			return std::any_of(
 			   soldiers_.begin(), soldiers_.end(), [soldier](const auto& s) { return s == soldier; });
 		}
 
-		std::vector<const Widelands::Bob*> get_soldiers() const {
+		std::vector<Widelands::OPtr<Widelands::Bob>> get_soldiers() const {
 			return soldiers_;
 		}
-		const Widelands::Bob* get_soldier() const {
+		const Widelands::OPtr<Widelands::Bob> get_soldier() const {
 			return soldiers_.back();
 		}
 
@@ -125,7 +125,7 @@ private:
 	private:
 		bool restricted_row_number_;
 		uint16_t current_size_;  // Current number of rows or columns
-		std::vector<const Widelands::Bob*> soldiers_;
+		std::vector<Widelands::OPtr<Widelands::Bob>> soldiers_;
 
 		ListOfSoldiers* other_;
 		AttackPanel* attack_box_;
@@ -133,7 +133,7 @@ private:
 		void update_desired_size() override;
 	};
 
-	std::function<std::vector<Widelands::Bob*>()> get_max_attackers_;
+	std::function<std::vector<Widelands::OPtr<Widelands::Bob>>()> get_max_attackers_;
 	const AttackType attack_type_;
 
 	/// The last time the information in this Panel got updated
@@ -179,7 +179,7 @@ protected:
 	void save(FileWrite&, Widelands::MapObjectSaver&) const override;
 
 private:
-	std::vector<Widelands::Bob*> get_max_attackers();
+	std::vector<Widelands::OPtr<Widelands::Bob>> get_max_attackers();
 
 	void act_attack();
 	void act_goto();

--- a/src/wui/attack_window.h
+++ b/src/wui/attack_window.h
@@ -90,8 +90,8 @@ private:
 		bool handle_mousemove(uint8_t, int32_t, int32_t, int32_t, int32_t) override;
 
 		const Widelands::OPtr<Widelands::Bob> soldier_at(int32_t x, int32_t y) const;
-		void add(const Widelands::OPtr<Widelands::Bob>);
-		void remove(const Widelands::OPtr<Widelands::Bob>);
+		void add(Widelands::OPtr<Widelands::Bob>);
+		void remove(Widelands::OPtr<Widelands::Bob>);
 		void sort();
 		bool contains(const Widelands::OPtr<Widelands::Bob> soldier) const {
 			return std::any_of(


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes https://www.widelands.org/forum/post/40799/

**To reproduce**
Not reproducible race condition. The attack window only updates itself every 500 ms so it may contain and draw soldiers or ships that no longer exist.

**New behavior**
Use `OPtr` instead of raw pointer everywhere. Most of the time the attack window only shuffles serials around and doesn't even need to access the object's properties; when it does access them, add mutex locks and check for `nullptr`.

**Possible regressions**
Attack window
