### PR TITLE
fix documentation for workers

### DIFF
--- a/data/tribes/workers/atlanteans/armorsmith/init.lua
+++ b/data/tribes/workers/atlanteans/armorsmith/init.lua
@@ -28,71 +28,71 @@
 --
 -- .. code-block:: lua
 --
--- push_textdomain("tribes")
-
--- dirname = path.dirname(__file__)
-
--- wl.Descriptions():new_worker_type {
-   -- name = "empire_fisher",
-   -- -- TRANSLATORS: This is a worker name used in lists of workers
-   -- descname = pgettext("empire_worker", "Fisher"),
-   -- animation_directory = dirname,
-   -- icon = dirname .. "menu.png",
-   -- vision_range = 2,
-
-   -- buildcost = {
-      -- empire_carrier = 1,
-      -- fishing_rod = 1
-   -- },
-
-   -- programs = {
-      -- fish = {
-         -- "findspace=size:any radius:7 resource:resource_fish",
-         -- "walk=coords",
-         -- "playsound=sound/fisher/fisher_throw_net priority:50% allow_multiple",
-         -- "mine=resource_fish radius:1",
-         -- "animate=fishing duration:10s", -- Play a fishing animation
-         -- "playsound=sound/fisher/fisher_pull_net priority:50% allow_multiple",
-         -- "createware=fish",
-         -- "return"
-      -- }
-   -- },
-
-   -- animations = {
-      -- idle = {
-         -- hotspot = { 7, 38 },
-      -- },
-   -- },
-
-   -- spritesheets = {
-      -- fishing = {
-         -- fps = 10,
-         -- frames = 30,
-         -- rows = 6,
-         -- columns = 5,
-         -- hotspot = { 9, 39 }
-      -- },
-      -- walk = {
-         -- fps = 20,
-         -- frames = 20,
-         -- rows = 5,
-         -- columns = 4,
-         -- directional = true,
-         -- hotspot = { 10, 38 }
-      -- },
-      -- walkload = {
-         -- basename = "walk",
-         -- fps = 20,
-         -- frames = 20,
-         -- rows = 5,
-         -- columns = 4,
-         -- directional = true,
-         -- hotspot = { 10, 38 }
-      -- },
-   -- },
--- }
-
--- pop_textdomain()
+--    push_textdomain("tribes")
+--
+--    dirname = path.dirname(__file__)
+--
+--    wl.Descriptions():new_worker_type {
+--        name = "empire_fisher",
+--       -- TRANSLATORS: This is a worker name used in lists of workers
+--       descname = pgettext("empire_worker", "Fisher"),
+--       animation_directory = dirname,
+--       icon = dirname .. "menu.png",
+--       vision_range = 2,
+--
+--       buildcost = {
+--          empire_carrier = 1,
+--          fishing_rod = 1
+--       },
+--
+--       programs = {
+--          fish = {
+--             "findspace=size:any radius:7 resource:resource_fish",
+--             "walk=coords",
+--             "playsound=sound/fisher/fisher_throw_net priority:50% allow_multiple",
+--             "mine=resource_fish radius:1",
+--             "animate=fishing duration:10s", -- Play a fishing animation
+--             "playsound=sound/fisher/fisher_pull_net priority:50% allow_multiple",
+--             "createware=fish",
+--             "return"
+--          }
+--       },
+--
+--       animations = {
+--          idle = {
+--             hotspot = { 7, 38 },
+--          },
+--       },
+--
+--       spritesheets = {
+--          fishing = {
+--             fps = 10,
+--             frames = 30,
+--             rows = 6,
+--             columns = 5,
+--             hotspot = { 9, 39 }
+--          },
+--          walk = {
+--             fps = 20,
+--             frames = 20,
+--             rows = 5,
+--             columns = 4,
+--             directional = true,
+--             hotspot = { 10, 38 }
+--          },
+--          walkload = {
+--             basename = "walk",
+--             fps = 20,
+--             frames = 20,
+--             rows = 5,
+--             columns = 4,
+--             directional = true,
+--             hotspot = { 10, 38 }
+--          },
+--       },
+--    }
+--
+--    pop_textdomain()
 
 push_textdomain("tribes")
 


### PR DESCRIPTION
The documentation of workers was messed up, see https://www.widelands.org/documentation/autogen_basic_workers_lua_tribes_workers_init/#lua-tribes-basic-workers

**Type of change**
This was introduced two years ago https://github.com/widelands/widelands/blame/master/data/tribes/workers/atlanteans/armorsmith/init.lua 

**Issue(s) closed**
This fixes the documentation for workers on the website.

**To reproduce**
Go to https://www.widelands.org/documentation/autogen_basic_workers_lua_tribes_workers_init/#lua-tribes-basic-workers

**How it works**
Reformatted the file to fit with the sphinx syntax.

**Possible regressions**
No

**Additional context**
Don't know if it was introduced by a auto formatter.
