### PR TITLE
Different overlay image for valid start positions

### DIFF
--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -577,7 +577,8 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 			}
 			const Image* player_image;
 			if (p == 0u) {
-				player_image = playercolor_image(color(220, 220, 220), "images/players/player_position.png");
+				player_image =
+				   playercolor_image(color(220, 220, 220), "images/players/player_position.png");
 			} else {
 				player_image = playercolor_image(p - 1, "images/players/player_position.png");
 			}
@@ -608,7 +609,8 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 				float opacity =
 				   f->seeing == Widelands::VisibleState::kVisible ? 1.f : kBuildhelpOpacity;
 				if (picking_starting_pos) {
-					caps = show_port_space || buildhelp() ? f->fcoords.field->nodecaps() : Widelands::CAPS_NONE;
+					caps = show_port_space || buildhelp() ? f->fcoords.field->nodecaps() :
+                                                       Widelands::CAPS_NONE;
 				} else if (show_port_space) {
 					caps = maxcaps;
 				} else {
@@ -626,7 +628,8 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 				}
 
 				const auto* overlay = get_buildhelp_overlay(caps, scale);
-				if (overlay != nullptr && (!suited_as_starting_pos || (caps & Widelands::BUILDCAPS_PORT) != 0)) {
+				if (overlay != nullptr &&
+				    (!suited_as_starting_pos || (caps & Widelands::BUILDCAPS_PORT) != 0)) {
 					// draw overlay if not a starting pos, but draw port space anyway
 					blit_field_overlay(
 					   dst, *f, overlay->pic, overlay->hotspot, scale / overlay->scale, opacity);

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -23,6 +23,7 @@
 #include "base/mutex.h"
 #include "economy/flag.h"
 #include "game_io/game_loader.h"
+#include "graphic/color.h"
 #include "graphic/game_renderer.h"
 #include "graphic/mouse_cursor.h"
 #include "graphic/text_layout.h"
@@ -578,7 +579,7 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 			const Image* player_image;
 			if (p == 0u) {
 				player_image =
-				   playercolor_image(color(220, 220, 220), "images/players/player_position.png");
+				   playercolor_image(RGBColor(220, 220, 220), "images/players/player_position.png");
 			} else {
 				player_image = playercolor_image(p - 1, "images/players/player_position.png");
 			}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -497,7 +497,8 @@ void InteractivePlayer::draw(RenderTarget& dst) {
 	draw_map_view(map_view(), &dst);
 }
 
-constexpr float kBuildhelpOpacity = 0.3f;
+constexpr float kBuildhelpOpacityMedium = 0.6f;
+constexpr float kBuildhelpOpacityWeak = 0.3f;
 
 void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst) {
 	// In-game, selection can never be on triangles or have a radius.
@@ -588,8 +589,8 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 					}
 					player_image = playercolor_image(p->get_playercolor(), icon_filename);
 					icon_scale = 1.0f;
-					icon_opacity =
-					   p->get_starting_position_suitability(f->fcoords) ? 0.7f : kBuildhelpOpacity;
+					icon_opacity = p->get_starting_position_suitability(f->fcoords) ?
+                              kBuildhelpOpacityMedium : kBuildhelpOpacityWeak;
 					break;
 				}
 			}
@@ -626,7 +627,7 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 				Widelands::NodeCaps caps;
 				Widelands::NodeCaps maxcaps = f->fcoords.field->maxcaps();
 				float opacity =
-				   f->seeing == Widelands::VisibleState::kVisible ? 1.f : kBuildhelpOpacity;
+				   f->seeing == Widelands::VisibleState::kVisible ? 1.f : kBuildhelpOpacityWeak;
 				if (picking_starting_pos) {
 					caps = show_port_space || buildhelp() ? f->fcoords.field->nodecaps() :
                                                        Widelands::CAPS_NONE;
@@ -639,7 +640,7 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 						     plr.tribe().buildings_built_over_immovables()) {
 							if (plr.check_can_build(*b, f->fcoords)) {
 								caps = maxcaps;
-								opacity *= 2 * kBuildhelpOpacity;
+								opacity *= kBuildhelpOpacityMedium;
 								break;
 							}
 						}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -579,17 +579,17 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 			// Not all map starting positions pass the suitability test.
 			// TODO(tothxa): Make the editor at least use the same test. But manual changes would still
 			//               be possible.
-			for (unsigned p = map.get_nrplayers(); p != 0u; --p) {
-				if (map.get_starting_pos(p) == f->fcoords) {
-					Widelands::Player* plr = gbase.get_player(p);
-					if (plr == nullptr || !plr->is_picking_custom_starting_position()) {
+			for (unsigned pn = map.get_nrplayers(); pn != 0u; --pn) {
+				if (map.get_starting_pos(pn) == f->fcoords) {
+					Widelands::Player* p = gbase.get_player(pn);
+					if (p == nullptr || !p->is_picking_custom_starting_position()) {
 						// Should have a HQ if finished picking, no need for the overlay
 						continue;
 					}
-					player_image = playercolor_image(plr->get_playercolor(), icon_filename);
+					player_image = playercolor_image(p->get_playercolor(), icon_filename);
 					icon_scale = 1.0f;
 					icon_opacity =
-					   plr->get_starting_position_suitability(f->fcoords) ? 0.7f : kBuildhelpOpacity;
+					   p->get_starting_position_suitability(f->fcoords) ? 0.7f : kBuildhelpOpacity;
 					break;
 				}
 			}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -584,14 +584,15 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 				if (map.get_starting_pos(pn) == f->fcoords) {
 					Widelands::Player* p = gbase.get_player(pn);
 					if (p == nullptr || p->get_starting_position_state() ==
-					    Widelands::Player::StartingPositionState::kFinal) {
+					                       Widelands::Player::StartingPositionState::kFinal) {
 						// Should have a HQ if finished picking, no need for the overlay
 						continue;
 					}
 					player_image = playercolor_image(p->get_playercolor(), icon_filename);
 					icon_scale = 1.0f;
 					icon_opacity = p->get_starting_position_suitability(f->fcoords) ?
-                              kBuildhelpOpacityMedium : kBuildhelpOpacityWeak;
+                                 kBuildhelpOpacityMedium :
+                                 kBuildhelpOpacityWeak;
 					break;
 				}
 			}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -583,7 +583,8 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 			for (unsigned pn = map.get_nrplayers(); pn != 0u; --pn) {
 				if (map.get_starting_pos(pn) == f->fcoords) {
 					Widelands::Player* p = gbase.get_player(pn);
-					if (p == nullptr || !p->is_picking_custom_starting_position()) {
+					if (p == nullptr || p->get_starting_position_state() ==
+					    Widelands::Player::StartingPositionState::kFinal) {
 						// Should have a HQ if finished picking, no need for the overlay
 						continue;
 					}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -569,16 +569,21 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 		const bool suited_as_starting_pos =
 		   picking_starting_pos && plr.get_starting_position_suitability(f->fcoords);
 		if (suited_as_starting_pos) {
-			for (unsigned p = map.get_nrplayers(); p != 0u; --p) {
+			unsigned p;
+			for (p = map.get_nrplayers(); p != 0u; --p) {
 				if (map.get_starting_pos(p) == f->fcoords) {
-					const Image* player_image =
-					   playercolor_image(p - 1, "images/players/player_position.png");
-					static constexpr int kStartingPosHotspotY = 55;
-					blit_field_overlay(dst, *f, player_image,
-					                   Vector2i(player_image->width() / 2, kStartingPosHotspotY), scale);
 					break;
 				}
 			}
+			const Image* player_image;
+			if (p == 0u) {
+				player_image = playercolor_image(color(220, 220, 220), "images/players/player_position.png");
+			} else {
+				player_image = playercolor_image(p - 1, "images/players/player_position.png");
+			}
+			static constexpr int kStartingPosHotspotY = 55;
+			blit_field_overlay(dst, *f, player_image,
+			                   Vector2i(player_image->width() / 2, kStartingPosHotspotY), scale);
 		}
 
 		// Draw work area markers.

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -567,25 +567,35 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 		}
 
 		// Draw the player starting position overlays.
-		const bool suited_as_starting_pos =
-		   picking_starting_pos && plr.get_starting_position_suitability(f->fcoords);
-		if (suited_as_starting_pos) {
-			unsigned p;
-			for (p = map.get_nrplayers(); p != 0u; --p) {
+		bool suited_as_starting_pos = false;
+		if (picking_starting_pos) {
+			static const std::string icon_filename = "images/players/player_position.png";
+			static constexpr int kStartingPosHotspotY = 55;
+
+			const Image* player_image = nullptr;
+			float icon_scale = 0.7f;
+
+			// Not all map starting positions pass the suitability test.
+			// TODO(tothxa): Make the editor at least use the same test. But manual changes would still
+			//               be possible.
+			for (unsigned p = map.get_nrplayers(); p != 0u; --p) {
 				if (map.get_starting_pos(p) == f->fcoords) {
+					player_image = playercolor_image(p - 1, icon_filename);
+					icon_scale = 1.0f;
 					break;
 				}
 			}
-			const Image* player_image;
-			if (p == 0u) {
-				player_image =
-				   playercolor_image(RGBColor(220, 220, 220), "images/players/player_position.png");
-			} else {
-				player_image = playercolor_image(p - 1, "images/players/player_position.png");
+
+			if (player_image == nullptr && plr.get_starting_position_suitability(f->fcoords)) {
+				player_image = g_image_cache->get(icon_filename);
 			}
-			static constexpr int kStartingPosHotspotY = 55;
-			blit_field_overlay(dst, *f, player_image,
-			                   Vector2i(player_image->width() / 2, kStartingPosHotspotY), scale);
+
+			if (player_image != nullptr) {
+				suited_as_starting_pos = true;
+				blit_field_overlay(dst, *f, player_image,
+				                   Vector2i(player_image->width() / 2, kStartingPosHotspotY),
+				                   scale * icon_scale);
+			}
 		}
 
 		// Draw work area markers.

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -602,14 +602,13 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 		if (f->seeing != Widelands::VisibleState::kUnexplored) {
 			// Draw build help.
 			const bool show_port_space = has_expedition_port_space(f->fcoords);
-			if (show_port_space || suited_as_starting_pos || buildhelp()) {
+			if (show_port_space || buildhelp()) {
 				Widelands::NodeCaps caps;
 				Widelands::NodeCaps maxcaps = f->fcoords.field->maxcaps();
 				float opacity =
 				   f->seeing == Widelands::VisibleState::kVisible ? 1.f : kBuildhelpOpacity;
 				if (picking_starting_pos) {
-					caps = suited_as_starting_pos || buildhelp() ? f->fcoords.field->nodecaps() :
-                                                              Widelands::CAPS_NONE;
+					caps = show_port_space || buildhelp() ? f->fcoords.field->nodecaps() : Widelands::CAPS_NONE;
 				} else if (show_port_space) {
 					caps = maxcaps;
 				} else {
@@ -627,7 +626,8 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 				}
 
 				const auto* overlay = get_buildhelp_overlay(caps, scale);
-				if (overlay != nullptr) {
+				if (overlay != nullptr && (!suited_as_starting_pos || (caps & Widelands::BUILDCAPS_PORT) != 0)) {
+					// draw overlay if not a starting pos, but draw port space anyway
 					blit_field_overlay(
 					   dst, *f, overlay->pic, overlay->hotspot, scale / overlay->scale, opacity);
 				}

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -574,14 +574,22 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 
 			const Image* player_image = nullptr;
 			float icon_scale = 0.7f;
+			float icon_opacity = 1.0f;
 
 			// Not all map starting positions pass the suitability test.
 			// TODO(tothxa): Make the editor at least use the same test. But manual changes would still
 			//               be possible.
 			for (unsigned p = map.get_nrplayers(); p != 0u; --p) {
 				if (map.get_starting_pos(p) == f->fcoords) {
-					player_image = playercolor_image(p - 1, icon_filename);
+					Widelands::Player* plr = gbase.get_player(p);
+					if (plr == nullptr || !plr->is_picking_custom_starting_position()) {
+						// Should have a HQ if finished picking, no need for the overlay
+						continue;
+					}
+					player_image = playercolor_image(plr->get_playercolor(), icon_filename);
 					icon_scale = 1.0f;
+					icon_opacity =
+					   plr->get_starting_position_suitability(f->fcoords) ? 0.7f : kBuildhelpOpacity;
 					break;
 				}
 			}
@@ -594,7 +602,7 @@ void InteractivePlayer::draw_map_view(MapView* given_map_view, RenderTarget* dst
 				suited_as_starting_pos = true;
 				blit_field_overlay(dst, *f, player_image,
 				                   Vector2i(player_image->width() / 2, kStartingPosHotspotY),
-				                   scale * icon_scale);
+				                   scale * icon_scale, icon_opacity);
 			}
 		}
 


### PR DESCRIPTION
**Type of change**
New feature

**Issue(s) closed**
Replaces #6017, with apologies to @SimonHeimberg. I still consider him the primary author of this change.

**New behavior**
While selecting the starting position, a different icon is shown on valid starting positions, replacing the green big building space icon, but portspaces are still shown normally even if they are valid starting positions.

The icon for the default starting position is used, with a white flag and smaller size.

The default starting positions (in playercolour) are shown with slight transparency if valid, more transparency if invalid,  until the corresponding player picks a starting position.

The default starting positions and the selection cursor are now shown in actual player colour instead of default.

**To reproduce**
*If it's a bugfix:*
Steps to reproduce the behavior which cause the bug in master but not in your branch:
1. Start a game with custom starting positions
2. Enable buildhelp
3. Old: Valid starting positions are indistinguishable from other big build spaces; New: Valid starting positions are well visible

**Possible regressions**
Buildhelp overlays?