### PR TITLE
Fix building on FreeBSD / OpenBSD

### DIFF
--- a/cmake/WlFunctions.cmake
+++ b/cmake/WlFunctions.cmake
@@ -112,7 +112,8 @@ macro(_common_compile_tasks)
       endif()
   endif()
 
-  if(ARG_USES_ATOMIC AND NOT APPLE AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
+  if(ARG_USES_ATOMIC AND CMAKE_SYSTEM MATCHES "Linux"
+     AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
     # clang on linux needs explicit linkage against standard library atomic
     target_link_libraries(${NAME} atomic)
   endif()


### PR DESCRIPTION
OS's that use compiler-rt do not use libatomic like a traditional
libgcc based runtime environment does.