### PR TITLE
Misc sea-fighting-related UI tweaks

### DIFF
--- a/src/graphic/gl/utils.cc
+++ b/src/graphic/gl/utils.cc
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <memory>
 
+#include "base/multithreading.h"
 #include "base/wexception.h"
 #include "io/fileread.h"
 #include "io/filesystem/layered_filesystem.h"
@@ -256,6 +257,7 @@ void State::enable_vertex_attrib_array(std::unordered_set<GLint> entries) {
 
 // static
 State& State::instance() {
+	assert(is_initializer_thread());
 	static State binder;
 	return binder;
 }

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2370,8 +2370,6 @@ void Ship::sink_ship(Game& game) {
 	ship_wakeup(game);
 }
 
-constexpr int kShipHealthBarWidth = 30;
-
 void Ship::draw(const EditorGameBase& egbase,
                 const InfoToDraw& info_to_draw,
                 const Vector2f& field_on_dst,

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -1424,6 +1424,7 @@ void Ship::battle_update(Game& game) {
 			                          _("An enemy ship has destroyed your warship."),
 			                          "images/wui/ship/ship_attack.png");
 
+			target_ship->hitpoints_ = 0;
 			target_ship->battles_.clear();
 			target_ship->reset_tasks(game);
 			target_ship->set_ship_state_and_notify(
@@ -2382,7 +2383,9 @@ void Ship::draw(const EditorGameBase& egbase,
 	// Show ship name and current activity
 	std::string statistics_string;
 	if ((info_to_draw & InfoToDraw::kStatistics) != 0) {
-		if (has_battle()) {
+		if (state_is_sinking()) {
+			statistics_string = pgettext("ship_state", "Sinking");
+		} else if (has_battle()) {
 			statistics_string = pgettext("ship_state", "Fighting");
 		} else if (is_refitting()) {
 			switch (pending_refit_) {

--- a/src/logic/map_objects/tribes/ship.cc
+++ b/src/logic/map_objects/tribes/ship.cc
@@ -2488,8 +2488,8 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 	const Vector2i draw_position = point_on_dst.cast<int>();
 
 	// The frame gets a slight tint of player color
-	Recti energy_outer(draw_position - Vector2i(kShipHealthBarWidth, 0) * scale,
-	                   kShipHealthBarWidth * 2 * scale, 5 * scale);
+	Recti energy_outer(draw_position - Vector2i(kShipHalfHealthBarWidth, 0) * scale,
+	                   kShipHalfHealthBarWidth * 2 * scale, 5 * scale);
 	dst->fill_rect(energy_outer, color);
 	dst->brighten_rect(energy_outer, brighten_factor);
 
@@ -2510,10 +2510,10 @@ void Ship::draw_healthbar(const EditorGameBase& egbase,
 	}
 
 	// Now draw the health bar itself
-	constexpr int kInnerHealthBarWidth = 2 * (kShipHealthBarWidth - 1);
+	constexpr int kInnerHealthBarWidth = 2 * (kShipHalfHealthBarWidth - 1);
 	int health_width = kInnerHealthBarWidth * health_to_show / descr().max_hitpoints_;
 
-	Recti energy_inner(draw_position + Vector2i(-kShipHealthBarWidth + 1, 1) * scale,
+	Recti energy_inner(draw_position + Vector2i(-kShipHalfHealthBarWidth + 1, 1) * scale,
 	                   health_width * scale, 3 * scale);
 	Recti energy_complement(energy_inner.origin() + Vector2i(health_width, 0) * scale,
 	                        (kInnerHealthBarWidth - health_width) * scale, 3 * scale);

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -99,7 +99,8 @@ constexpr int32_t kShipInterval = 1500;
 struct Ship : Bob {
 	MO_DESCR(ShipDescr)
 
-	static constexpr int kShipHealthBarWidth = 30;
+	/** Half the total width of a ship's health bar at 1× scale. */
+	static constexpr int kShipHalfHealthBarWidth = 30;
 
 	explicit Ship(const ShipDescr& descr);
 	~Ship() override = default;

--- a/src/logic/map_objects/tribes/ship.h
+++ b/src/logic/map_objects/tribes/ship.h
@@ -99,6 +99,8 @@ constexpr int32_t kShipInterval = 1500;
 struct Ship : Bob {
 	MO_DESCR(ShipDescr)
 
+	static constexpr int kShipHealthBarWidth = 30;
+
 	explicit Ship(const ShipDescr& descr);
 	~Ship() override = default;
 

--- a/src/ui_basic/dropdown.h
+++ b/src/ui_basic/dropdown.h
@@ -321,6 +321,10 @@ public:
 		unfiltered_entries.clear();
 	}
 
+	[[nodiscard]] uint32_t unfiltered_size() const {
+		return unfiltered_entries.size();
+	}
+
 	void clear_filter() override {
 		if (current_filter_.empty()) {
 			return;

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -36,6 +36,10 @@
 constexpr Duration kUpdateTimeInGametimeMs(500);  //  half a second, gametime
 constexpr int kSpacing = 8;
 
+constexpr int kSoldierIconWidth = 32;
+constexpr int kSoldierIconHeight = 30;
+constexpr int kShipIconHeight = 34;
+
 static unsigned next_serial_(0);
 static std::map<unsigned, AttackWindow*> living_attack_windows_;
 
@@ -123,8 +127,8 @@ AttackPanel::AttackPanel(
      target_coordinates_(target_coordinates),
      get_max_attackers_(get_max_attackers),
      attack_type_(attack_type),
-     icon_w_(attack_type_ == AttackPanel::AttackType::kShip ? 64 : 32),
-     icon_h_(attack_type_ == AttackPanel::AttackType::kShip ? 45 : 30),
+     icon_w_(attack_type_ == AttackPanel::AttackType::kShip ? (2 * Widelands::Ship::kShipHealthBarWidth + kSpacing) : kSoldierIconWidth),
+     icon_h_(attack_type_ == AttackPanel::AttackType::kShip ? kShipIconHeight : kSoldierIconHeight),
      lastupdate_(0),
 
      linebox_(this, UI::PanelStyle::kWui, "line_box", 0, 0, UI::Box::Horizontal),
@@ -722,6 +726,9 @@ void AttackPanel::ListOfSoldiers::draw(RenderTarget& dst) {
 
 				upcast(const Widelands::Ship, ship, bob);
 				assert(ship != nullptr);
+
+				const Image* icon = g_image_cache->get(ship->descr().icon_filename());
+				dst.blit(location, icon, BlendMode::Default, UI::Align::kCenter);
 
 				ship->draw_healthbar(attack_box_->iplayer_.egbase(), &dst, location.cast<float>(), 1.f);
 

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -127,7 +127,9 @@ AttackPanel::AttackPanel(
      target_coordinates_(target_coordinates),
      get_max_attackers_(get_max_attackers),
      attack_type_(attack_type),
-     icon_w_(attack_type_ == AttackPanel::AttackType::kShip ? (2 * Widelands::Ship::kShipHealthBarWidth + kSpacing) : kSoldierIconWidth),
+     icon_w_(attack_type_ == AttackPanel::AttackType::kShip ?
+                (2 * Widelands::Ship::kShipHealthBarWidth + kSpacing) :
+                kSoldierIconWidth),
      icon_h_(attack_type_ == AttackPanel::AttackType::kShip ? kShipIconHeight : kSoldierIconHeight),
      lastupdate_(0),
 

--- a/src/wui/attack_window.cc
+++ b/src/wui/attack_window.cc
@@ -128,7 +128,7 @@ AttackPanel::AttackPanel(
      get_max_attackers_(get_max_attackers),
      attack_type_(attack_type),
      icon_w_(attack_type_ == AttackPanel::AttackType::kShip ?
-                (2 * Widelands::Ship::kShipHealthBarWidth + kSpacing) :
+                (2 * Widelands::Ship::kShipHalfHealthBarWidth + kSpacing) :
                 kSoldierIconWidth),
      icon_h_(attack_type_ == AttackPanel::AttackType::kShip ? kShipIconHeight : kSoldierIconHeight),
      lastupdate_(0),

--- a/src/wui/attack_window.h
+++ b/src/wui/attack_window.h
@@ -137,6 +137,9 @@ private:
 	std::function<std::vector<Widelands::OPtr<Widelands::Bob>>()> get_max_attackers_;
 	const AttackType attack_type_;
 
+	int icon_w_;
+	int icon_h_;
+
 	/// The last time the information in this Panel got updated
 	Time lastupdate_;
 

--- a/src/wui/shipwindow.cc
+++ b/src/wui/shipwindow.cc
@@ -68,7 +68,8 @@ ShipWindow::ShipWindow(InteractiveBase& ib, UniqueWindow::Registry& reg, Widelan
      vbox_(this, UI::PanelStyle::kWui, "vbox", 0, 0, UI::Box::Vertical),
      navigation_box_(&vbox_, UI::PanelStyle::kWui, "navigation_box", 0, 0, UI::Box::Vertical),
      warship_capacity_control_(create_soldier_list(vbox_, ibase_, *ship)),
-     warship_health_(&vbox_, UI::PanelStyle::kWui, "health", UI::FontStyle::kWuiLabel, "", UI::Align::kCenter) {
+     warship_health_(
+        &vbox_, UI::PanelStyle::kWui, "health", UI::FontStyle::kWuiLabel, "", UI::Align::kCenter) {
 	vbox_.set_inner_spacing(kPadding);
 	assert(ship->get_owner());
 
@@ -81,10 +82,11 @@ ShipWindow::ShipWindow(InteractiveBase& ib, UniqueWindow::Registry& reg, Widelan
 		name_field_ = nullptr;
 	}
 
-	warship_health_.set_tooltip(format(ngettext(
-			"Damaged warships regain %u hitpoint per second when anchored in a port.",
-			"Damaged warships regain %u hitpoints per second when anchored in a port.",
-			ship->descr().heal_per_second_), ship->descr().heal_per_second_));
+	warship_health_.set_tooltip(
+	   format(ngettext("Damaged warships regain %u hitpoint per second when anchored in a port.",
+	                   "Damaged warships regain %u hitpoints per second when anchored in a port.",
+	                   ship->descr().heal_per_second_),
+	          ship->descr().heal_per_second_));
 	warship_health_.set_handle_mouse(true);
 
 	display_ = new ItemWaresDisplay(&vbox_, ship->owner());
@@ -312,9 +314,9 @@ void ShipWindow::update_destination_buttons(const Widelands::Ship* ship) {
 		all_spaces.push_back(dps.get());
 	}
 
-	bool needs_update = (set_destination_->unfiltered_size() != all_ports.size() + all_ships.size() +
-	                                                              all_notes.size() +
-	                                                              all_spaces.size() + 1);
+	bool needs_update =
+	   (set_destination_->unfiltered_size() !=
+	    all_ports.size() + all_ships.size() + all_notes.size() + all_spaces.size() + 1);
 	if (!needs_update) {
 		size_t i = 0;
 		for (Widelands::PortDock* pd : all_ports) {
@@ -477,7 +479,8 @@ void ShipWindow::think() {
 
 	const uint32_t max_hitpoints = ship->descr().max_hitpoints_;
 	const uint32_t cur_hitpoints = ship->get_hitpoints();
-	warship_health_.set_visible(cur_hitpoints < max_hitpoints || ship->get_ship_type() == Widelands::ShipType::kWarship);
+	warship_health_.set_visible(cur_hitpoints < max_hitpoints ||
+	                            ship->get_ship_type() == Widelands::ShipType::kWarship);
 	warship_health_.set_text(format(_("HP: %1$u/%2$u"), cur_hitpoints, max_hitpoints));
 
 	Widelands::ShipStates state = ship->get_ship_state();

--- a/src/wui/shipwindow.h
+++ b/src/wui/shipwindow.h
@@ -27,6 +27,7 @@
 #include "logic/map_objects/walkingdir.h"
 #include "ui_basic/button.h"
 #include "ui_basic/dropdown.h"
+#include "ui_basic/textarea.h"
 #include "ui_basic/textinput.h"
 #include "ui_basic/unique_window.h"
 #include "wui/interactive_base.h"
@@ -76,6 +77,7 @@ private:
 	UI::Box vbox_;
 	UI::Box navigation_box_;
 	UI::Panel* warship_capacity_control_;
+	UI::Textarea warship_health_;
 	UI::EditBox* name_field_;
 	UI::Button* btn_goto_;
 	UI::Button* btn_destination_;

--- a/src/wui/soldiercapacitycontrol.cc
+++ b/src/wui/soldiercapacitycontrol.cc
@@ -107,6 +107,7 @@ SoldierCapacityControl::SoldierCapacityControl(UI::Panel* parent,
 	decrease_.set_repeating(true);
 	increase_.set_repeating(true);
 
+	value_.set_fixed_width(value_.get_w());
 	set_thinks(true);
 }
 

--- a/src/wui/soldierlist.cc
+++ b/src/wui/soldierlist.cc
@@ -62,7 +62,6 @@ struct SoldierPanel : UI::Panel {
 
 	void think() override;
 	void draw(RenderTarget& /*dst*/) override;
-	void update_size();
 
 	void set_mouseover(const SoldierFn& fn);
 	void set_click(const SoldierFn& fn);
@@ -179,6 +178,8 @@ SoldierPanel::SoldierPanel(UI::Panel& parent,
 		rows_ = (maxcapacity + cols_ - 1) / cols_;
 	}
 
+	set_size(cols_ * icon_width_, rows_ * icon_height_);
+	set_desired_size(cols_ * icon_width_, rows_ * icon_height_);
 	set_thinks(true);
 
 	// Initialize the icons
@@ -208,19 +209,6 @@ SoldierPanel::SoldierPanel(UI::Panel& parent,
 			row++;
 		}
 	}
-
-	update_size();
-}
-
-void SoldierPanel::update_size() {
-	uint32_t max_row = 0;
-	for (const Icon& icon : icons_) {
-		max_row = std::max(max_row, icon.row);
-	}
-	++max_row;
-
-	set_size(cols_ * icon_width_, max_row * icon_height_);
-	set_desired_size(cols_ * icon_width_, max_row * icon_height_);
 }
 
 /**
@@ -359,7 +347,6 @@ void SoldierPanel::think() {
 	if (changes) {
 		Vector2i mousepos = get_mouse_position();
 		mouseover_fn_(find_soldier(mousepos.x, mousepos.y));
-		update_size();
 	}
 }
 

--- a/src/wui/soldierlist.cc
+++ b/src/wui/soldierlist.cc
@@ -62,6 +62,7 @@ struct SoldierPanel : UI::Panel {
 
 	void think() override;
 	void draw(RenderTarget& /*dst*/) override;
+	void update_size();
 
 	void set_mouseover(const SoldierFn& fn);
 	void set_click(const SoldierFn& fn);
@@ -178,8 +179,6 @@ SoldierPanel::SoldierPanel(UI::Panel& parent,
 		rows_ = (maxcapacity + cols_ - 1) / cols_;
 	}
 
-	set_size(cols_ * icon_width_, rows_ * icon_height_);
-	set_desired_size(cols_ * icon_width_, rows_ * icon_height_);
 	set_thinks(true);
 
 	// Initialize the icons
@@ -209,6 +208,19 @@ SoldierPanel::SoldierPanel(UI::Panel& parent,
 			row++;
 		}
 	}
+
+	update_size();
+}
+
+void SoldierPanel::update_size() {
+	uint32_t max_row = 0;
+	for (const Icon& icon : icons_) {
+		max_row = std::max(max_row, icon.row);
+	}
+	++max_row;
+
+	set_size(cols_ * icon_width_, max_row * icon_height_);
+	set_desired_size(cols_ * icon_width_, max_row * icon_height_);
 }
 
 /**
@@ -347,6 +359,7 @@ void SoldierPanel::think() {
 	if (changes) {
 		Vector2i mousepos = get_mouse_position();
 		mouseover_fn_(find_soldier(mousepos.x, mousepos.y));
+		update_size();
 	}
 }
 
@@ -425,11 +438,11 @@ bool SoldierPanel::handle_mousemove(
 bool SoldierPanel::handle_mousepress(uint8_t btn, int32_t x, int32_t y) {
 	if (btn == SDL_BUTTON_LEFT) {
 		if (click_fn_) {
-			if (const Widelands::Soldier* soldier = find_soldier(x, y)) {
+			if (const Widelands::Soldier* soldier = find_soldier(x, y); soldier != nullptr) {
 				click_fn_(soldier);
+				return true;
 			}
 		}
-		return true;
 	}
 
 	return false;


### PR DESCRIPTION
**Type of change**
Bugfixes

**Issue(s) closed**
This fixes a number of the most common smaller UI annoyances, namely:
- The attack window now uses bigger icons for ships to display the health bar properly. *edit: and also draws ship icons as background*
  Fixes #5949
- ~~The soldier list for warships and military buildings collapses itself to only take up as much vertical space as required.~~ *rejected*
- Clicking and dragging on an empty part of the soldier list drags the window now.
- The ship window shows the warship's health.
- Fixes the bug with filtering the ship destination dropdown.
- Sinking ships show their status text as "Sinking" and their health as zero.
- *New:* Added an assert so if a very weird, very rare race condition is encountered in a debug build we might get a helpful backtrace of all threads.