### PR TITLE
Add Lua APIs for Missing Bob Types

### DIFF
--- a/src/logic/map_objects/tribes/soldier.h
+++ b/src/logic/map_objects/tribes/soldier.h
@@ -439,6 +439,10 @@ public:
 
 	void add_soldier(EditorGameBase& egbase, Soldier* soldier);
 
+	[[nodiscard]] const std::set<OPtr<Soldier>>& get_soldiers() const {
+		return soldiers_;
+	}
+
 	void save(EditorGameBase&, MapObjectSaver&, FileWrite&) override;
 	static Loader* load(EditorGameBase&, MapObjectLoader&, FileRead&);
 

--- a/src/scripting/lua_bases.cc
+++ b/src/scripting/lua_bases.cc
@@ -988,7 +988,7 @@ int LuaPlayerBase::place_ship(lua_State* L) {  // NOLINT - can not be made const
 }
 
 /* RST
-   .. method:: place_pinned_note(field, text, r, g, b)
+   .. method:: place_pinned_note(field, text[, r, g, b])
 
       .. versionadded:: 1.2
 
@@ -1008,6 +1008,10 @@ int LuaPlayerBase::place_ship(lua_State* L) {  // NOLINT - can not be made const
       :returns: The new :class:`~wl.map.PinnedNote` that was created.
 */
 int LuaPlayerBase::place_pinned_note(lua_State* L) {  // NOLINT - can not be made const
+	if (lua_gettop(L) != 3 && lua_gettop(L) != 6) {
+		report_error(L, "Takes either 2 or 5 arguments");
+	}
+
 	LuaMaps::LuaField* c = *get_user_class<LuaMaps::LuaField>(L, 2);
 
 	Widelands::EditorGameBase& egbase = get_egbase(L);
@@ -1015,6 +1019,7 @@ int LuaPlayerBase::place_pinned_note(lua_State* L) {  // NOLINT - can not be mad
 
 	Widelands::PinnedNote& note = Widelands::PinnedNote::create(
 	   egbase, player, c->coords(), luaL_checkstring(L, 3),
+	   lua_gettop(L) < 6 ? get(L, get_egbase(L)).get_playercolor() :
 	   RGBColor(luaL_checkuint32(L, 4), luaL_checkuint32(L, 5), luaL_checkuint32(L, 6)));
 
 	LuaMaps::upcasted_map_object_to_lua(L, &note);

--- a/src/scripting/lua_bases.cc
+++ b/src/scripting/lua_bases.cc
@@ -622,11 +622,16 @@ PlayerBase
 
 const char LuaPlayerBase::className[] = "PlayerBase";
 const MethodType<LuaPlayerBase> LuaPlayerBase::Methods[] = {
-   METHOD(LuaPlayerBase, __eq),        METHOD(LuaPlayerBase, __tostring),
-   METHOD(LuaPlayerBase, conquer),     METHOD(LuaPlayerBase, get_wares),
-   METHOD(LuaPlayerBase, get_workers), METHOD(LuaPlayerBase, place_building),
-   METHOD(LuaPlayerBase, place_flag),  METHOD(LuaPlayerBase, place_road),
-   METHOD(LuaPlayerBase, place_ship),  METHOD(LuaPlayerBase, place_pinned_note),
+   METHOD(LuaPlayerBase, __eq),
+   METHOD(LuaPlayerBase, __tostring),
+   METHOD(LuaPlayerBase, conquer),
+   METHOD(LuaPlayerBase, get_wares),
+   METHOD(LuaPlayerBase, get_workers),
+   METHOD(LuaPlayerBase, place_building),
+   METHOD(LuaPlayerBase, place_flag),
+   METHOD(LuaPlayerBase, place_road),
+   METHOD(LuaPlayerBase, place_ship),
+   METHOD(LuaPlayerBase, place_pinned_note),
    {nullptr, nullptr},
 };
 const PropertyType<LuaPlayerBase> LuaPlayerBase::Properties[] = {
@@ -1008,8 +1013,9 @@ int LuaPlayerBase::place_pinned_note(lua_State* L) {  // NOLINT - can not be mad
 	Widelands::EditorGameBase& egbase = get_egbase(L);
 	Widelands::Player& player = get(L, egbase);
 
-	Widelands::PinnedNote& note = Widelands::PinnedNote::create(egbase, player, c->coords(),
-			luaL_checkstring(L, 3), RGBColor(luaL_checkuint32(L, 4), luaL_checkuint32(L, 5), luaL_checkuint32(L, 6)));
+	Widelands::PinnedNote& note = Widelands::PinnedNote::create(
+	   egbase, player, c->coords(), luaL_checkstring(L, 3),
+	   RGBColor(luaL_checkuint32(L, 4), luaL_checkuint32(L, 5), luaL_checkuint32(L, 6)));
 
 	LuaMaps::upcasted_map_object_to_lua(L, &note);
 

--- a/src/scripting/lua_bases.cc
+++ b/src/scripting/lua_bases.cc
@@ -626,7 +626,8 @@ const MethodType<LuaPlayerBase> LuaPlayerBase::Methods[] = {
    METHOD(LuaPlayerBase, conquer),     METHOD(LuaPlayerBase, get_wares),
    METHOD(LuaPlayerBase, get_workers), METHOD(LuaPlayerBase, place_building),
    METHOD(LuaPlayerBase, place_flag),  METHOD(LuaPlayerBase, place_road),
-   METHOD(LuaPlayerBase, place_ship),  {nullptr, nullptr},
+   METHOD(LuaPlayerBase, place_ship),  METHOD(LuaPlayerBase, place_pinned_note),
+   {nullptr, nullptr},
 };
 const PropertyType<LuaPlayerBase> LuaPlayerBase::Properties[] = {
    PROP_RO(LuaPlayerBase, number),
@@ -977,6 +978,40 @@ int LuaPlayerBase::place_ship(lua_State* L) {  // NOLINT - can not be made const
 	Widelands::Bob& ship = egbase.create_ship(c->coords(), descr->name(), &player);
 
 	LuaMaps::upcasted_map_object_to_lua(L, &ship);
+
+	return 1;
+}
+
+/* RST
+   .. method:: place_pinned_note(field, text, r, g, b)
+
+      .. versionadded:: 1.2
+
+      Place a pinned note on the map for this player.
+
+      :arg field: The field where the note should be placed.
+      :type field: :class:`~wl.map.Field`
+      :arg text: The text of the note.
+      :type text: :class:`string`
+      :arg r: The Red component of the note's color.
+      :type r: :class:`integer`
+      :arg g: The Green component of the note's color.
+      :type g: :class:`integer`
+      :arg b: The Blue component of the note's color.
+      :type b: :class:`integer`
+
+      :returns: The new :class:`~wl.map.PinnedNote` that was created.
+*/
+int LuaPlayerBase::place_pinned_note(lua_State* L) {  // NOLINT - can not be made const
+	LuaMaps::LuaField* c = *get_user_class<LuaMaps::LuaField>(L, 2);
+
+	Widelands::EditorGameBase& egbase = get_egbase(L);
+	Widelands::Player& player = get(L, egbase);
+
+	Widelands::PinnedNote& note = Widelands::PinnedNote::create(egbase, player, c->coords(),
+			luaL_checkstring(L, 3), RGBColor(luaL_checkuint32(L, 4), luaL_checkuint32(L, 5), luaL_checkuint32(L, 6)));
+
+	LuaMaps::upcasted_map_object_to_lua(L, &note);
 
 	return 1;
 }

--- a/src/scripting/lua_bases.cc
+++ b/src/scripting/lua_bases.cc
@@ -1019,8 +1019,9 @@ int LuaPlayerBase::place_pinned_note(lua_State* L) {  // NOLINT - can not be mad
 
 	Widelands::PinnedNote& note = Widelands::PinnedNote::create(
 	   egbase, player, c->coords(), luaL_checkstring(L, 3),
-	   lua_gettop(L) < 6 ? get(L, get_egbase(L)).get_playercolor() :
-	   RGBColor(luaL_checkuint32(L, 4), luaL_checkuint32(L, 5), luaL_checkuint32(L, 6)));
+	   lua_gettop(L) < 6 ?
+         get(L, get_egbase(L)).get_playercolor() :
+         RGBColor(luaL_checkuint32(L, 4), luaL_checkuint32(L, 5), luaL_checkuint32(L, 6)));
 
 	LuaMaps::upcasted_map_object_to_lua(L, &note);
 

--- a/src/scripting/lua_bases.h
+++ b/src/scripting/lua_bases.h
@@ -117,6 +117,7 @@ public:
 	int place_road(lua_State* L);
 	int place_building(lua_State* L);
 	int place_ship(lua_State* L);
+	int place_pinned_note(lua_State* L);
 	int conquer(lua_State* L);
 	int get_workers(lua_State* L);
 	int get_wares(lua_State* L);

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -9052,6 +9052,5 @@ void luaopen_wlmap(lua_State* L) {
 	add_parent<LuaFerryFleetYardInterface, LuaBob>(L);
 	add_parent<LuaFerryFleetYardInterface, LuaMapObject>(L);
 	lua_pop(L, 1);  // Pop the meta table
-
 }
 }  // namespace LuaMaps

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -7820,8 +7820,10 @@ int LuaPinnedNote::get_color(lua_State* L) {
 	lua_newtable(L);
 	lua_pushuint32(L, 1);
 	lua_pushuint32(L, rgb.r);
+	lua_rawset(L, -3);
 	lua_pushuint32(L, 2);
 	lua_pushuint32(L, rgb.g);
+	lua_rawset(L, -3);
 	lua_pushuint32(L, 3);
 	lua_pushuint32(L, rgb.b);
 	lua_rawset(L, -3);

--- a/src/scripting/lua_map.cc
+++ b/src/scripting/lua_map.cc
@@ -932,6 +932,14 @@ int upcasted_map_object_to_lua(lua_State* L, Widelands::MapObject* mo) {
 		return CAST_TO_LUA(MilitarySite);
 	case Widelands::MapObjectType::TRAININGSITE:
 		return CAST_TO_LUA(TrainingSite);
+	case Widelands::MapObjectType::PINNED_NOTE:
+		return CAST_TO_LUA(PinnedNote);
+	case Widelands::MapObjectType::SHIP_FLEET_YARD_INTERFACE:
+		return CAST_TO_LUA(ShipFleetYardInterface);
+	case Widelands::MapObjectType::FERRY_FLEET_YARD_INTERFACE:
+		return CAST_TO_LUA(FerryFleetYardInterface);
+	case Widelands::MapObjectType::NAVAL_INVASION_BASE:
+		return CAST_TO_LUA(NavalInvasionBase);
 	case Widelands::MapObjectType::MAPOBJECT:
 	case Widelands::MapObjectType::RESOURCE:
 	case Widelands::MapObjectType::TERRAIN:
@@ -940,10 +948,6 @@ int upcasted_map_object_to_lua(lua_State* L, Widelands::MapObject* mo) {
 	case Widelands::MapObjectType::SHIP_FLEET:
 	case Widelands::MapObjectType::FERRY_FLEET:
 	case Widelands::MapObjectType::WARE:
-	case Widelands::MapObjectType::PINNED_NOTE:
-	case Widelands::MapObjectType::SHIP_FLEET_YARD_INTERFACE:
-	case Widelands::MapObjectType::FERRY_FLEET_YARD_INTERFACE:
-	case Widelands::MapObjectType::NAVAL_INVASION_BASE:
 		throw LuaError(
 		   format("upcasted_map_object_to_lua: Unknown %i", static_cast<int>(mo->descr().type())));
 	}
@@ -7041,11 +7045,9 @@ int LuaShip::get_destination(lua_State* L) {
 	if (Widelands::Ship* s = ship->get_destination_ship(egbase); s != nullptr) {
 		return upcasted_map_object_to_lua(L, s);
 	}
-#if 0  // TODO(Nordfriese): Pinned notes don't have a Lua class yet
 	if (Widelands::PinnedNote* note = ship->get_destination_note(egbase); note != nullptr) {
 		return upcasted_map_object_to_lua(L, note);
 	}
-#endif
 
 	lua_pushnil(L);
 	return 1;
@@ -7740,6 +7742,299 @@ int LuaSoldier::set_current_health(lua_State* L) {
 
 	s.set_current_health(ch);
 	return 0;
+}
+
+/*
+ ==========================================================
+ LUA METHODS
+ ==========================================================
+ */
+
+/*
+ ==========================================================
+ C METHODS
+ ==========================================================
+ */
+
+/* RST
+PinnedNote
+----------
+
+.. class:: PinnedNote
+
+   .. versionadded:: 1.2
+
+   This represents a note pinned to a map field.
+
+   More properties are available through this object's
+   :class:`MapObjectDescription`, which you can access via :any:`MapObject.descr`.
+*/
+
+const char LuaPinnedNote::className[] = "PinnedNote";
+const MethodType<LuaPinnedNote> LuaPinnedNote::Methods[] = {
+   {nullptr, nullptr},
+};
+const PropertyType<LuaPinnedNote> LuaPinnedNote::Properties[] = {
+   PROP_RO(LuaPinnedNote, owner),
+   PROP_RW(LuaPinnedNote, text),
+   PROP_RW(LuaPinnedNote, color),
+   {nullptr, nullptr, nullptr},
+};
+
+/*
+ ==========================================================
+ PROPERTIES
+ ==========================================================
+ */
+/* RST
+   .. attribute:: owner
+
+      (RO) The :class:`wl.game.Player` who owns this object.
+*/
+int LuaPinnedNote::get_owner(lua_State* L) {
+	get_factory(L).push_player(L, get(L, get_egbase(L))->get_owner()->player_number());
+	return 1;
+}
+
+/* RST
+   .. attribute:: text
+
+      (RW) The text of the note.
+*/
+int LuaPinnedNote::get_text(lua_State* L) {
+	lua_pushstring(L, get(L, get_egbase(L))->get_text().c_str());
+	return 1;
+}
+int LuaPinnedNote::set_text(lua_State* L) {
+	get(L, get_egbase(L))->set_text(luaL_checkstring(L, -1));
+	return 0;
+}
+
+/* RST
+   .. attribute:: color
+
+      (RW) The color of the note, as an :class:`array` of three integers representing R, G, and B.
+*/
+int LuaPinnedNote::get_color(lua_State* L) {
+	const RGBColor& rgb = get(L, get_egbase(L))->get_rgb();
+	lua_newtable(L);
+	lua_pushuint32(L, 1);
+	lua_pushuint32(L, rgb.r);
+	lua_pushuint32(L, 2);
+	lua_pushuint32(L, rgb.g);
+	lua_pushuint32(L, 3);
+	lua_pushuint32(L, rgb.b);
+	lua_rawset(L, -3);
+	return 1;
+}
+int LuaPinnedNote::set_color(lua_State* L) {
+	luaL_checktype(L, -1, LUA_TTABLE);
+
+	lua_geti(L, -1, 1);
+	const unsigned r = luaL_checkuint32(L, -1);
+	lua_pop(L, 1);
+
+	lua_geti(L, -1, 2);
+	const unsigned g = luaL_checkuint32(L, -1);
+	lua_pop(L, 1);
+
+	lua_geti(L, -1, 3);
+	const unsigned b = luaL_checkuint32(L, -1);
+	lua_pop(L, 1);
+
+	get(L, get_egbase(L))->set_rgb(RGBColor(r, g, b));
+
+	return 0;
+}
+
+/*
+ ==========================================================
+ LUA METHODS
+ ==========================================================
+ */
+
+/*
+ ==========================================================
+ C METHODS
+ ==========================================================
+ */
+
+/* RST
+NavalInvasionBase
+-----------------
+
+.. class:: NavalInvasionBase
+
+   .. versionadded:: 1.2
+
+   This represents a naval invasion in progress.
+
+   More properties are available through this object's
+   :class:`MapObjectDescription`, which you can access via :any:`MapObject.descr`.
+*/
+
+const char LuaNavalInvasionBase::className[] = "NavalInvasionBase";
+const MethodType<LuaNavalInvasionBase> LuaNavalInvasionBase::Methods[] = {
+   {nullptr, nullptr},
+};
+const PropertyType<LuaNavalInvasionBase> LuaNavalInvasionBase::Properties[] = {
+   PROP_RO(LuaNavalInvasionBase, owner),
+   PROP_RO(LuaNavalInvasionBase, soldiers),
+   {nullptr, nullptr, nullptr},
+};
+
+/*
+ ==========================================================
+ PROPERTIES
+ ==========================================================
+ */
+/* RST
+   .. attribute:: owner
+
+      (RO) The :class:`wl.game.Player` who owns this object.
+*/
+int LuaNavalInvasionBase::get_owner(lua_State* L) {
+	get_factory(L).push_player(L, get(L, get_egbase(L))->get_owner()->player_number());
+	return 1;
+}
+
+/* RST
+   .. attribute:: soldiers
+
+      (RO) An :class:`array` with every :class:`~wl.map.Soldier`
+      currently stationed on this invasion base.
+*/
+int LuaNavalInvasionBase::get_soldiers(lua_State* L) {
+	Widelands::EditorGameBase& egbase = get_egbase(L);
+	const auto& soldiers = get(L, egbase)->get_soldiers();
+	lua_newtable(L);
+	uint32_t cidx = 1;
+	for (const auto& ptr : soldiers) {
+		lua_pushuint32(L, cidx++);
+		upcasted_map_object_to_lua(L, ptr.get(egbase));
+		lua_rawset(L, -3);
+	}
+	return 1;
+}
+
+/*
+ ==========================================================
+ LUA METHODS
+ ==========================================================
+ */
+
+/*
+ ==========================================================
+ C METHODS
+ ==========================================================
+ */
+
+/* RST
+ShipFleetYardInterface
+----------------------
+
+.. class:: ShipFleetYardInterface
+
+   .. versionadded:: 1.2
+
+   This represents an interface between a shipyard and a ship fleet.
+
+   More properties are available through this object's
+   :class:`MapObjectDescription`, which you can access via :any:`MapObject.descr`.
+*/
+
+const char LuaShipFleetYardInterface::className[] = "ShipFleetYardInterface";
+const MethodType<LuaShipFleetYardInterface> LuaShipFleetYardInterface::Methods[] = {
+   {nullptr, nullptr},
+};
+const PropertyType<LuaShipFleetYardInterface> LuaShipFleetYardInterface::Properties[] = {
+   PROP_RO(LuaShipFleetYardInterface, building),
+   {nullptr, nullptr, nullptr},
+};
+
+/*
+ ==========================================================
+ PROPERTIES
+ ==========================================================
+ */
+/* RST
+   .. attribute:: owner
+
+      (RO) The :class:`wl.game.Player` who owns this object.
+*/
+int LuaShipFleetYardInterface::get_owner(lua_State* L) {
+	get_factory(L).push_player(L, get(L, get_egbase(L))->get_owner()->player_number());
+	return 1;
+}
+
+/* RST
+   .. attribute:: building
+
+      (RO) The shipyard this interface belongs to.
+*/
+int LuaShipFleetYardInterface::get_building(lua_State* L) {
+	upcasted_map_object_to_lua(L, get(L, get_egbase(L))->get_building());
+	return 1;
+}
+
+/*
+ ==========================================================
+ LUA METHODS
+ ==========================================================
+ */
+
+/*
+ ==========================================================
+ C METHODS
+ ==========================================================
+ */
+
+/* RST
+FerryFleetYardInterface
+-----------------------
+
+.. class:: FerryFleetYardInterface
+
+   .. versionadded:: 1.2
+
+   This represents an interface between a ferry yard and a ferry fleet.
+
+   More properties are available through this object's
+   :class:`MapObjectDescription`, which you can access via :any:`MapObject.descr`.
+*/
+
+const char LuaFerryFleetYardInterface::className[] = "FerryFleetYardInterface";
+const MethodType<LuaFerryFleetYardInterface> LuaFerryFleetYardInterface::Methods[] = {
+   {nullptr, nullptr},
+};
+const PropertyType<LuaFerryFleetYardInterface> LuaFerryFleetYardInterface::Properties[] = {
+   PROP_RO(LuaFerryFleetYardInterface, building),
+   {nullptr, nullptr, nullptr},
+};
+
+/*
+ ==========================================================
+ PROPERTIES
+ ==========================================================
+ */
+/* RST
+   .. attribute:: owner
+
+      (RO) The :class:`wl.game.Player` who owns this object.
+*/
+int LuaFerryFleetYardInterface::get_owner(lua_State* L) {
+	get_factory(L).push_player(L, get(L, get_egbase(L))->get_owner()->player_number());
+	return 1;
+}
+
+/* RST
+   .. attribute:: building
+
+      (RO) The ferry yard this interface belongs to.
+*/
+int LuaFerryFleetYardInterface::get_building(lua_State* L) {
+	upcasted_map_object_to_lua(L, get(L, get_egbase(L))->get_building());
+	return 1;
 }
 
 /*
@@ -8735,5 +9030,26 @@ void luaopen_wlmap(lua_State* L) {
 	add_parent<LuaTrainingSite, LuaBaseImmovable>(L);
 	add_parent<LuaTrainingSite, LuaMapObject>(L);
 	lua_pop(L, 1);  // Pop the meta table
+
+	register_class<LuaPinnedNote>(L, "map", true);
+	add_parent<LuaPinnedNote, LuaBob>(L);
+	add_parent<LuaPinnedNote, LuaMapObject>(L);
+	lua_pop(L, 1);  // Pop the meta table
+
+	register_class<LuaNavalInvasionBase>(L, "map", true);
+	add_parent<LuaNavalInvasionBase, LuaBob>(L);
+	add_parent<LuaNavalInvasionBase, LuaMapObject>(L);
+	lua_pop(L, 1);  // Pop the meta table
+
+	register_class<LuaShipFleetYardInterface>(L, "map", true);
+	add_parent<LuaShipFleetYardInterface, LuaBob>(L);
+	add_parent<LuaShipFleetYardInterface, LuaMapObject>(L);
+	lua_pop(L, 1);  // Pop the meta table
+
+	register_class<LuaFerryFleetYardInterface>(L, "map", true);
+	add_parent<LuaFerryFleetYardInterface, LuaBob>(L);
+	add_parent<LuaFerryFleetYardInterface, LuaMapObject>(L);
+	lua_pop(L, 1);  // Pop the meta table
+
 }
 }  // namespace LuaMaps

--- a/src/scripting/lua_map.h
+++ b/src/scripting/lua_map.h
@@ -20,10 +20,13 @@
 #define WL_SCRIPTING_LUA_MAP_H
 
 #include "economy/economy.h"
+#include "economy/ferry_fleet.h"
 #include "economy/flag.h"
 #include "economy/portdock.h"
 #include "economy/road.h"
+#include "economy/ship_fleet.h"
 #include "logic/game.h"
+#include "logic/map_objects/pinned_note.h"
 #include "logic/map_objects/tribes/constructionsite.h"
 #include "logic/map_objects/tribes/dismantlesite.h"
 #include "logic/map_objects/tribes/market.h"
@@ -1441,6 +1444,118 @@ public:
 	 */
 	CASTED_GET(Ship)
 };
+
+class LuaPinnedNote : public LuaBob {
+public:
+	LUNA_CLASS_HEAD(LuaPinnedNote);
+
+	LuaPinnedNote() = default;
+	explicit LuaPinnedNote(Widelands::PinnedNote& n) : LuaBob(n) {
+	}
+	explicit LuaPinnedNote(lua_State* L) : LuaBob(L) {
+	}
+	~LuaPinnedNote() override = default;
+
+	/*
+	 * Properties
+	 */
+	int get_owner(lua_State* L);
+	int get_text(lua_State*);
+	int set_text(lua_State*);
+	int get_color(lua_State*);
+	int set_color(lua_State*);
+
+	/*
+	 * Lua methods
+	 */
+
+	/*
+	 * C methods
+	 */
+	CASTED_GET(PinnedNote)
+};
+
+class LuaNavalInvasionBase : public LuaBob {
+public:
+	LUNA_CLASS_HEAD(LuaNavalInvasionBase);
+
+	LuaNavalInvasionBase() = default;
+	explicit LuaNavalInvasionBase(Widelands::NavalInvasionBase& n) : LuaBob(n) {
+	}
+	explicit LuaNavalInvasionBase(lua_State* L) : LuaBob(L) {
+	}
+	~LuaNavalInvasionBase() override = default;
+
+	/*
+	 * Properties
+	 */
+	int get_owner(lua_State* L);
+	int get_soldiers(lua_State*);
+
+	/*
+	 * Lua methods
+	 */
+
+	/*
+	 * C methods
+	 */
+	CASTED_GET(NavalInvasionBase)
+};
+
+class LuaShipFleetYardInterface : public LuaBob {
+public:
+	LUNA_CLASS_HEAD(LuaShipFleetYardInterface);
+
+	LuaShipFleetYardInterface() = default;
+	explicit LuaShipFleetYardInterface(Widelands::ShipFleetYardInterface& i) : LuaBob(i) {
+	}
+	explicit LuaShipFleetYardInterface(lua_State* L) : LuaBob(L) {
+	}
+	~LuaShipFleetYardInterface() override = default;
+
+	/*
+	 * Properties
+	 */
+	int get_owner(lua_State* L);
+	int get_building(lua_State*);
+
+	/*
+	 * Lua methods
+	 */
+
+	/*
+	 * C methods
+	 */
+	CASTED_GET(ShipFleetYardInterface)
+};
+
+class LuaFerryFleetYardInterface : public LuaBob {
+public:
+	LUNA_CLASS_HEAD(LuaFerryFleetYardInterface);
+
+	LuaFerryFleetYardInterface() = default;
+	explicit LuaFerryFleetYardInterface(Widelands::FerryFleetYardInterface& i) : LuaBob(i) {
+	}
+	explicit LuaFerryFleetYardInterface(lua_State* L) : LuaBob(L) {
+	}
+	~LuaFerryFleetYardInterface() override = default;
+
+	/*
+	 * Properties
+	 */
+	int get_owner(lua_State* L);
+	int get_building(lua_State*);
+
+	/*
+	 * Lua methods
+	 */
+
+	/*
+	 * C methods
+	 */
+	CASTED_GET(FerryFleetYardInterface)
+};
+
 #undef CASTED_GET
 
 class LuaField : public LuaMapModuleClass {

--- a/src/ui_fsmenu/main.cc
+++ b/src/ui_fsmenu/main.cc
@@ -765,8 +765,8 @@ void MainMenu::draw(RenderTarget& r) {
 
 		if (system_clock_) {
 			clock_.set_text(realtimestring());
-			r.fill_rect(Recti(0, 0, clock_.get_w() + 2 * padding_, clock_.get_h() + 2 * padding_),
-			            bg, BlendMode::Default);
+			r.fill_rect(Recti(0, 0, clock_.get_w() + 2 * padding_, clock_.get_h() + 2 * padding_), bg,
+			            BlendMode::Default);
 		} else {
 			clock_.set_text(std::string());
 		}

--- a/test/maps/plain.wmf/scripting/test_pinned_notes.lua
+++ b/test/maps/plain.wmf/scripting/test_pinned_notes.lua
@@ -1,0 +1,29 @@
+run(function()
+   sleep(8000)
+
+   local f = map:get_field(25, 25)
+   assert_equal(0, #f.bobs)
+
+   local note = p1:place_pinned_note(f, "Hello World", 255, 0, 123)
+   sleep(1000)
+   assert_equal(1, #f.bobs)
+   assert_equal(note, f.bobs[1])
+   assert_equal("Hello World", note.text)
+   assert_equal(123, note.color[3])
+
+   note.text = "<Richtext injection attempt>"
+   note.color = {50, 200, 250}
+   sleep(5000)
+
+   assert_equal("<Richtext injection attempt>", note.text)
+   assert_equal(50, note.color[1])
+   assert_equal(1, #f.bobs)
+
+   sleep(1000)
+   note:remove()
+   sleep(1000)
+   assert_equal(0, #f.bobs)
+
+   print("# All Tests passed.")
+   wl.ui.MapView():close()
+end)


### PR DESCRIPTION
**Type of change**
Bugfix / New feature

**Issue(s) closed**
Fixes #6074

**New behavior**
Added basic Lua APIs for bob types that don't have one yet.

**Additional context**
Stacked on navalwarfare because `NavalInvasionBase` also needs an API.