### PR TITLE
Don't install documentation dependencies on macOS

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -179,8 +179,9 @@ elif [ "$DISTRO" = "msys64" ]; then
 elif [ "$DISTRO" = "homebrew" ]; then
    echo "Installing dependencies for Mac Homebrew..."
    # TODO(k.halfmann): minizip package of brew fails to link dynamically, See also #5620
-   brew install $@ asio git cmake doxygen gettext glew graphviz icu4c jpeg \
+   brew install $@ asio git cmake gettext glew icu4c jpeg \
     libogg libpng libvorbis ninja python sdl2 sdl2_image sdl2_mixer sdl2_ttf zlib
+    # doxygen graphviz ## these are only required for building the documentation
 
 elif [ "$DISTRO" = "solus" ]; then
    echo "Installing dependencies for Solus..."


### PR DESCRIPTION
**Type of change**
Workflow fix

**Issue(s) closed**
doesn't work for #6335

**Possible regressions**
 - Faster dependency install in macOS workflow? ;)
 - building documentation needs manual installation of dependencies (like on other systems)