### PR TITLE
Build: many GitHub annotations

### DIFF
--- a/.github/workflows/build_appimage.yaml
+++ b/.github/workflows/build_appimage.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Installing dependencies
       run: sh ./.github/scripts/install_deps.sh
     - name: show compiler failures clearly on github
-      uses: ammaraskar/gcc-problem-matcher@0.2
+      uses: ammaraskar/gcc-problem-matcher@0.2.0
     - name: Compile
       run: |
         if [ "${CXX:0:1}" == "c" ]

--- a/.github/workflows/build_appimage.yaml
+++ b/.github/workflows/build_appimage.yaml
@@ -18,6 +18,8 @@ jobs:
       uses: actions/checkout@v3
     - name: Installing dependencies
       run: sh ./.github/scripts/install_deps.sh
+    - name: show compiler failures clearly on github
+      uses: ammaraskar/gcc-problem-matcher@0.2
     - name: Compile
       run: |
         if [ "${CXX:0:1}" == "c" ]
@@ -35,6 +37,7 @@ jobs:
         popd
         mv AppDir/usr/bin/share/* AppDir/usr/share
         rmdir AppDir/usr/bin/share
+        echo ::remove-matcher owner=gcc-problem-matcher:: # removes the problem matcher
     - name: Build AppImage
       run: |
         wget -nv -c https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage

--- a/.github/workflows/build_clang_tidy.yaml
+++ b/.github/workflows/build_clang_tidy.yaml
@@ -44,5 +44,8 @@ jobs:
       with:
         path: build/clang-tidy-cache
         key: clang-tidy-cache-${{ github.sha }}
+    - name: show clang-tidy failures clearly on github
+      uses: ammaraskar/gcc-problem-matcher@0.2
+      # error format is the same as gcc
     - name: Report
       run: utils/check_clang_tidy_results.py clang-tidy.log

--- a/.github/workflows/build_clang_tidy.yaml
+++ b/.github/workflows/build_clang_tidy.yaml
@@ -45,7 +45,7 @@ jobs:
         path: build/clang-tidy-cache
         key: clang-tidy-cache-${{ github.sha }}
     - name: show clang-tidy failures clearly on github
-      uses: ammaraskar/gcc-problem-matcher@0.2
+      uses: ammaraskar/gcc-problem-matcher@0.2.0
       # error format is the same as gcc
     - name: Report
       run: utils/check_clang_tidy_results.py clang-tidy.log

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -20,11 +20,15 @@ jobs:
         export ICU_ROOT="$(brew --prefix icu4c)" && \
         export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/gettext/bin:$PATH";
         ./install-dependencies.sh homebrew ccache dylibbundler
+    - name: show compiler failures clearly on github
+      uses: ammaraskar/gcc-problem-matcher@0.2
+      # clang reports problems the same way
     - name: Building
       run: |
         mkdir build_wl
         cd build_wl/
         ../utils/macos/build_app.sh "--${{ matrix.config }}" "--${{ matrix.compiler }}"
+        echo ::remove-matcher owner=gcc-problem-matcher:: # removes the problem matcher
         grep -v REVDETECT-BROKEN ../build/VERSION
         DMGPATH="$(pwd)"
         DMGFILE="$(ls *.dmg)"

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -21,7 +21,7 @@ jobs:
         export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/gettext/bin:$PATH";
         ./install-dependencies.sh homebrew ccache dylibbundler
     - name: show compiler failures clearly on github
-      uses: ammaraskar/gcc-problem-matcher@0.2
+      uses: ammaraskar/gcc-problem-matcher@0.2.0
       # clang reports problems the same way
     - name: Building
       run: |

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -54,6 +54,8 @@ jobs:
         fetch-depth: 1
     - name: Installing dependencies
       run: sh ./.github/scripts/install_deps.sh
+    - name: show compiler failures clearly on github
+      uses: ammaraskar/gcc-problem-matcher@0.2
     - name: Compile
       run: |
         if [ "${CXX:0:1}" == "c" ]

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Installing dependencies
       run: sh ./.github/scripts/install_deps.sh
     - name: show compiler failures clearly on github
-      uses: ammaraskar/gcc-problem-matcher@0.2
+      uses: ammaraskar/gcc-problem-matcher@0.2.0
     - name: Compile
       run: |
         if [ "${CXX:0:1}" == "c" ]

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -30,7 +30,7 @@ jobs:
         bash.exe -c "./install-dependencies.sh msys${{ matrix.bits }} --noconfirm --disable-download-timeout"
         choco install innosetup
     - name: show compiler failures clearly on github
-      uses: ammaraskar/gcc-problem-matcher@0.2
+      uses: ammaraskar/gcc-problem-matcher@0.2.0
     - name: Compiler
       run: |
         $env:Path = "C:/msys64/mingw${{ matrix.bits }}/include;C:/msys64/mingw${{ matrix.bits }}/lib;C:/msys64/mingw${{ matrix.bits }}/bin;C:/msys64/usr/bin;$env:Path"

--- a/.github/workflows/build_windows.yaml
+++ b/.github/workflows/build_windows.yaml
@@ -29,6 +29,8 @@ jobs:
         pacman.exe --noconfirm -Syyuu --ignore ca-certificates
         bash.exe -c "./install-dependencies.sh msys${{ matrix.bits }} --noconfirm --disable-download-timeout"
         choco install innosetup
+    - name: show compiler failures clearly on github
+      uses: ammaraskar/gcc-problem-matcher@0.2
     - name: Compiler
       run: |
         $env:Path = "C:/msys64/mingw${{ matrix.bits }}/include;C:/msys64/mingw${{ matrix.bits }}/lib;C:/msys64/mingw${{ matrix.bits }}/bin;C:/msys64/usr/bin;$env:Path"

--- a/.github/workflows/build_windows_msvc.yaml
+++ b/.github/workflows/build_windows_msvc.yaml
@@ -50,7 +50,7 @@ jobs:
         # Check https://github.com/actions/runner-images/blob/main/images/win/toolsets/toolset-2022.json for installed versions
         toolset: ${{ steps.prepare.outputs.toolset }}
     - name: show compiler failures clearly on github
-      uses: ammaraskar/msvc-problem-matcher@0.2
+      uses: ammaraskar/msvc-problem-matcher@0.2.0
     - name: Compiler
       env:
         VCPKG_ROOT: C:\vcpkg

--- a/.github/workflows/build_windows_msvc.yaml
+++ b/.github/workflows/build_windows_msvc.yaml
@@ -49,6 +49,8 @@ jobs:
         arch: ${{ matrix.arch }}
         # Check https://github.com/actions/runner-images/blob/main/images/win/toolsets/toolset-2022.json for installed versions
         toolset: ${{ steps.prepare.outputs.toolset }}
+    - name: show compiler failures clearly on github
+      uses: ammaraskar/msvc-problem-matcher@0.2
     - name: Compiler
       env:
         VCPKG_ROOT: C:\vcpkg


### PR DESCRIPTION
**Type of change**
Enhancement of testsuite

**Issue(s) closed**
Fixes -

**New behavior**
Compiler errors and similar messages are marked clearly on GitHub.

**How it works**
The marking of the failure is done with github problem matchers.
A README.md about it is included in another pr (only in one to avoid merge conflicts), see: https://github.com/SimonHeimberg/widelands/tree/build_codecheck_improve/.github/problem_matchers