### PR TITLE
WIP: Silence macos/homebrew spam in workflow annotations

### DIFF
--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -26,7 +26,10 @@ jobs:
       run: |
         export ICU_ROOT="$(brew --prefix icu4c)" && \
         export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/gettext/bin:$PATH";
-        ./install-dependencies.sh homebrew ccache
+        # Use --quiet to silence warnings and corresponding workflow annotations about
+        # already installed packages and packages that could be installed from casks.
+        # Not good, but those annotations were even worse.
+        ./install-dependencies.sh homebrew --quiet ccache
     - name: Building
       run: |
         mkdir build_wl

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -178,7 +178,7 @@ elif [ "$DISTRO" = "msys64" ]; then
 elif [ "$DISTRO" = "homebrew" ]; then
    echo "Installing dependencies for Mac Homebrew..."
    # TODO(k.halfmann): minizip package of brew fails to link dynamically, See also #5620
-   brew install $@ asio git cmake doxygen glew graphviz icu4c jpeg \
+   brew install $@ asio git homebrew/cask/cmake homebrew/cask/doxygen glew graphviz icu4c jpeg \
     libogg libpng libvorbis ninja python sdl2 sdl2_image sdl2_mixer sdl2_ttf zlib
 
 elif [ "$DISTRO" = "solus" ]; then


### PR DESCRIPTION
**Type of change**
Bugfix?

**Issue(s) closed**
Workflow runs with macos builds reported lots of warnings as workflow annotations, none of which seem to be important. See e.g. https://github.com/widelands/widelands/actions/runs/10607914740

**New behavior**
Warnings are disabled with the `--quiet` option to `homebrew`.

**Possible regressions**
New important warnings being missed?

**Additional context**
This is the only simple fix I've found in the homebrew docs... Better suggestions are welcome from anybody who actually knows it...

The warnings are (multiplied by the number of macos configs in the matrix):
 - 2 deps could be installed from casks. Maybe that would be nice, but would need more maintenance as packages are added or removed to/from casks. Not worth it for only 2.
 - 5 deps are default-installed in the runner images, but we can't just remove them from `install_dependecies.sh`, because normal users probably don't have them.