### PR TITLE
Fix heap-use-after-free in message preview drawing

### DIFF
--- a/src/wui/info_panel.cc
+++ b/src/wui/info_panel.cc
@@ -66,12 +66,16 @@ inline bool MessagePreview::message_still_exists() const {
 }
 
 void MessagePreview::think() {
+	MutexLock m(MutexLock::ID::kMessages);
+
 	if (!message_still_exists() || SDL_GetTicks() - creation_time_ > kMessagePreviewMaxLifetime) {
 		owner_.pop_message(this);
 	}
 }
 
 void MessagePreview::draw(RenderTarget& r) {
+	MutexLock m(MutexLock::ID::kMessages);
+
 	if (!message_still_exists()) {
 		return;
 	}


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Should fix #6168

**Additional context**
None-reproducible race condition