### PR TITLE
Game Chat Accessibility Tweaks

### DIFF
--- a/src/wui/chat_overlay.cc
+++ b/src/wui/chat_overlay.cc
@@ -78,6 +78,7 @@ ChatOverlay::ChatOverlay(UI::Panel* const parent,
    : UI::Panel(parent, UI::PanelStyle::kWui, "chat_overlay", x, y, w, h), m(new Impl(fn)) {
 	m->transparent_ = get_config_bool("transparent_chat", true);
 
+	set_z(UI::Panel::ZOrder::kConfirmation);  // above regular windows
 	set_thinks(true);
 }
 

--- a/src/wui/chat_overlay.h
+++ b/src/wui/chat_overlay.h
@@ -41,6 +41,10 @@ struct ChatOverlay : public UI::Panel {
 	// Check if position and size is still correct.
 	void recompute();
 
+	[[nodiscard]] UI::Panel::ZOrder get_z() const override {
+		return UI::Panel::ZOrder::kInfoPanel;  // draw chat above regular windows
+	}
+
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m;

--- a/src/wui/chat_overlay.h
+++ b/src/wui/chat_overlay.h
@@ -41,10 +41,6 @@ struct ChatOverlay : public UI::Panel {
 	// Check if position and size is still correct.
 	void recompute();
 
-	[[nodiscard]] UI::Panel::ZOrder get_z() const override {
-		return UI::Panel::ZOrder::kInfoPanel;  // draw chat above regular windows
-	}
-
 private:
 	struct Impl;
 	std::unique_ptr<Impl> m;

--- a/src/wui/game_chat_menu.cc
+++ b/src/wui/game_chat_menu.cc
@@ -107,7 +107,7 @@ void GameChatMenu::minimize() {
 }
 
 void GameChatMenu::acknowledge() {
-	if (close_on_send_) {
+	if (close_on_send_ && !is_pinned()) {
 		die();
 	}
 }


### PR DESCRIPTION
**Type of change**
Feature enhancement

**Issue(s) closed**
- As requested in chat: If the chat menu is pinned, leave it open when sending a message.
- Draw the chat overlay above regular windows.