### PR TITLE
test: editor tests run the test suite only once

### DIFF
--- a/test/maps/Aquila.wmf/scripting/editor_init.lua
+++ b/test/maps/Aquila.wmf/scripting/editor_init.lua
@@ -1,3 +1,11 @@
 -- No logic required. Just try to load this old map in the Editor.
+
+if editor_init_has_run then -- was loaded before
+   -- avoid reporting twice (for cleanness), which happens in editor
+   wl.ui.MapView():close() -- must be repeated
+   return
+end
+
 print("# All Tests passed.")
 wl.ui.MapView():close()
+editor_init_has_run = 1

--- a/test/maps/lua_testsuite.wmf/scripting/editor_init.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/editor_init.lua
@@ -1,3 +1,8 @@
-include "map:scripting/common_init.lua"
+if player1 then -- was loaded before
+   -- avoid running tests twice, which happens in editor
+   wl.ui.MapView():close() -- was done by init.lua, but must be repeated
+   return
+end
 
+-- "map:scripting/common_init.lua" is included by "map:scripting/init.lua"
 include "map:scripting/init.lua" -- Run the ordinary testsuite


### PR DESCRIPTION
**Type of change**
Fix of test suite

**New behavior**
editor tests run the test suite only once
This avoids mixing up test results.

No clue why editor_init.lua is loaded twice.