### PR TITLE
include missing <cstdint>

### DIFF
--- a/src/base/format/abstract_node.h
+++ b/src/base/format/abstract_node.h
@@ -19,6 +19,8 @@
 #ifndef WL_BASE_FORMAT_ABSTRACT_NODE_H
 #define WL_BASE_FORMAT_ABSTRACT_NODE_H
 
+#include <cstdint>
+
 namespace format_impl {
 
 enum Flags : uint8_t {

--- a/src/logic/map_objects/tribes/training_attribute.h
+++ b/src/logic/map_objects/tribes/training_attribute.h
@@ -19,6 +19,8 @@
 #ifndef WL_LOGIC_MAP_OBJECTS_TRIBES_TRAINING_ATTRIBUTE_H
 #define WL_LOGIC_MAP_OBJECTS_TRIBES_TRAINING_ATTRIBUTE_H
 
+#include <cstdint>
+
 namespace Widelands {
 
 /**


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
Bugfix

Without the change build fails on upcoming gcc-15 as:

        In file included from src/logic/map_objects/tribes/requirements.h:27:
        src/logic/map_objects/tribes/training_attribute.h:28:6: warning: elaborated-type-specifier for a scoped enum must not use the 'class' keyword
           28 | enum class TrainingAttribute : uint8_t { kHealth = 0, kAttack, kDefense, kEvade, kTotal = 100 };
              | ~~~~ ^~~~~
              |      -----
        src/logic/map_objects/tribes/training_attribute.h:28:30: error: found ':' in nested-name-specifier, expected '::'
           28 | enum class TrainingAttribute : uint8_t { kHealth = 0, kAttack, kDefense, kEvade, kTotal = 100 };
              |                              ^
              |                              ::

**Additional context**

`gcc-15` cleaned up it's `libstdc++` headers and does not use `<cstdint>` as much. As a result it exposes missing includes in downstream projects.