### PR TITLE
Add gettext tools to vcpkg dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      if: github.ref == 'refs/heads/master'
+      # if: github.ref == 'refs/heads/master'
       with:
         fetch-depth: 1
     - name: Check for changed files

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
   push:
-    branches: [ master, protected/*, 6383-gettext ]
+    branches: [ master, protected/* ]
 
 jobs:
   changes:
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      # if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
       with:
         fetch-depth: 1
     - name: Check for changed files

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
   push:
-    branches: [ master, protected/* ]
+    branches: [ master, protected/*, 6383-gettext ]
 
 jobs:
   changes:

--- a/.github/workflows/build_windows_msvc.yaml
+++ b/.github/workflows/build_windows_msvc.yaml
@@ -34,7 +34,8 @@ jobs:
     - name: Restore vcpkg and its artifacts.
       uses: actions/cache@v4
       with:
-        path: ${{ env.VCPKG_ROOT }}\installed
+        # Explicit path here because env is overridden by msvc-dev-cmd
+        path: C:\vcpkg\installed
         key: |
           ${{ steps.prepare.outputs.vcpkg_key }}-${{ matrix.arch }}
     - name: Installing dependencies

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -196,7 +196,7 @@ elif [ "$DISTRO" = "void" ]; then
 
 elif [ "$DISTRO" = "vcpkg" ]; then
    echo "Installing dependencies for vcpkg..."
-   vcpkg install --disable-metrics $@ asio gettext libpng icu glbinding sdl2 sdl2-ttf \
+   vcpkg install --disable-metrics $@ asio gettext[tools] libpng icu glbinding sdl2 sdl2-ttf \
      sdl2-mixer[libflac,mpg123] sdl2-image[libjpeg-turbo,tiff] graphite2 \
      harfbuzz opusfile libwebp
 


### PR DESCRIPTION
**Type of change**
Bugfix 

**Issue(s) closed**
Fixes #6383 
Re #6296

**New behavior**
Explicitly install gettext tools, which have been used from the git distribution before.

**Additional context**
This will build a new cache but remains at the old vcpkg version where wavpack is not needed.
