### PR TITLE
Decomission Listselect<Entry&>

### DIFF
--- a/src/ui_basic/listselect.h
+++ b/src/ui_basic/listselect.h
@@ -198,6 +198,14 @@ private:
 };
 
 template <typename Entry> struct Listselect : public BaseListselect {
+	/**
+	 * Listselect<Entry&> is no longer permitted. Allowing references as
+	 * template parameter is not a good idea (e.g. STL containers don't
+	 * allow it). You should use pointers instead because they are more
+	 * explicit, and that was how Listselect<Entry&> worked internally.
+	 */
+	static_assert(!std::is_reference<Entry>::value, "Listselect does not accept reference types!");
+
 	Listselect(Panel* parent,
 	           const std::string& name,
 	           int32_t x,
@@ -237,47 +245,6 @@ template <typename Entry> struct Listselect : public BaseListselect {
 
 private:
 	std::deque<Entry> entry_cache_;
-};
-
-/**
- * This template specialization is for backwards compatibility and convenience
- * only. Allowing references as template parameter is not a good idea
- * (e.g. STL containers don't allow it), you should really use pointers instead
- * because they are more explicit, and that's what this specialization does
- * internally.
- */
-template <typename Entry> struct Listselect<Entry&> : public Listselect<Entry*> {
-	using Base = Listselect<Entry*>;
-
-	Listselect(Panel* parent,
-	           const std::string& name,
-	           int32_t x,
-	           int32_t y,
-	           uint32_t w,
-	           uint32_t h,
-	           UI::PanelStyle style,
-	           ListselectLayout selection_mode = ListselectLayout::kPlain)
-	   : Base(parent, name, x, y, w, h, style, selection_mode) {
-	}
-
-	void add(const std::string& name,
-	         Entry& value,
-	         const Image* pic = nullptr,
-	         const bool select_this = false,
-	         const std::string& tooltip_text = std::string(),
-	         const std::string& hotkey = std::string(),
-	         const unsigned indent = 0,
-	         const bool enable = true) {
-		Base::add(name, &value, pic, select_this, tooltip_text, hotkey, indent, enable);
-	}
-
-	Entry& operator[](uint32_t const i) const {
-		return *Base::operator[](i);
-	}
-
-	Entry& get_selected() const {
-		return *Base::get_selected();
-	}
 };
 }  // namespace UI
 

--- a/src/wui/game_diplomacy_menu.h
+++ b/src/wui/game_diplomacy_menu.h
@@ -22,7 +22,6 @@
 #include "logic/game.h"
 #include "ui_basic/box.h"
 #include "ui_basic/icon.h"
-#include "ui_basic/listselect.h"
 #include "ui_basic/textarea.h"
 #include "ui_basic/unique_window.h"
 

--- a/src/wui/game_objectives_menu.cc
+++ b/src/wui/game_objectives_menu.cc
@@ -57,24 +57,24 @@ GameObjectivesMenu::GameObjectivesMenu(InteractivePlayer& parent,
 void GameObjectivesMenu::think() {
 	//  Adjust the list according to the game state.
 	for (const auto& pair : iplayer_.game().map().objectives()) {
-		const Widelands::Objective& obj = *(pair.second);
-		bool should_show = obj.visible() && !obj.done();
+		const Widelands::Objective* obj = pair.second.get();
+		bool should_show = obj->visible() && !obj->done();
 		uint32_t const list_size = objective_list_.size();
 		for (uint32_t j = 0;; ++j) {
 			if (j == list_size) {  //  the objective is not in our list
 				if (should_show) {
-					objective_list_.add(obj.descname(), obj);
+					objective_list_.add(obj->descname(), obj);
 				}
 				break;
 			}
-			if (&objective_list_[j] == &obj) {  //  the objective is in our list
+			if (objective_list_[j] == obj) {  //  the objective is in our list
 				if (!should_show) {
 					objective_list_.remove(j);
-				} else if (objective_list_[j].descname() != obj.descname() ||
-				           objective_list_[j].descr() != obj.descr()) {
+				} else if (objective_list_[j]->descname() != obj->descname() ||
+				           objective_list_[j]->descr() != obj->descr()) {
 					// Update
 					objective_list_.remove(j);
-					objective_list_.add(obj.descname(), obj);
+					objective_list_.add(obj->descname(), obj);
 				}
 				break;
 			}
@@ -90,7 +90,7 @@ void GameObjectivesMenu::think() {
  * An entry in the objectives menu has been selected
  */
 void GameObjectivesMenu::selected(uint32_t const t) {
-	objective_text_.set_text(t == ListType::no_selection_index() ? "" : objective_list_[t].descr());
+	objective_text_.set_text(t == ListType::no_selection_index() ? "" : objective_list_[t]->descr());
 }
 
 void GameObjectivesMenu::draw(RenderTarget& rt) {

--- a/src/wui/game_objectives_menu.h
+++ b/src/wui/game_objectives_menu.h
@@ -50,7 +50,7 @@ private:
 
 	UI::Box objective_box_;
 
-	using ListType = UI::Listselect<const Widelands::Objective&>;
+	using ListType = UI::Listselect<const Widelands::Objective*>;
 	ListType objective_list_;
 	UI::MultilineTextarea objective_text_;
 };


### PR DESCRIPTION
**Type of change**
Refactoring

**Issue(s) closed**
`Listselect<Entry&>` was created for backwards compatibility in 9527204f, in which some users of Listselect that used references as entries began to be migrated to use pointers instead.
https://github.com/widelands/widelands/blob/abc27599111b9834a1571ef7482c12edbbb3f74d/src/ui_basic/listselect.h#L242-L249
It has been 17 years since then and `GameObjectivesMenu` is the only place in the codebase still using `Listselect<Entry&>`.

**New behavior / How it works**

Change `GameObjectivesMenu::objective_list_` from `Listselect<const Objective&>` to `Listselect<const Objective*>`. This is what the template specialization was doing under the hood anyway. Note that `Map::objectives_` has ownership of objective objects (it is a `std::map<std::string, std::unique_ptr<Objective>>`); we are handling a non-owning 'dumb' pointer obtained using `std::unique_ptr::get()`

`Listselect<Entry&>` template specialization deleted.

`static_assert` added to "generic " `Listselect<Entry>` prohibiting reference type.

**Possible regressions**
Stuff might break if some other future change alters the lifetime of objectives and leaves us with a dangling pointer.

**Additional context**
This would allow culling some code from #6525
