### PR TITLE
Add zero check for division in textinput

### DIFF
--- a/src/ui_basic/textinput.cc
+++ b/src/ui_basic/textinput.cc
@@ -208,7 +208,7 @@ void AbstractTextInputPanel::Data::draw(RenderTarget& dst, bool with_caret) {
 
 void AbstractTextInputPanel::layout() {
 	// Offset snaps the text panel to the start of input. Saved text always displays from beginning
-	d_->scrolloffset = get_text().length() / get_h();
+	d_->scrolloffset = get_h() == 0 ? 0 : get_text().length() / get_h();
 	Panel::layout();
 	d_->scrollbar.set_pos(Vector2i(get_w() - Scrollbar::kSize, 0));
 }


### PR DESCRIPTION
**Type of change**
Bugfix 

**Issue(s) closed**
Fixes #6213 

**How it works**
Catch divide by zero introduced by #6172 

@jtorruellas22 please check whether this line is still logically correct or should use `get_w()` instead.