### PR TITLE
vcpkg workflow fix for v1.2.1

### DIFF
--- a/.github/workflows/build_windows_msvc.yaml
+++ b/.github/workflows/build_windows_msvc.yaml
@@ -44,7 +44,6 @@ jobs:
         [ -n "$REF" ] && git fetch
         git checkout $REF || git pull origin $REF
         echo "vcpkg_key=${{ hashFiles( './install-dependencies.sh' ) }}-${REF}" >> $GITHUB_OUTPUT
-        echo "toolset=${TOOLSET}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Restore vcpkg and its artifacts.
       uses: actions/cache@v4
@@ -63,8 +62,6 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
-        # Check https://github.com/actions/runner-images/blob/main/images/win/toolsets/toolset-2022.json for installed versions
-        toolset: ${{ steps.prepare.outputs.toolset }}
     - name: Compiler
       env:
         VCPKG_ROOT: C:\vcpkg

--- a/.github/workflows/build_windows_msvc.yaml
+++ b/.github/workflows/build_windows_msvc.yaml
@@ -28,8 +28,6 @@ jobs:
       with:
         path: vcpkg_ref
         key: vcpkg_ref-invalid-to-use-latest
-        # Never fall back to unspecified vcpkg version
-        fail-on-cache-miss: true
         restore-keys: |
           vcpkg_ref-
     - name: Checkout vcpkg

--- a/.github/workflows/check_vcpkg.yaml
+++ b/.github/workflows/check_vcpkg.yaml
@@ -38,13 +38,7 @@ jobs:
         popd
         echo "Current HEAD is $HEAD"
         echo "vcpkg_key=${{ hashFiles( './install-dependencies.sh' ) }}-${HEAD}" >> $GITHUB_OUTPUT
-        # Test newest toolset
-        toolset=$(curl https://raw.githubusercontent.com/actions/runner-images/main/images/windows/toolsets/toolset-2022.json | \
-                  jq '.visualStudio.workloads[] | capture("Component\\.VC\\.(?<v>[0-9]+\\.[0-9]+)(\\.[0-9]+){2}\\.x86\\.x64") | .v' | \
-                  sort -u | tail -n 1 | tr -d '"')
-        echo "Current toolset is ${toolset}"
-        echo "toolset=${toolset}" >> $GITHUB_OUTPUT
-        echo "vcpkg_ref=\"$HEAD ${toolset}\"" >> $GITHUB_OUTPUT
+        echo "vcpkg_ref=$HEAD" >> $GITHUB_OUTPUT
       shell: bash
     - name: Check whether cache exists
       id: lookup
@@ -64,7 +58,6 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
-        toolset: ${{ steps.prepare.outputs.toolset }}
     - name: Compiler
       id: build
       if: steps.lookup.outputs.cache-hit != 'true'

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -197,7 +197,7 @@ elif [ "$DISTRO" = "void" ]; then
 elif [ "$DISTRO" = "vcpkg" ]; then
    echo "Installing dependencies for vcpkg..."
    vcpkg install --disable-metrics $@ asio gettext[tools] libpng icu glbinding sdl2 sdl2-ttf \
-     sdl2-mixer[libflac,mpg123] sdl2-image[libjpeg-turbo,tiff] graphite2 \
+     sdl2-mixer[core,libflac,mpg123] sdl2-image[libjpeg-turbo,tiff] graphite2 \
      harfbuzz opusfile libwebp
 
 elif [ -z "$DISTRO" ]; then


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
This should fix msvc builds in the release-1.2 branch

**Possible regressions**
dependency caching may not work in all cases

**Additional context**
`check_vcpkg.yaml` is not actually needed, it's only a sync-up