### PR TITLE
atl01: Don't eat sawdust

### DIFF
--- a/data/campaigns/atl01.wmf/scripting/mission_thread.lua
+++ b/data/campaigns/atl01.wmf/scripting/mission_thread.lua
@@ -148,7 +148,7 @@ function build_food_environment()
    while not check_for_buildings(p1, {
       atlanteans_farm = 1,
       atlanteans_blackroot_farm = 1,
-      atlanteans_sawmill = 1,
+      atlanteans_mill = 1,
       atlanteans_well = 1,
       atlanteans_bakery = 1,
       atlanteans_hunters_house = 1,


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
Objective related to food supply checks if player has `atlanteans_sawmill`, rather than (flour) mill:
https://github.com/widelands/widelands/blob/bf9af9cbc3d16214d01e8e34ec5fc65778e7dee3/data/campaigns/atl01.wmf/scripting/mission_thread.lua#L147-L159

Player was already asked to build a sawmill in an earlier objective (together with woodcutters, foresters)

**New behavior**
Check for `atlanteans_mill`
