### PR TITLE
Do not handle_mousein in ware display

### DIFF
--- a/src/wui/waresdisplay.cc
+++ b/src/wui/waresdisplay.cc
@@ -165,12 +165,6 @@ bool AbstractWaresDisplay::handle_mousemove(
 	return true;
 }
 
-void AbstractWaresDisplay::handle_mousein(bool inside) {
-	if (!inside) {
-		finalize_anchor_selection();
-	}
-}
-
 bool AbstractWaresDisplay::handle_mousepress(uint8_t btn, int32_t x, int32_t y) {
 	if (btn == SDL_BUTTON_LEFT) {
 		Widelands::DescriptionIndex ware = ware_at_point(x, y);

--- a/src/wui/waresdisplay.h
+++ b/src/wui/waresdisplay.h
@@ -53,7 +53,6 @@ public:
 
 	bool
 	handle_mousemove(uint8_t state, int32_t x, int32_t y, int32_t xdiff, int32_t ydiff) override;
-	void handle_mousein(bool inside) override;
 	bool handle_mousepress(uint8_t btn, int32_t x, int32_t y) override;
 	bool handle_mouserelease(uint8_t btn, int32_t x, int32_t y) override;
 

--- a/src/wui/waresdisplay.h
+++ b/src/wui/waresdisplay.h
@@ -146,7 +146,7 @@ private:
 	 * The ware on which the mouse press has been performed.
 	 * It is not selected directly, but will be on mouse release.
 	 */
-	std::atomic<Widelands::DescriptionIndex> selection_anchor_;
+	Widelands::DescriptionIndex selection_anchor_;
 	std::function<void(Widelands::DescriptionIndex, bool)> callback_function_;
 
 	std::unique_ptr<Notifications::Subscriber<GraphicResolutionChanged>>

--- a/src/wui/waresdisplay.h
+++ b/src/wui/waresdisplay.h
@@ -147,7 +147,7 @@ private:
 	 * The ware on which the mouse press has been performed.
 	 * It is not selected directly, but will be on mouse release.
 	 */
-	Widelands::DescriptionIndex selection_anchor_;
+	std::atomic<Widelands::DescriptionIndex> selection_anchor_;
 	std::function<void(Widelands::DescriptionIndex, bool)> callback_function_;
 
 	std::unique_ptr<Notifications::Subscriber<GraphicResolutionChanged>>


### PR DESCRIPTION
**Type of change**
Bugfix 

**Issue(s) closed**
Fixes #6155

It turned out that moving the chat above all windows in #6127 messes with panel focusing

**New behavior**
The ware selection is not reset when the cursor leaves the window and so can handle the short loss of focus to the chat overlay. IMHO this is actually better than stopping the selection when outside the window. Only mouse release the selection is stopped.

**Possible regressions**
More windows having problems with focus loss.