### PR TITLE
Dropdown Listselect: horizontal centering of pics

### DIFF
--- a/src/ui_basic/listselect.cc
+++ b/src/ui_basic/listselect.cc
@@ -474,11 +474,13 @@ void BaseListselect::draw(RenderTarget& dst) {
 
 		// Now draw pictures
 		if (er.pic != nullptr) {
-			dst.blit(Vector2i(UI::g_fh->fontset()->is_rtl() ?
-                              get_eff_w() - er.pic->width() - (max_pic_width_ - er.pic->width()) / 2 - 1 - kIndentStrength * er.indent :
-                              kIndentStrength * er.indent + (max_pic_width_ - er.pic->width()) / 2 + 1,
-			                  y + (lineheight_unpadded - er.pic->height()) / 2),
-			         er.pic);
+			dst.blit(
+			   Vector2i(UI::g_fh->fontset()->is_rtl() ?
+                        get_eff_w() - er.pic->width() - (max_pic_width_ - er.pic->width()) / 2 - 1 -
+			                  kIndentStrength * er.indent :
+                        kIndentStrength * er.indent + (max_pic_width_ - er.pic->width()) / 2 + 1,
+			            y + (lineheight_unpadded - er.pic->height()) / 2),
+			   er.pic);
 		}
 
 		// Fix vertical position for mixed font heights

--- a/src/ui_basic/listselect.cc
+++ b/src/ui_basic/listselect.cc
@@ -475,8 +475,8 @@ void BaseListselect::draw(RenderTarget& dst) {
 		// Now draw pictures
 		if (er.pic != nullptr) {
 			dst.blit(Vector2i(UI::g_fh->fontset()->is_rtl() ?
-                              get_eff_w() - er.pic->width() - 1 - kIndentStrength * er.indent :
-                              kIndentStrength * er.indent + 1,
+                              get_eff_w() - er.pic->width() - ( max_pic_width_ - er.pic->width() ) / 2 - 1 - kIndentStrength * er.indent :
+                              kIndentStrength * er.indent + ( max_pic_width_ - er.pic->width() ) / 2 + 1,
 			                  y + (lineheight_unpadded - er.pic->height()) / 2),
 			         er.pic);
 		}

--- a/src/ui_basic/listselect.cc
+++ b/src/ui_basic/listselect.cc
@@ -475,8 +475,8 @@ void BaseListselect::draw(RenderTarget& dst) {
 		// Now draw pictures
 		if (er.pic != nullptr) {
 			dst.blit(Vector2i(UI::g_fh->fontset()->is_rtl() ?
-                              get_eff_w() - er.pic->width() - ( max_pic_width_ - er.pic->width() ) / 2 - 1 - kIndentStrength * er.indent :
-                              kIndentStrength * er.indent + ( max_pic_width_ - er.pic->width() ) / 2 + 1,
+                              get_eff_w() - er.pic->width() - (max_pic_width_ - er.pic->width()) / 2 - 1 - kIndentStrength * er.indent :
+                              kIndentStrength * er.indent + (max_pic_width_ - er.pic->width()) / 2 + 1,
 			                  y + (lineheight_unpadded - er.pic->height()) / 2),
 			         er.pic);
 		}


### PR DESCRIPTION
**Type of change**
Polish

**Issue(s) closed**
Fixes pictures displayed off-center when different entries in a pictorial dropdown list have differently sized images.

**How it works**
When drawing a list entry, compensate for difference between overall `max_pic_width_` of the whole list vs width of the picture in the entry.

**Screenshots**

Before:
![dropdown-listselect-pic-before](https://github.com/user-attachments/assets/d93b9296-4906-4222-888e-b947ad01b84f)

After:
![dropdown-listselect-pic-centered](https://github.com/user-attachments/assets/5b65dff1-5846-45ee-8a82-20bb4acaa292)

**Describe alternatives you've considered**
Full-blown implementation with left/center/right horizontal alignment options. Not clear this would really be required. Also more complicated due to need to consider localization and text direction.

**Possible regressions**
Maybe there's a dropdown or other kind of listselect somewhere that requires its pictures to be flush left (or flush right for RTL text direction)


