### PR TITLE
More consistent worker eviction

### DIFF
--- a/src/economy/request.cc
+++ b/src/economy/request.cc
@@ -283,7 +283,7 @@ uint32_t Request::get_priority(const int32_t cost) const {
 	   (target_building_ != nullptr ? target_building_->get_priority(get_type(), get_index()) :
                                      WarePriority::kNormal);
 
-	// Workaround for bug #4809 Kicking a worker let him go the building where he was kicked off
+	// Don't allow evicted workers to go straight back inside (bug #4809)
 	const Time& cur_time = economy_->owner().egbase().get_gametime();
 	if (target_building_ != nullptr && get_type() == wwWORKER &&
 	    target_building_->get_worker_evicted().is_valid() &&

--- a/src/logic/map_objects/tribes/militarysite.cc
+++ b/src/logic/map_objects/tribes/militarysite.cc
@@ -933,7 +933,7 @@ void MilitarySite::send_attacker(Soldier& soldier, Building& target) {
 		// The soldier may not be present anymore due to having been kicked out. Most of the time
 		// the function calling us will notice this, but there are cornercase where it might not,
 		// e.g. when a soldier was ordered to leave but did not physically quit the building yet.
-		log_warn_time(
+		verb_log_warn_time(
 		   owner().egbase().get_gametime(),
 		   "MilitarySite(%3dx%3d)::send_attacker: Not sending soldier %u because he left the "
 		   "building\n",

--- a/src/logic/map_objects/tribes/worker.cc
+++ b/src/logic/map_objects/tribes/worker.cc
@@ -1960,13 +1960,15 @@ void Worker::update_task_carry_trade_item(Game& game) {
  */
 void Worker::evict(Game& game) {
 	if (!is_evict_allowed()) {
-		verb_log_warn_time(game.get_gametime(), "Worker %s %u: evict not currently allowed", descr().name().c_str(), serial());
+		verb_log_warn_time(game.get_gametime(), "Worker %s %u: evict not currently allowed",
+		                   descr().name().c_str(), serial());
 		return;
 	}
 
 	upcast(Building, building, get_location(game));
 	if (building == nullptr || get_state(taskBuildingwork) == nullptr) {
-		verb_log_warn_time(game.get_gametime(), "Trying to evict worker %s %u who is not employed", descr().name().c_str(), serial());
+		verb_log_warn_time(game.get_gametime(), "Trying to evict worker %s %u who is not employed",
+		                   descr().name().c_str(), serial());
 		return;
 	}
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #4888
Fixes #4809

**New behavior**
When a worker receives the evict signal, he instantly and without delay drops whatever he is doing regardless of what that is and returns to his building's flag after making sure the building properly sets it eviction blacklist timer.

**Possible regressions**
Worker eviction
