### PR TITLE
Remember more settings in stock/unique window

### DIFF
--- a/src/editor/ui_menus/main_menu_map_options.cc
+++ b/src/editor/ui_menus/main_menu_map_options.cc
@@ -336,8 +336,7 @@ MainMenuMapOptions::MainMenuMapOptions(EditorInteractive& parent, Registry& regi
                          kSuggestedTeamsUnitSize,
                          UI::ButtonStyle::kWuiSecondary,
                          _("Add lineup"),
-                         _("Add another suggested team lineup")),
-     registry_(registry) {
+                         _("Add another suggested team lineup")) {
 
 	tab_box_.set_size(max_w_, get_inner_h() - labelh_ - 2 * padding_);
 	tabs_.set_size(max_w_, tab_box_.get_inner_h());
@@ -603,11 +602,11 @@ void MainMenuMapOptions::clicked_ok() {
 	map.add_tag(balancing_dropdown_.get_selected());
 	map.set_background_theme(theme_dropdown_.get_selected());
 	Notifications::publish(NoteMapOptions());
-	registry_.destroy();
+	registry_->destroy();
 }
 
 void MainMenuMapOptions::clicked_cancel() {
-	registry_.destroy();
+	registry_->destroy();
 }
 
 bool MainMenuMapOptions::handle_key(bool down, SDL_Keysym code) {

--- a/src/editor/ui_menus/main_menu_map_options.h
+++ b/src/editor/ui_menus/main_menu_map_options.h
@@ -86,8 +86,6 @@ private:
 
 	std::vector<SuggestedTeamsEntry*> suggested_teams_entries_;
 	UI::Button new_suggested_team_;
-
-	UI::UniqueWindow::Registry& registry_;
 };
 
 struct SuggestedTeamsEntry : public UI::Panel {

--- a/src/ui_basic/unique_window.cc
+++ b/src/ui_basic/unique_window.cc
@@ -111,6 +111,7 @@ UniqueWindow::UniqueWindow(Panel* const parent,
 	if (registry_ != nullptr) {
 		delete registry_->window;
 		registry_->window = this;
+		set_pinned(registry_->pinned);
 		if (registry_->valid_pos) {
 			set_pos(Vector2i(registry_->x, registry_->y));
 			usedefaultpos_ = false;
@@ -139,6 +140,7 @@ void UniqueWindow::save_position() {
 		registry_->x = get_x();
 		registry_->y = get_y();
 		registry_->valid_pos = true;
+		registry_->pinned = is_pinned();
 	}
 }
 

--- a/src/ui_basic/unique_window.h
+++ b/src/ui_basic/unique_window.h
@@ -51,9 +51,10 @@ struct UniqueWindow : public Window {
 		int32_t x{0};
 		int32_t y{0};
 		bool valid_pos{false};
+		bool pinned{false};
 
 		Registry() = default;
-		~Registry();
+		virtual ~Registry();
 	};
 
 	UniqueWindow(Panel* parent,
@@ -82,8 +83,10 @@ struct UniqueWindow : public Window {
 		return usedefaultpos_;
 	}
 
+protected:
+	Registry* const registry_;
+
 private:
-	Registry* registry_;
 	bool usedefaultpos_;
 };
 }  // namespace UI

--- a/src/wui/interactive_gamebase.h
+++ b/src/wui/interactive_gamebase.h
@@ -27,6 +27,7 @@
 #include "ui_basic/unique_window.h"
 #include "wui/general_statistics_menu.h"
 #include "wui/interactive_base.h"
+#include "wui/stock_menu.h"
 
 class InteractiveGameBase : public InteractiveBase {
 public:
@@ -102,7 +103,7 @@ public:
 
 		GeneralStatisticsMenu::Registry stats_general;
 		UI::UniqueWindow::Registry stats_wares;
-		UI::UniqueWindow::Registry stats_stock;
+		StockMenu::Registry stats_stock;
 		UI::UniqueWindow::Registry stats_buildings;
 		UI::UniqueWindow::Registry stats_soldiers;
 		UI::UniqueWindow::Registry stats_seafaring;

--- a/src/wui/stock_menu.cc
+++ b/src/wui/stock_menu.cc
@@ -36,7 +36,7 @@ color_tag(const RGBColor& c, const std::string& text1, const std::string& text2)
 	return format(_("%1$s %2$s"), StyleManager::color_tag(text1, c), text2);
 }
 
-StockMenu::StockMenu(InteractivePlayer& plr, UI::UniqueWindow::Registry& registry)
+StockMenu::StockMenu(InteractivePlayer& plr, Registry& registry)
    : UI::UniqueWindow(&plr, UI::WindowStyle::kWui, "stock_menu", &registry, 480, 640, _("Stock")),
      player_(plr),
      colors_(g_style_manager->building_statistics_style()),
@@ -84,17 +84,22 @@ StockMenu::StockMenu(InteractivePlayer& plr, UI::UniqueWindow::Registry& registr
 	          warehouse_workers_, _("Workers in warehouses"));
 
 	solid_icon_backgrounds_.changedto.connect([this](const bool b) {
+		dynamic_cast<Registry*>(registry_)->solid_icon_backgrounds = b;
 		all_wares_->set_solid_icon_backgrounds(!b);
 		all_workers_->set_solid_icon_backgrounds(!b);
 		warehouse_wares_->set_solid_icon_backgrounds(!b);
 		warehouse_workers_->set_solid_icon_backgrounds(!b);
+	});
+	tabs_.sigclicked.connect([this]() {
+		dynamic_cast<Registry*>(registry_)->active_tab = tabs_.active();
 	});
 
 	main_box_.add(&tabs_, UI::Box::Resizing::kExpandBoth);
 	main_box_.add(&solid_icon_backgrounds_, UI::Box::Resizing::kFullSize);
 
 	// Preselect the wares_in_warehouses tab
-	tabs_.activate(2);
+	tabs_.activate(registry.active_tab);
+	solid_icon_backgrounds_.set_state(registry.solid_icon_backgrounds);
 
 	initialization_complete();
 }

--- a/src/wui/stock_menu.cc
+++ b/src/wui/stock_menu.cc
@@ -90,9 +90,8 @@ StockMenu::StockMenu(InteractivePlayer& plr, Registry& registry)
 		warehouse_wares_->set_solid_icon_backgrounds(!b);
 		warehouse_workers_->set_solid_icon_backgrounds(!b);
 	});
-	tabs_.sigclicked.connect([this]() {
-		dynamic_cast<Registry*>(registry_)->active_tab = tabs_.active();
-	});
+	tabs_.sigclicked.connect(
+	   [this]() { dynamic_cast<Registry*>(registry_)->active_tab = tabs_.active(); });
 
 	main_box_.add(&tabs_, UI::Box::Resizing::kExpandBoth);
 	main_box_.add(&solid_icon_backgrounds_, UI::Box::Resizing::kFullSize);

--- a/src/wui/stock_menu.h
+++ b/src/wui/stock_menu.h
@@ -35,7 +35,12 @@ class InteractivePlayer;
  * one player
  */
 struct StockMenu : public UI::UniqueWindow {
-	StockMenu(InteractivePlayer&, UI::UniqueWindow::Registry&);
+	struct Registry : public UI::UniqueWindow::Registry {
+		size_t active_tab{2};
+		bool solid_icon_backgrounds{false};
+	};
+
+	StockMenu(InteractivePlayer&, Registry&);
 
 	void think() override;
 	void layout() override;


### PR DESCRIPTION
**Type of change**
Feature enhancement

**Issue(s) closed**
Re #2116

- Stock menu remembers last active tab and whether Evaluate is on/off
- All unique windows remember whether they were pinned
