### PR TITLE
Use cmakes newer FindPython module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,12 @@ if (OPTION_BUILD_WINSTATIC)
   endif()
 endif()
 
-find_package (PythonInterp REQUIRED)
+if(${CMAKE_VERSION} VERSION_LESS 3.12.0)
+  # PythonInterp module has been deprecated since CMake 3.12.
+  find_package (PythonInterp REQUIRED)
+else()
+  find_package (Python REQUIRED)
+endif()
 
 find_package(Gettext REQUIRED)
 find_package(OpenGL REQUIRED)


### PR DESCRIPTION
**Type of change**
Maintenance

**Issue(s) closed**
Re #5641 

**New behavior**
Use newer Python module on cmake versions >= 3.12 to resolve cmake warning.
