### PR TITLE
Refactor WaresDisplay ware list handling

### DIFF
--- a/src/wui/constructionsitewindow.cc
+++ b/src/wui/constructionsitewindow.cc
@@ -63,11 +63,14 @@ ConstructionSiteWindow::FakeWaresDisplay::FakeWaresDisplay(UI::Panel* parent,
 			warelist_->add(w->descr().worker_index(), 1);
 		}
 	}
-	add_warelist(*warelist_);
 }
 
 ConstructionSiteWindow::FakeWaresDisplay::~FakeWaresDisplay() {
 	warelist_->clear();  // Avoid annoying warnings
+}
+
+uint32_t ConstructionSiteWindow::FakeWaresDisplay::amount_of(const Widelands::DescriptionIndex ware) {
+	return warelist_->stock(ware);
 }
 
 void ConstructionSiteWindow::FakeWaresDisplay::draw_ware(RenderTarget& dst,

--- a/src/wui/constructionsitewindow.cc
+++ b/src/wui/constructionsitewindow.cc
@@ -69,7 +69,8 @@ ConstructionSiteWindow::FakeWaresDisplay::~FakeWaresDisplay() {
 	warelist_->clear();  // Avoid annoying warnings
 }
 
-uint32_t ConstructionSiteWindow::FakeWaresDisplay::amount_of(const Widelands::DescriptionIndex ware) {
+uint32_t
+ConstructionSiteWindow::FakeWaresDisplay::amount_of(const Widelands::DescriptionIndex ware) {
 	return warelist_->stock(ware);
 }
 

--- a/src/wui/constructionsitewindow.h
+++ b/src/wui/constructionsitewindow.h
@@ -85,6 +85,7 @@ private:
 
 	protected:
 		void draw_ware(RenderTarget& dst, Widelands::DescriptionIndex ware) override;
+		uint32_t amount_of(Widelands::DescriptionIndex) override;
 
 	private:
 		Widelands::WarehouseSettings& settings_;

--- a/src/wui/stock_menu.cc
+++ b/src/wui/stock_menu.cc
@@ -75,11 +75,13 @@ StockMenu::StockMenu(InteractivePlayer& plr, Registry& registry)
 	tabs_.add(
 	   "workers_total", g_image_cache->get(pic_tab_workers), all_workers_, _("Workers (total)"));
 
-	warehouse_wares_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWARE, false);
+	warehouse_wares_ =
+	   new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWARE, false);
 	tabs_.add("wares_in_warehouses", g_image_cache->get(pic_tab_wares_warehouse), warehouse_wares_,
 	          _("Wares in warehouses"));
 
-	warehouse_workers_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWORKER, false);
+	warehouse_workers_ =
+	   new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWORKER, false);
 	tabs_.add("workers_in_warehouses", g_image_cache->get(pic_tab_workers_warehouse),
 	          warehouse_workers_, _("Workers in warehouses"));
 

--- a/src/wui/stock_menu.cc
+++ b/src/wui/stock_menu.cc
@@ -68,18 +68,18 @@ StockMenu::StockMenu(InteractivePlayer& plr, Registry& registry)
                                      _("Stock is higher than the target"))))) {
 	set_center_panel(&main_box_);
 
-	all_wares_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWARE);
+	all_wares_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWARE, true);
 	tabs_.add("total_wares", g_image_cache->get(pic_tab_wares), all_wares_, _("Wares (total)"));
 
-	all_workers_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWORKER);
+	all_workers_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWORKER, true);
 	tabs_.add(
 	   "workers_total", g_image_cache->get(pic_tab_workers), all_workers_, _("Workers (total)"));
 
-	warehouse_wares_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWARE);
+	warehouse_wares_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWARE, false);
 	tabs_.add("wares_in_warehouses", g_image_cache->get(pic_tab_wares_warehouse), warehouse_wares_,
 	          _("Wares in warehouses"));
 
-	warehouse_workers_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWORKER);
+	warehouse_workers_ = new StockMenuWaresDisplay(&tabs_, 0, 0, plr.player(), Widelands::wwWORKER, false);
 	tabs_.add("workers_in_warehouses", g_image_cache->get(pic_tab_workers_warehouse),
 	          warehouse_workers_, _("Workers in warehouses"));
 
@@ -113,57 +113,6 @@ void StockMenu::layout() {
 		solid_icon_backgrounds_.get_desired_size(&w1, &h1);
 		tabs_.get_desired_size(&w2, &h2);
 		main_box_.set_size(w2, h1 + h2);
-	}
-}
-
-/*
-===============
-Push the current wares status to the WaresDisplay.
-===============
-*/
-void StockMenu::think() {
-	UI::UniqueWindow::think();
-
-	fill_total_waresdisplay(all_wares_, Widelands::wwWARE);
-	fill_total_waresdisplay(all_workers_, Widelands::wwWORKER);
-	fill_warehouse_waresdisplay(warehouse_wares_, Widelands::wwWARE);
-	fill_warehouse_waresdisplay(warehouse_workers_, Widelands::wwWORKER);
-}
-
-/**
- * Keep the list of wares repositories up-to-date (honoring that the set of
- * \ref Economy of a player may change)
- */
-void StockMenu::fill_total_waresdisplay(WaresDisplay* waresdisplay, Widelands::WareWorker type) {
-	MutexLock m(MutexLock::ID::kObjects);
-
-	waresdisplay->remove_all_warelists();
-	const Widelands::Player& player = *player_.get_player();
-
-	for (const auto& economy : player.economies()) {
-		if (economy.second->type() == type) {
-			waresdisplay->add_warelist(economy.second->get_wares_or_workers());
-		}
-	}
-}
-
-/**
- * Keep the list of wares repositories up-to-date (consider that the available
- * \ref Warehouse may change)
- */
-void StockMenu::fill_warehouse_waresdisplay(WaresDisplay* waresdisplay,
-                                            Widelands::WareWorker type) {
-	MutexLock m(MutexLock::ID::kObjects);
-
-	waresdisplay->remove_all_warelists();
-
-	for (const auto& economy : player_.player().economies()) {
-		if (economy.second->type() == type) {
-			for (const auto* warehouse : economy.second->warehouses()) {
-				waresdisplay->add_warelist(type == Widelands::wwWARE ? warehouse->get_wares() :
-                                                                   warehouse->get_workers());
-			}
-		}
 	}
 }
 

--- a/src/wui/stock_menu.cc
+++ b/src/wui/stock_menu.cc
@@ -38,7 +38,6 @@ color_tag(const RGBColor& c, const std::string& text1, const std::string& text2)
 
 StockMenu::StockMenu(InteractivePlayer& plr, Registry& registry)
    : UI::UniqueWindow(&plr, UI::WindowStyle::kWui, "stock_menu", &registry, 480, 640, _("Stock")),
-     player_(plr),
      colors_(g_style_manager->building_statistics_style()),
      main_box_(this, UI::PanelStyle::kWui, "main_box", 0, 0, UI::Box::Vertical),
      tabs_(&main_box_, UI::TabPanelStyle::kWuiDark, "tabs"),

--- a/src/wui/stock_menu.h
+++ b/src/wui/stock_menu.h
@@ -42,7 +42,6 @@ struct StockMenu : public UI::UniqueWindow {
 
 	StockMenu(InteractivePlayer&, Registry&);
 
-	void think() override;
 	void layout() override;
 
 	UI::Panel::SaveType save_type() const override {
@@ -61,9 +60,6 @@ private:
 	StockMenuWaresDisplay* all_workers_;
 	StockMenuWaresDisplay* warehouse_wares_;
 	StockMenuWaresDisplay* warehouse_workers_;
-
-	void fill_total_waresdisplay(WaresDisplay* waresdisplay, Widelands::WareWorker type);
-	void fill_warehouse_waresdisplay(WaresDisplay* waresdisplay, Widelands::WareWorker type);
 };
 
 #endif  // end of include guard: WL_WUI_STOCK_MENU_H

--- a/src/wui/stock_menu.h
+++ b/src/wui/stock_menu.h
@@ -51,7 +51,6 @@ struct StockMenu : public UI::UniqueWindow {
 	static UI::Window& load(FileRead&, InteractiveBase&);
 
 private:
-	InteractivePlayer& player_;
 	const UI::BuildingStatisticsStyleInfo& colors_;
 	UI::Box main_box_;
 	UI::TabPanel tabs_;

--- a/src/wui/warehousewindow.cc
+++ b/src/wui/warehousewindow.cc
@@ -53,6 +53,10 @@ public:
 protected:
 	void draw_ware(RenderTarget& dst, Widelands::DescriptionIndex ware) override;
 
+	uint32_t amount_of(const Widelands::DescriptionIndex ware) override {
+		return (get_type() == Widelands::wwWORKER ? warehouse_.get_workers() : warehouse_.get_wares()).stock(ware);
+	}
+
 private:
 	Widelands::Warehouse& warehouse_;
 };
@@ -64,7 +68,6 @@ WarehouseWaresDisplay::WarehouseWaresDisplay(UI::Panel* parent,
                                              bool selectable)
    : WaresDisplay(parent, 0, 0, wh.owner().tribe(), type, selectable), warehouse_(wh) {
 	set_inner_size(width, 0);
-	add_warelist(type == Widelands::wwWORKER ? warehouse_.get_workers() : warehouse_.get_wares());
 	if (type == Widelands::wwWORKER) {
 		const std::vector<Widelands::DescriptionIndex>& worker_types_without_cost =
 		   warehouse_.owner().tribe().worker_types_without_cost();

--- a/src/wui/warehousewindow.cc
+++ b/src/wui/warehousewindow.cc
@@ -54,7 +54,8 @@ protected:
 	void draw_ware(RenderTarget& dst, Widelands::DescriptionIndex ware) override;
 
 	uint32_t amount_of(const Widelands::DescriptionIndex ware) override {
-		return (get_type() == Widelands::wwWORKER ? warehouse_.get_workers() : warehouse_.get_wares()).stock(ware);
+		return (get_type() == Widelands::wwWORKER ? warehouse_.get_workers() : warehouse_.get_wares())
+		   .stock(ware);
 	}
 
 private:

--- a/src/wui/waresdisplay.cc
+++ b/src/wui/waresdisplay.cc
@@ -49,7 +49,7 @@ AbstractWaresDisplay::AbstractWaresDisplay(
    bool horizontal,
    int32_t hgap,
    int32_t vgap)
-   :  // Size is set when add_warelist is called, as it depends on the type_.
+   :  // Size is set when layout is called
      UI::Panel(parent, UI::PanelStyle::kWui, "wares_display", x, y, 0, 0),
      tribe_(tribe),
 
@@ -510,7 +510,7 @@ StockMenuWaresDisplay::StockMenuWaresDisplay(UI::Panel* const parent,
                                              const Widelands::Player& p,
                                              const Widelands::WareWorker type,
                                              bool total)
-   : WaresDisplay(parent, x, y, p.tribe(), type, false), player_(p), totalstock_(total) {
+   : WaresDisplay(parent, x, y, p.tribe(), type, false), player_(p), show_total_stock_(total) {
 }
 
 std::string StockMenuWaresDisplay::info_for_ware(const Widelands::DescriptionIndex di) {
@@ -608,8 +608,8 @@ uint32_t StockMenuWaresDisplay::amount_of(const Widelands::DescriptionIndex ware
 	uint32_t totalstock = 0;
 	for (const auto& economy : player_.economies()) {
 		if (economy.second->type() == get_type()) {
-			if (totalstock_) {
-				totalstock += economy.second->get_wares_or_workers().stock(ware);
+			if (show_total_stock_) {
+				totalstock += economy.second->stock_ware_or_worker(ware);
 			} else {
 				for (const Widelands::Warehouse* warehouse : economy.second->warehouses()) {
 					totalstock += (get_type() == Widelands::wwWARE ? warehouse->get_wares() :

--- a/src/wui/waresdisplay.cc
+++ b/src/wui/waresdisplay.cc
@@ -612,7 +612,9 @@ uint32_t StockMenuWaresDisplay::amount_of(const Widelands::DescriptionIndex ware
 				totalstock += economy.second->get_wares_or_workers().stock(ware);
 			} else {
 				for (const Widelands::Warehouse* warehouse : economy.second->warehouses()) {
-					totalstock += (get_type() == Widelands::wwWARE ? warehouse->get_wares() : warehouse->get_workers()).stock(ware);
+					totalstock += (get_type() == Widelands::wwWARE ? warehouse->get_wares() :
+                                                                warehouse->get_workers())
+					                 .stock(ware);
 				}
 			}
 		}

--- a/src/wui/waresdisplay.h
+++ b/src/wui/waresdisplay.h
@@ -113,7 +113,6 @@ protected:
 	}
 
 private:
-	using WareListVector = std::vector<const Widelands::WareList*>;
 	using WareListSelectionType = std::map<const Widelands::DescriptionIndex, bool>;
 
 	/**
@@ -171,18 +170,9 @@ public:
 	             Widelands::WareWorker type,
 	             bool selectable);
 
-	~WaresDisplay() override;
-
-	void add_warelist(const Widelands::WareList&);
-	void remove_all_warelists();
-
 protected:
-	uint32_t amount_of(Widelands::DescriptionIndex);
+	virtual uint32_t amount_of(Widelands::DescriptionIndex) = 0;
 	std::string info_for_ware(Widelands::DescriptionIndex) override;
-
-private:
-	using WareListVector = std::vector<const Widelands::WareList*>;
-	WareListVector warelists_;
 };
 
 class StockMenuWaresDisplay : public WaresDisplay {
@@ -191,18 +181,21 @@ public:
 	                      int32_t x,
 	                      int32_t y,
 	                      const Widelands::Player&,
-	                      Widelands::WareWorker type);
+	                      Widelands::WareWorker type,
+	                      bool total);
 
 	void set_solid_icon_backgrounds(const bool s) {
 		solid_icon_backgrounds_ = s;
 	}
 
 protected:
+	uint32_t amount_of(Widelands::DescriptionIndex) override;
 	RGBAColor draw_ware_background_overlay(Widelands::DescriptionIndex) override;
 	std::string info_for_ware(Widelands::DescriptionIndex) override;
 
 	const Widelands::Player& player_;
 	bool solid_icon_backgrounds_{true};
+	bool totalstock_;
 };
 
 std::string waremap_to_richtext(const Widelands::TribeDescr& tribe,

--- a/src/wui/waresdisplay.h
+++ b/src/wui/waresdisplay.h
@@ -195,7 +195,7 @@ protected:
 
 	const Widelands::Player& player_;
 	bool solid_icon_backgrounds_{true};
-	bool totalstock_;
+	bool show_total_stock_;
 };
 
 std::string waremap_to_richtext(const Widelands::TribeDescr& tribe,


### PR DESCRIPTION
**Type of change**
Bugfix & Refactoring

**Issue(s) closed**
Similar to #6091: There is still a rare race condition with a segfault when a warehouse is destroyed while the stock menu is open. So instead of caching the warelist pointers, we now get them fresh every time they're needed.

**Possible regressions**
Various types of wares displays
