### PR TITLE
Fix comment box overflow

### DIFF
--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -364,6 +364,10 @@ AddOnsCtrl::AddOnsCtrl(FsMenu::MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
                   UI::PanelStyle::kFsMenu,
                   "server_name",
                   UI::FontStyle::kWarning,
+				  0,
+				  0,
+				  0,
+				  0,
                   "",
                   UI::Align::kRight) {
 
@@ -1301,7 +1305,6 @@ void AddOnsCtrl::layout() {
 		int w;
 		int h;
 		server_name_.get_desired_size(&w, &h);
-		server_name_.set_size(w, h);
 		server_name_.set_pos(Vector2i(login_button_.get_x() - w - kRowButtonSpacing,
 		                              login_button_.get_y() + (login_button_.get_h() - h) / 2));
 	}

--- a/src/ui_fsmenu/addons/manager.cc
+++ b/src/ui_fsmenu/addons/manager.cc
@@ -364,10 +364,10 @@ AddOnsCtrl::AddOnsCtrl(FsMenu::MainMenu& fsmm, UI::UniqueWindow::Registry& reg)
                   UI::PanelStyle::kFsMenu,
                   "server_name",
                   UI::FontStyle::kWarning,
-				  0,
-				  0,
-				  0,
-				  0,
+                  0,
+                  0,
+                  0,
+                  0,
                   "",
                   UI::Align::kRight) {
 

--- a/src/ui_fsmenu/addons/remote_interaction.cc
+++ b/src/ui_fsmenu/addons/remote_interaction.cc
@@ -852,6 +852,7 @@ void RemoteInteractionWindow::layout() {
 		admin_action_.set_pos(Vector2i(
 		   login_button_.get_x() - admin_action_.get_w() - kRowButtonSpacing, login_button_.get_y()));
 
+		box_comment_rows_.set_max_size(get_inner_w(), 0);
 		box_comment_rows_.set_desired_size(0, 0);
 	}
 	UI::Window::layout();


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6151

**How it works**
Honestly, I am not sure why reducing the max size fixes the issue. It seems counter intuitive. But maybe I am wrong and did not test it correctly?
I also fixed the layout of the server name panel. It only showed up sometimes because its parent is the window and not a layouting box.
