### PR TITLE
Remove misplaced, obsolete comment from warehouse.h

### DIFF
--- a/src/logic/map_objects/tribes/warehouse.h
+++ b/src/logic/map_objects/tribes/warehouse.h
@@ -216,9 +216,6 @@ public:
 	}
 	void update_statistics_string(std::string* str) override;
 
-	// Returns the first matching not completely filled waresqueue of the expedition if this is a
-	// port.
-	// Will throw an exception otherwise or if all queues of this type are full.
 	std::unique_ptr<const BuildingSettings> create_building_settings() const override;
 
 	// Returns the waresqueue of the expedition if this is a port.


### PR DESCRIPTION
**Type of change**
Code gardening/cleanup

**Issue(s) closed**

Removes this misplaced comment above `create_building_settings`:

https://github.com/widelands/widelands/blob/468b108ba0f8a7085908b80ccf96aed19ca3465d/src/logic/map_objects/tribes/warehouse.h#L219-L226

The comment originated in 4f4fbb3e, and was probably intended for `inputqueue` (which is just below it), seeing as that was the [only thing changed](https://github.com/widelands/widelands/commit/4f4fbb3ea0ed0fc447215b7e7d26bc46bf18444c#diff-336332db7c889651b97cb66fabfe61768ebd2d4bc3b12e684e9463dd9fbd660a) in `warehouse.cc` in that commit.

In any case, the information appears to be obsolete as of 61d4a5c0, when the relevant code was refactored to [pass a specific request](https://github.com/widelands/widelands/commit/61d4a5c01e5ab4abbddd5f4ca4d6decd4ee64971#diff-336332db7c889651b97cb66fabfe61768ebd2d4bc3b12e684e9463dd9fbd660aL1438-R1438) and [match to the corresponding queue](https://github.com/widelands/widelands/commit/61d4a5c01e5ab4abbddd5f4ca4d6decd4ee64971#diff-ebe571b73e3396109476fdb351fecd47b1b372d1a291faadf92bcc9e01d75de8L193-R199), instead of grabbing the first empty queue that wanted that kind of ware or worker.


