### PR TITLE
bar02: Adjust check for sentry in 'basic economy' objective

### DIFF
--- a/data/campaigns/bar02.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/bar02.wmf/scripting/mission_thread.lua
@@ -47,7 +47,7 @@ function initial_message_and_small_food_economy()
          barbarians_quarry = 1,
          barbarians_wood_hardener = 1,
       }) do sleep(3413) end
-   while not check_for_buildings(p1, {barbarians_sentry=1}, game.map:get_field(57,36):region(6)) do
+   while game.map:get_field(60,38).owner ~= p1 do
       sleep(1500)
    end
    set_objective_done(o)


### PR DESCRIPTION
**Type of change**
Bugfix

**Problem description**
As part of the first objective in barbarian campaign mission 2, the player is asked to:

> Build a sentry on the eastern border

However, the objective can be completed even if the sentry is placed quite far from the border. In this screenshot, it doesn't even push the borders any further forward compared to the existing conquer range from the headquarters:
![bar02-obj_build_basic_economy](https://github.com/user-attachments/assets/392f5fb4-daf6-4782-b2b0-c9e40b039235)

Reason for this is that the "intended solution" would be to place the sentry at (57,36); the criteria is loosened to check within a size 6 region -- presumably to give the player a bit of leeway; but it seems the criteria got relaxed way too much.

**To reproduce**
Play the scenario, place sentry as shown in screenshot.

**New behavior**
Requires the sentry to be placed close enough to the southeast border so that it gets advanced forward.
Sentry must be occupied by soldiers (previously, criteria fulfilled as soon as construction completed).

**How it works**
Instead of checking for placement of sentry building, test if player has gained ownership of position (60,38). This is one step forward from the midpoint of southeast edge of existing territory at mission start.

In the below screenshot, reed fields have been placed to mark (60,38) and show that it is the midpoint of southeast edge of size 10 hexagon from headquarters (conquer range = 9). Sentry at intended (57,36) easily fulfills this requirement.
![bar02-obj_build_basic_economy-f-60-38](https://github.com/user-attachments/assets/981b07fd-b943-4c8b-b50d-b336eec76249)

With conquer range = 6, there are already three possible locations for the sentry upon game start. A fourth position at (54,38) becomes available by cutting down just one tree.

**Possible regressions**
The northeast side would also technically count as "on the eastern border", but with the rocks and forest in the way, it is hopefully obvious to players that they should expand toward the open ground to southeast. In the worst case, objective text can be changed to be more specific: "southeast border"