### PR TITLE
BuildingStatisticsMenu: fix update spam when minimized

### DIFF
--- a/src/wui/building_statistics_menu.cc
+++ b/src/wui/building_statistics_menu.cc
@@ -622,7 +622,7 @@ void BuildingStatisticsMenu::think() {
 	// Update statistics
 	const Time& gametime = iplayer().game().get_gametime();
 
-	if (was_minimized_ || (gametime - lastupdate_) > kUpdateTimeInGametimeMs) {
+	if (!is_minimal() && (was_minimized_ || (gametime - lastupdate_) > kUpdateTimeInGametimeMs)) {
 		update_building_list();
 		update();
 		lastupdate_ = gametime;


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Stop the BuildingStatisticsMenu from spamming its update functions when the window is minimized.

**To reproduce**

1. For ease of comparison, change `kUpdateTimeInGametimeMs` to a higher value, e.g. 5000ms
2. Add a logging message inside `BuildingStatisticsMenu::think()`
```diff
	if (was_minimized_ || (gametime - lastupdate_) > kUpdateTimeInGametimeMs) {
+		log_info(".");
		update_building_list();
		update();
		lastupdate_ = gametime;
	}
```
3. Compile, execute, go into a game, open building stats
4. Observe steady 5s interval of logging when window open
5. Minimize window and watch the frequency of log output go nuts

![bsm-think-spam](https://github.com/user-attachments/assets/f70b58a2-2e25-4b93-b9e1-e76f3fbaab1c)

**New behavior**
Doesn't do any updating until window is no longer minimized

**How it works**
Fix the conditional to actually test for the window not being minimized, as a prerequisite.
