### PR TITLE
Disable objectives button if there are no current objectives

### DIFF
--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 
@@ -559,6 +560,15 @@ public:
 	// The objectives that are defined in this map if it is a scenario.
 	[[nodiscard]] const Objectives& objectives() const {
 		return objectives_;
+	}
+	// Count the number of objectives that match the given done/visible flags
+	// Pass nullopt for "don't care"
+	int objectives_count(std::optional<bool> done = std::nullopt, std::optional<bool> visible = std::nullopt) const {
+		return std::count_if(objectives_.begin(), objectives_.end(),
+		    [done, visible](const auto& o) {
+			return (!done.has_value() || o.second->done() == *done ) &&
+			       (!visible.has_value() || o.second->visible() == *visible );
+		    });
 	}
 	Objectives* mutable_objectives() {
 		return &objectives_;

--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -563,8 +563,8 @@ public:
 	}
 	// Count the number of objectives that match the given done/visible flags
 	// Pass nullopt for "don't care"
-	int objectives_count(std::optional<bool> done = std::nullopt,
-	                     std::optional<bool> visible = std::nullopt) const {
+	[[nodiscard]] int objectives_count(std::optional<bool> done = std::nullopt,
+	                                   std::optional<bool> visible = std::nullopt) const {
 		return std::count_if(objectives_.begin(), objectives_.end(), [done, visible](const auto& o) {
 			return (!done.has_value() || o.second->done() == *done) &&
 			       (!visible.has_value() || o.second->visible() == *visible);

--- a/src/logic/map.h
+++ b/src/logic/map.h
@@ -563,12 +563,12 @@ public:
 	}
 	// Count the number of objectives that match the given done/visible flags
 	// Pass nullopt for "don't care"
-	int objectives_count(std::optional<bool> done = std::nullopt, std::optional<bool> visible = std::nullopt) const {
-		return std::count_if(objectives_.begin(), objectives_.end(),
-		    [done, visible](const auto& o) {
-			return (!done.has_value() || o.second->done() == *done ) &&
-			       (!visible.has_value() || o.second->visible() == *visible );
-		    });
+	int objectives_count(std::optional<bool> done = std::nullopt,
+	                     std::optional<bool> visible = std::nullopt) const {
+		return std::count_if(objectives_.begin(), objectives_.end(), [done, visible](const auto& o) {
+			return (!done.has_value() || o.second->done() == *done) &&
+			       (!visible.has_value() || o.second->visible() == *visible);
+		});
 	}
 	Objectives* mutable_objectives() {
 		return &objectives_;

--- a/src/ui_basic/unique_window.cc
+++ b/src/ui_basic/unique_window.cc
@@ -72,6 +72,20 @@ void UniqueWindow::Registry::toggle() {
 }
 
 /**
+ * Does the window exist? (may be open or minimal)
+ */
+bool UniqueWindow::Registry::exists() const {
+	return window != nullptr;
+}
+
+/**
+ * Is the window open? (not minimal)
+ */
+bool UniqueWindow::Registry::is_open() const {
+	return window != nullptr && !window->is_minimal();
+}
+
+/**
  * In order to avoid dangling pointers, we need to kill our contained window
  * here.
  */

--- a/src/ui_basic/unique_window.h
+++ b/src/ui_basic/unique_window.h
@@ -48,6 +48,9 @@ struct UniqueWindow : public Window {
 		void destroy() const;
 		void toggle();
 
+		bool exists() const;
+		bool is_open() const;
+
 		int32_t x{0};
 		int32_t y{0};
 		bool valid_pos{false};

--- a/src/wui/game_message_menu.h
+++ b/src/wui/game_message_menu.h
@@ -33,7 +33,7 @@ class Game;
 class InteractiveBase;
 class InteractivePlayer;
 
-///  Shows the not already fulfilled objectives.
+///  Shows messages and alerts.
 struct GameMessageMenu : public UI::UniqueWindow {
 	GameMessageMenu(InteractivePlayer&, UI::UniqueWindow::Registry&);
 

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -913,7 +913,9 @@ bool InteractivePlayer::handle_key(bool const down, SDL_Keysym const code) {
 			return true;
 		}
 		if (matches_shortcut(KeyboardShortcut::kInGameObjectives, code)) {
-			if (toggle_objective_menu_->enabled()) {
+			// check the toggle's enabled state to make sure there are objectives to show
+			// if there are no objectives, allow closing the window but not opening it
+			if (toggle_objective_menu_->enabled() || objectives_.is_open()) {
 				objectives_.toggle();
 			}
 			return true;

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -913,7 +913,9 @@ bool InteractivePlayer::handle_key(bool const down, SDL_Keysym const code) {
 			return true;
 		}
 		if (matches_shortcut(KeyboardShortcut::kInGameObjectives, code)) {
-			objectives_.toggle();
+			if (toggle_objective_menu_->enabled()) {
+				objectives_.toggle();
+			}
 			return true;
 		}
 		if (matches_shortcut(KeyboardShortcut::kInGameStatsBuildings, code)) {

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -213,7 +213,7 @@ InteractivePlayer::InteractivePlayer(Widelands::Game& g,
 
 	add_statistics_menu();
 
-	add_toolbar_button(
+	toggle_objective_menu_ = add_toolbar_button(
 	   "wui/menus/objectives", "objectives",
 	   as_tooltip_text_with_hotkey(_("Objectives"),
 	                               shortcut_string_for(KeyboardShortcut::kInGameObjectives, true),
@@ -479,6 +479,14 @@ void InteractivePlayer::think() {
 			}
 			flag_to_connect_ = Widelands::Coords::null();
 		}
+	}
+	{
+		bool const has_objectives = !game().map().objectives().empty();
+		std::string obj_tooltip = has_objectives ? _("Objectives") : _("No current objectives");
+		toggle_objective_menu_->set_enabled(has_objectives);
+		toggle_objective_menu_->set_tooltip(as_tooltip_text_with_hotkey(
+		   obj_tooltip, shortcut_string_for(KeyboardShortcut::kInGameObjectives, true),
+		   UI::PanelStyle::kWui));
 	}
 	{
 		char const* msg_icon = "images/wui/menus/message_old.png";

--- a/src/wui/interactive_player.cc
+++ b/src/wui/interactive_player.cc
@@ -481,7 +481,7 @@ void InteractivePlayer::think() {
 		}
 	}
 	{
-		bool const has_objectives = !game().map().objectives().empty();
+		bool const has_objectives = game().map().objectives_count(false, true) > 0;
 		std::string obj_tooltip = has_objectives ? _("Objectives") : _("No current objectives");
 		toggle_objective_menu_->set_enabled(has_objectives);
 		toggle_objective_menu_->set_tooltip(as_tooltip_text_with_hotkey(

--- a/src/wui/interactive_player.h
+++ b/src/wui/interactive_player.h
@@ -122,6 +122,7 @@ private:
 	bool auto_roadbuild_mode_;
 	Widelands::Coords flag_to_connect_;
 
+	UI::Button* toggle_objective_menu_;
 	UI::Button* toggle_message_menu_;
 
 	// Statistics menu on the toolbar

--- a/src/wui/interactive_player.h
+++ b/src/wui/interactive_player.h
@@ -124,6 +124,7 @@ private:
 
 	UI::Button* toggle_objective_menu_;
 	UI::Button* toggle_message_menu_;
+	void do_toggle_objective_menu();
 
 	// Statistics menu on the toolbar
 	UI::Dropdown<StatisticsMenuEntry> statisticsmenu_;

--- a/test/maps/plain.wmf/scripting/test_ui_2.lua
+++ b/test/maps/plain.wmf/scripting/test_ui_2.lua
@@ -40,7 +40,21 @@ function test_window_property1()
    assert_not_nil(mv.windows.messages)
 end
 
-function test_window_property2()
+function test_window_property2a()
+   -- Won't open with no current objectives
+   assert_equal(0, _cnt_PANEL(mv.windows))
+
+   mv.buttons.objectives:click()
+   sleep(2000)
+   assert_equal(0, _cnt_PANEL(mv.windows))
+
+   assert_nil(mv.windows.objectives)
+end
+
+function test_window_property2b()
+   -- Will open when there are objectives
+   p1:add_objective("test", "blah", "blah blah")
+   sleep(2000)
    assert_equal(0, _cnt_PANEL(mv.windows))
 
    mv.buttons.objectives:click()
@@ -202,7 +216,8 @@ run(function()
    for i,fn in pairs({
          test_buttons_property,
          test_window_property1,
-         test_window_property2,
+         test_window_property2a,
+         test_window_property2b,
          test_position_x,
          test_position_y,
          test_descendant_position,


### PR DESCRIPTION
**Type of change**
New feature

**Issue(s) closed**
Fixes #2118

**New behavior**
When the player has no current objectives:
- the objectives button on the toolbar will have its tooltip changed to indicate that there are no objectives.
- if the objectives window is not open, the objectives button on the toolbar is disabled, and the associated hotkey will also be prevented from opening the objectives window.
- if the window was already open, the toolbar button and hotkey are not disabled and can be used to close the window
  - they will be disabled once the window is closed
