### PR TITLE
Listselect: properly clear entry_cache_

### DIFF
--- a/src/ui_basic/listselect.h
+++ b/src/ui_basic/listselect.h
@@ -57,7 +57,7 @@ struct BaseListselect : public Panel {
 	Notifications::Signal<uint32_t> selected;
 	Notifications::Signal<uint32_t> double_clicked;
 
-	void clear();
+	virtual void clear();
 	void sort(uint32_t Begin = 0, uint32_t End = std::numeric_limits<uint32_t>::max());
 	/**
 	 * Text conventions: Title Case for the 'name', Sentence case for the 'tooltip_text'
@@ -202,6 +202,11 @@ template <typename Entry> struct Listselect : public BaseListselect {
 	           UI::PanelStyle style,
 	           ListselectLayout selection_mode = ListselectLayout::kPlain)
 	   : BaseListselect(parent, name, x, y, w, h, style, selection_mode) {
+	}
+
+	void clear() override {
+		entry_cache_.clear();
+		BaseListselect::clear();
 	}
 
 	void add(const std::string& name,


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Fixes `entry_cache_` of `Listselect` not being cleared when `clear()` called.
Consequently, size of `entry_cache_` will grow larger than number of entries in the listselect itself. Dropdown menus are most greatly impacted, because they clear and rebuild the underlying listselect when filtering is used.

**To reproduce**

1. Add logging to `listselect.h`

```diff
@@ -215,6 +216,9 @@ template <typename Entry> struct Listselect : public BaseListselect {
                entry_cache_.push_back(value);
                BaseListselect::add(
                   name, entry_cache_.size() - 1, pic, select_this, tooltip_text, hotkey, indent, enable);
+
+               log_info("List size: %i; Entry cache size: %li", size(), entry_cache_.size());
+
        }
 
        const Entry& operator[](uint32_t const i) const {
```

2. Compile and execute. Perform tests:
 a. `n` for new game, click the lineup dropdown, and type `team` to filter.
 b. start or load a game, and press hotkeys such as `space`, `c` and `s` to toggle show/hide of information in the map view.

![](https://github.com/user-attachments/assets/694a0baf-5d21-4eac-bfea-4e17a645b6aa)


**New behavior**
`entry_cache_` properly cleaned out

**How it works**
Implement `clear()` in the derived `Listselect`
