### PR TITLE
Territorial Lua error fix

### DIFF
--- a/data/scripting/win_conditions/territorial_functions.lua
+++ b/data/scripting/win_conditions/territorial_functions.lua
@@ -111,7 +111,7 @@ function calculate_territory_points(fields, players)
       for tidx, teaminfo in ipairs(ranked_players) do
          remaining_points = remaining_points - teaminfo.points
       end
-      if (ranked_players[1].points - ranked_players[2].points) > remaining_points then
+      if (count_factions(plrs) == 1 or (ranked_players[1].points - ranked_players[2].points) > remaining_points) then
          winning_points = ranked_players[1].points
       end
    -- Without peaceful mode we need half the useful fields to win


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes #6388

**New behavior**
do not produce the coroutine error

**How it works**
first check if we have more then one faction that needs comparison of ranked players[1] and [2] else declare the points of the only faction remaining as winner

**Possible regressions**
incorrect determination of winning points winners


