### PR TITLE
Flag: fix nr_of_roads()

### DIFF
--- a/src/ai/defaultai.cc
+++ b/src/ai/defaultai.cc
@@ -3705,10 +3705,10 @@ bool DefaultAI::improve_roads(const Time& gametime) {
 
 	// when deciding if we attempt to build a road from here we use probability
 	uint16_t probability_score = 0;
-	if (flag.nr_of_roads() == 1) {
+	if (flag.nr_of_roadbases() == 1) {
 		probability_score += 20;
 	}
-	if (is_warehouse && flag.nr_of_roads() <= 3) {
+	if (is_warehouse && flag.nr_of_roadbases() <= 3) {
 		probability_score += 20;
 	}
 	probability_score += flag.current_wares() * 5;
@@ -3748,7 +3748,7 @@ bool DefaultAI::dispensable_road_test(const Widelands::Road& road) {
 
 	for (int j = 0; j < 2; ++j) {
 		bool new_road_found = true;
-		while (new_road_found && full_road.back()->nr_of_roads() <= 2 &&
+		while (new_road_found && full_road.back()->nr_of_roadbases() <= 2 &&
 		       full_road.back()->get_building() == nullptr) {
 			new_road_found = false;
 			for (uint8_t i = Widelands::WalkingDir::FIRST_DIRECTION;

--- a/src/economy/flag.cc
+++ b/src/economy/flag.cc
@@ -371,7 +371,7 @@ uint8_t Flag::nr_of_roads() const {
 	uint8_t counter = 0;
 	for (uint8_t road_id = WalkingDir::LAST_DIRECTION; road_id >= WalkingDir::FIRST_DIRECTION;
 	     --road_id) {
-		if (get_roadbase(road_id) != nullptr) {
+		if (get_road(road_id) != nullptr) {
 			++counter;
 		}
 	}


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
`nr_of_roads()` is identical to `nr_of_roadbases()`

https://github.com/widelands/widelands/blob/f915c8c5aab0b44dcc08eeeb5b083d6aff39df76/src/economy/flag.cc#L357-L367

https://github.com/widelands/widelands/blob/f915c8c5aab0b44dcc08eeeb5b083d6aff39df76/src/economy/flag.cc#L369-L379

**New behavior**
`nr_of_roads()` will now return number of roads (excludes waterways)
`nr_of_roadbases()` continues to return the number of roadbases (roads + waterways)