### PR TITLE
Correct float-int type mismatch in fragment shader's alpha calculation

### DIFF
--- a/data/shaders/draw_line.fp
+++ b/data/shaders/draw_line.fp
@@ -6,6 +6,6 @@ varying vec4 var_color;
 
 void main() {
 	// Empirically found shading function that got consensus.
-	float alpha = pow(cos(var_color.a * PI / 2), 1.5);
+	float alpha = pow(cos(var_color.a * PI / 2.0), 1.5);
 	gl_FragColor = vec4(var_color.r, var_color.g, var_color.b, alpha);
 }


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
Bugfix

If the bug/feature does not appear on the issue tracker: a clear and concise description of what your change does *and why it is desirable*.

**To reproduce**
Compile Widelands using glbinding and use gl4es for GL -> GL ES

**New behavior**
Works using GL4ES with glbinding and gl4es

**How it works**
This commit addresses a type mismatch error encountered during the compilation of a fragment shader while using GL4ES 

The issue was caused by the division of a float by an integer (PI / 2), leading to a type mismatch in GLSL ES, which has stricter type requirements compared to desktop GLSL. 

The fix involves explicitly making the divisor a float (PI / 2.0) to ensure consistent type usage in the shader's alpha calculation. 

This change resolves the shader compilation error and ensures proper execution of the fragment shader in environments using GLSL ES, such as those relying on gl4es for OpenGL to OpenGLES translation on the GLbinding backend.
