### PR TITLE
Fix some segfaults related to `Map::calc_distance`

### DIFF
--- a/src/logic/map.cc
+++ b/src/logic/map.cc
@@ -1904,7 +1904,7 @@ bool Map::set_port_space(const EditorGameBase& egbase,
  * Calculate the (Manhattan) distance from a to b
  * a and b are expected to be normalized!
  */
-uint32_t Map::calc_distance(const Coords& a, const Coords& b) const {
+uint32_t Map::calc_distance(const Coords a, const Coords b) const {
 	uint32_t dist;
 	int32_t dy;
 

--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -430,7 +430,7 @@ public:
 	FCoords get_fcoords(Field&) const;
 	void get_coords(Field& f, Coords& c) const;
 
-	[[nodiscard]] uint32_t calc_distance(const Coords&, const Coords&) const;
+	[[nodiscard]] uint32_t calc_distance(Coords, Coords) const;
 
 	[[nodiscard]] int32_t calc_cost_estimate(const Coords&, const Coords&) const override;
 	[[nodiscard]] int32_t calc_cost_lowerbound(const Coords&, const Coords&) const;

--- a/src/logic/map_objects/tribes/productionsite.cc
+++ b/src/logic/map_objects/tribes/productionsite.cc
@@ -581,6 +581,8 @@ void ProductionSite::set_economy(Economy* const e, WareWorker type) {
  * Cleanup after a production site is removed
  */
 void ProductionSite::cleanup(EditorGameBase& egbase) {
+	field_terrain_changed_subscriber_.reset();
+
 	for (uint32_t i = descr().nr_working_positions(); i != 0u;) {
 		--i;
 		delete working_positions_.at(i).worker_request;

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1881,7 +1881,8 @@ bool Soldier::check_node_blocked(Game& game, const FCoords& field, bool const co
 				multiplesoldiers = true;
 			}
 
-			if (soldier->get_battle() != nullptr && soldier->get_battle()->first() != nullptr && soldier->get_battle()->second() != nullptr &&
+			if (soldier->get_battle() != nullptr && soldier->get_battle()->first() != nullptr &&
+			    soldier->get_battle()->second() != nullptr &&
 			    game.map().calc_distance(soldier->get_battle()->first()->get_position(),
 			                             soldier->get_battle()->second()->get_position()) < 2) {
 				foundbattle = true;

--- a/src/logic/map_objects/tribes/soldier.cc
+++ b/src/logic/map_objects/tribes/soldier.cc
@@ -1881,7 +1881,7 @@ bool Soldier::check_node_blocked(Game& game, const FCoords& field, bool const co
 				multiplesoldiers = true;
 			}
 
-			if ((soldier->get_battle() != nullptr) &&
+			if (soldier->get_battle() != nullptr && soldier->get_battle()->first() != nullptr && soldier->get_battle()->second() != nullptr &&
 			    game.map().calc_distance(soldier->get_battle()->first()->get_position(),
 			                             soldier->get_battle()->second()->get_position()) < 2) {
 				foundbattle = true;


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Potentially fixes two non-reproducible logic thread segfaults in `calc_distance()`, one new I received from WorldSavior today and one I still had lying around from round 1.

The new one is a logic bug from `Soldier::check_node_blocked`. My best guess is that another soldier has a battle whose opponent no longer exists but which will not be cancelled until that soldier next self-updates, so we need to check for `nullptr`. I'm not 100% sure this is correct but it certainly won't hurt.

The old backtrace is the one related to the gardening center and shipyard and I really have no idea how this can *happen*, so I just fixed the two least implausible potential explanations: Clear the subscriber early during cleanup, and pass Coords by value instead reference in this one function. Neither should be harmful. Do they fix this? No idea, but not enough is known to be certain. 
One other explanation I can think of is that the subscriber should be *created* later, at the end of `init()`, but that would be much harder to do without regressions so I don't want to do that unless it is actually indicated that this does indeed cause the bug.

**Possible regressions**
Should all be safe
