### PR TITLE
Fix regression: immovables show/hide in editor

### DIFF
--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -737,8 +737,8 @@ void EditorInteractive::draw(RenderTarget& dst) {
 		if (get_display_flag(dfShowImmovables)) {
 			Widelands::BaseImmovable* const imm = field.fcoords.field->get_immovable();
 			if (imm != nullptr && imm->get_positions(ebase).front() == field.fcoords) {
-				imm->draw(gametime, InfoToDraw::kShowBuildings,
-				          field.rendertarget_pixel, field.fcoords, scale, &dst);
+				imm->draw(gametime, InfoToDraw::kShowBuildings, field.rendertarget_pixel, field.fcoords,
+				          scale, &dst);
 			}
 		}
 

--- a/src/editor/editorinteractive.cc
+++ b/src/editor/editorinteractive.cc
@@ -737,8 +737,8 @@ void EditorInteractive::draw(RenderTarget& dst) {
 		if (get_display_flag(dfShowImmovables)) {
 			Widelands::BaseImmovable* const imm = field.fcoords.field->get_immovable();
 			if (imm != nullptr && imm->get_positions(ebase).front() == field.fcoords) {
-				imm->draw(
-				   gametime, InfoToDraw::kNone, field.rendertarget_pixel, field.fcoords, scale, &dst);
+				imm->draw(gametime, InfoToDraw::kShowBuildings,
+				          field.rendertarget_pixel, field.fcoords, scale, &dst);
 			}
 		}
 


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes regression reported in [gh comment](https://github.com/widelands/widelands/pull/6499#issuecomment-2292149938) / [cb comment](https://codeberg.org/wl/widelands/pulls/4861#issuecomment-2177464)

show/hide immovables in editor toggled between completely invisible for hidden (intended behavior) and 30% opacity for shown (not intended behavior)

**New behavior**
The show setting is back to displaying immovables at full opacity again.

**How it works**
`editorinteractive` needed to pass appropriate `info_to_draw`.
Previously `Immovable::draw()` would not be affected by it, but now it is.