### PR TITLE
Fix for 6444 using mac dylibbundler to packe the .app Bundle

### DIFF
--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -9,10 +9,16 @@ jobs:
       matrix:
         # We test the two newest and the two oldest versions of each of the two compilers
         config: [Debug, Release]
-        os: [ubuntu-22.04]
-        compiler: [clang-15, clang-14, g++-12, g++-11, g++-9]
+        os: [ubuntu-24.04]
+        compiler: [clang-18, clang-17, g++-14, g++-13]
         include:
           # Some compilers need an older ubuntu version to run correctly
+          - compiler: g++-9
+            os: ubuntu-22.04
+            config: Debug
+          - compiler: g++-9
+            os: ubuntu-22.04
+            config: Release
           - compiler: g++-8
             os: ubuntu-20.04
             config: Debug

--- a/data/i18n/translation_stats.conf
+++ b/data/i18n/translation_stats.conf
@@ -34,7 +34,7 @@ translated=43739
 translated=372
 
 [eo]
-translated=5654
+translated=5862
 
 [es]
 translated=83297

--- a/data/i18n/translations/scenario_bar01.wmf/eo.po
+++ b/data/i18n/translations/scenario_bar01.wmf/eo.po
@@ -73,7 +73,7 @@ msgid ""
 " will search for ores; otherwise, they would search for water. Then build a "
 "mine for both kinds of resources that they will find, choosing the "
 "appropriate mine to be built:"
-msgstr "Por fari tion, metu flagon sur la orienta montoflanko (sed sur monta tereno, ne sur monta herbejo). Kiam vi klakos sur la nova flago, vi povos sendi geologojn tien. Ĉar la flago estas sur monto, la geologoj serĉos ercojn; alie, ili serĉus akvon. Poste konstruu minejon por ambaŭ specoj de resursoj, kiujn ili trovos, elektante la taŭgan minejon por konstrui:"
+msgstr "Por fari tion, metu flagon sur la orienta montoflanko (sed sur monta tereno, ne sur monta herbejo). Kiam vi alklakos la novan flagon, vi povos sendi geologojn tien. Ĉar la flago estas sur la monto, la geologoj serĉos ercojn; alie, ili serĉus akvon. Poste konstruu minejon por ambaŭ specoj de resursoj, kiujn ili trovos, elektante la taŭgan minejon por konstrui:"
 
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:44
 msgid "some coal"
@@ -201,7 +201,7 @@ msgid ""
 "beneath it; then it must be enhanced to a deep mine in order to keep it "
 "working properly. To enhance a building, choose it and then click the "
 "appropriate button in the appearing window."
-msgstr "Normala minejo povas nur elfosi ĉirkaŭ trionon de ĉiuj resursoj, kiuj kuŝas sub ĝi; poste ĝi devas esti plibonigita al profunda minejo por daŭre funkcii ĝuste. Por plibonigi konstruaĵon, elektu ĝin kaj poste klaku la taŭgan butonon en la aperanta fenestro."
+msgstr "Normala minejo povas nur elfosi ĉirkaŭ trionon de ĉiuj resursoj, kiuj kuŝas sub ĝi; poste ĝi devas esti plibonigita al profunda minejo por daŭre funkcii normale. Por plibonigi konstruaĵon, elektu ĝin kaj poste alklaku la taŭgan butonon en la aperanta fenestro."
 
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:90
 msgid ""
@@ -269,7 +269,7 @@ msgid ""
 "In order to call a geologist to search for water, click on a flag in the "
 "area that you want him to search and then on the button labeled ‘Send "
 "geologist to explore site’."
-msgstr "Por voki geologon por serĉi akvon, klaku sur flago en la areo, kie vi volas, ke li serĉu, kaj poste sur la butono etikedita «sendu geologon por esplori la lokon»."
+msgstr "Por voki geologon por serĉi akvon, alklaku flagon en la areo, kie vi volas, ke li serĉu, kaj poste alklaku la butonon kun la etikedo \"Sendu geologon por esplori la lokon\"."
 
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:112
 msgid ""
@@ -288,20 +288,20 @@ msgstr "Konstruu kalkfornon kaj puton. Krome, konstruu aŭ karbonigofornon aŭ k
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:120
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:122
 msgid "Build a reed yard"
-msgstr ""
+msgstr "Konstruu kankultivejon"
 
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:121
 msgid ""
 "The third material necessary for improved buildings is reed, used to cover "
 "roofs. Reed fields are planted by a gardener around his building, the reed "
 "yard."
-msgstr ""
+msgstr "La tria materialo necesa por plibonigitaj konstruaĵoj estas kano, uzata por tegi tegmentojn. La ĝardenisto plantas kanon ĉirkaŭ sia konstruaĵo, formante la kankultivejon."
 
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:127
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:129
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:132
 msgid "Build a cattle farm"
-msgstr ""
+msgstr "Konstruu bovbienon"
 
 #: ../../../../data/campaigns/bar01.wmf/scripting/texts.lua:130
 msgid ""

--- a/data/i18n/translations/widelands/eo.po
+++ b/data/i18n/translations/widelands/eo.po
@@ -493,17 +493,17 @@ msgstr "Origino de la mapo"
 msgid ""
 "Set the position that will have the coordinates (0, 0). This will be the "
 "top-left corner of a generated minimap."
-msgstr "Agordi la pozicion, kiu havu la koordinatojn (0, 0). Tiu estos la maldekstra supra angulo de la generita mapo."
+msgstr "Agordi la pozicion, kiu havos la koordinatojn (0, 0). Ĉi tiu estos la supra-maldekstra angulo de la generita minimapo."
 
 #. * TRANSLATORS: An entry in the editor's tool menu
 #: ../../../../src/editor/editorinteractive.cc:387
 msgid "Map size"
-msgstr "Amplekso de mapo"
+msgstr "Mapograndeco"
 
 #. * TRANSLATORS: Tooltip for the map size tool in the editor
 #: ../../../../src/editor/editorinteractive.cc:390
 msgid "Change the map’s size"
-msgstr "Ŝanĝi la amplekson de la mapo"
+msgstr "Ŝanĝi la grandecon de la mapo"
 
 #. * TRANSLATORS: An entry in the editor's tool menu
 #: ../../../../src/editor/editorinteractive.cc:394
@@ -513,19 +513,19 @@ msgstr "Informo"
 #. * TRANSLATORS: Tooltip for the map information tool in the editor
 #: ../../../../src/editor/editorinteractive.cc:397
 msgid "Click on a field to show information about it"
-msgstr "Klaku sur la kampon por montri informon pri ĝi"
+msgstr "Alklaku la kampon por montri informon pri ĝi."
 
 #. * TRANSLATORS: An entry in the editor's tool menu
 #: ../../../../src/editor/editorinteractive.cc:401
 #: ../../../../src/editor/ui_menus/tool_toolhistory_options_menu.cc:44
 #: ../../../../src/wlapplication_options.cc:537
 msgid "Tool History"
-msgstr ""
+msgstr "Ilohistorio"
 
 #. * TRANSLATORS: Tooltip for the tool history tool in the editor
 #: ../../../../src/editor/editorinteractive.cc:404
 msgid "Restore previous tool settings"
-msgstr ""
+msgstr "Restarigi la antaŭajn iloagordojn"
 
 #. * TRANSLATORS: An entry in the editor's show/hide menu to toggle whether
 #. building spaces are
@@ -536,13 +536,13 @@ msgstr ""
 #: ../../../../src/editor/editorinteractive.cc:476
 #: ../../../../src/wui/interactive_gamebase.cc:271
 msgid "Hide Building Spaces"
-msgstr "Kaŝi eblajn ejojn por konstruo"
+msgstr "Kaŝi eblajn konstruejojn"
 
 #: ../../../../src/editor/editorinteractive.cc:476
 #: ../../../../src/ui_fsmenu/options.cc:292
 #: ../../../../src/wui/interactive_gamebase.cc:271
 msgid "Show Building Spaces"
-msgstr "Montri eblajn lokojn por konstruo"
+msgstr "Montri eblajn konstruejojn"
 
 #. * TRANSLATORS: An entry in the editor's show/hide menu to toggle whether to
 #. show maximum
@@ -550,27 +550,27 @@ msgstr "Montri eblajn lokojn por konstruo"
 #. etc.) are removed
 #: ../../../../src/editor/editorinteractive.cc:483
 msgid "Hide Maximum Building Spaces"
-msgstr ""
+msgstr "Kaŝi la plej grandajn konstruejojn"
 
 #: ../../../../src/editor/editorinteractive.cc:484
 msgid "Show Maximum Building Spaces"
-msgstr ""
+msgstr "Montri la plej grandajn konstruejojn"
 
 #: ../../../../src/editor/editorinteractive.cc:487
 msgid ""
 "Toggle whether to show maximum building spaces that will be available if all"
 " immovables (trees, rocks, etc.) are removed"
-msgstr ""
+msgstr "Alterni ĉu montri la plej grandajn konstruejojn, kiuj estos disponeblaj, se ĉiuj nemoveblaĵoj (arboj, rokoj, ktp.) estas forigitaj"
 
 #. * TRANSLATORS: An entry in the editor's show/hide menu to toggle whether
 #. the map height heat map is shown
 #: ../../../../src/editor/editorinteractive.cc:494
 msgid "Disable height heat map"
-msgstr ""
+msgstr "Malŝalti la altecan varmapon"
 
 #: ../../../../src/editor/editorinteractive.cc:495
 msgid "Enable height heat map"
-msgstr ""
+msgstr "Ŝalti la altecan varmapon"
 
 #. * TRANSLATORS: An entry in the editor's show/hide menu to toggle whether
 #. the map grid is shown
@@ -586,28 +586,28 @@ msgstr "Montri kradon"
 #. the oceans are shown
 #: ../../../../src/editor/editorinteractive.cc:510
 msgid "Hide Oceans"
-msgstr ""
+msgstr "Kaŝi oceanojn"
 
 #: ../../../../src/editor/editorinteractive.cc:510
 msgid "Show Oceans"
-msgstr ""
+msgstr "Montri oceanojn"
 
 #: ../../../../src/editor/editorinteractive.cc:513
 msgid ""
 "Display separate water bodies with differently coloured overlays to see "
 "which coasts can be connected by shipping routes"
-msgstr ""
+msgstr "Montru apartajn akvokorpojn kun malsamkoloraj tavoloj por vidi, kiuj marbordoj povas esti konektitaj per maraj itineroj."
 
 #. * TRANSLATORS: An entry in the editor's show/hide menu to toggle whether
 #. immovables
 #. *  (trees, rocks etc.) are shown
 #: ../../../../src/editor/editorinteractive.cc:520
 msgid "Hide Immovables"
-msgstr "Kaŝi nemoveblajn aĵojn"
+msgstr "Kaŝi nemoveblaĵojn"
 
 #: ../../../../src/editor/editorinteractive.cc:520
 msgid "Show Immovables"
-msgstr "Montri nemoveblajn aĵojn"
+msgstr "Montri nemoveblaĵojn"
 
 #. * TRANSLATORS: An entry in the editor's show/hide menu to toggle whether
 #. animals are shown
@@ -623,26 +623,26 @@ msgstr "Montri bestojn"
 #. resources are shown
 #: ../../../../src/editor/editorinteractive.cc:531
 msgid "Hide Resources"
-msgstr "Kaŝi materialojn"
+msgstr "Kaŝi resursojn"
 
 #: ../../../../src/editor/editorinteractive.cc:531
 msgid "Show Resources"
-msgstr "Montri materialojn"
+msgstr "Montri resursojn"
 
 #: ../../../../src/editor/editorinteractive.cc:582
 msgid "Unsupported Format"
-msgstr "Ne konata formo"
+msgstr "Nesubtenata formato"
 
 #: ../../../../src/editor/editorinteractive.cc:583
 #, c-format
 msgid ""
 "Widelands could not load the file \"%s\". The file format seems to be "
 "incompatible."
-msgstr "Widelands ne povis ŝargi la dosieron \"%s\". La formato ŝajnas esti nekongrua"
+msgstr "Widelands ne povis ŝargi la dosieron \"%s\". Ŝajnas, ke la dosiera formato estas ne kongrua."
 
 #: ../../../../src/editor/editorinteractive.cc:648
 msgid "Exit Editor Confirmation"
-msgstr ""
+msgstr "Konfirmo de eliro el la redaktilo"
 
 #: ../../../../src/editor/editorinteractive.cc:648
 msgid "Unsaved Map"
@@ -654,7 +654,7 @@ msgstr "La mapo ne estis konservita; ĉu vi vere volas eliri?"
 
 #: ../../../../src/editor/editorinteractive.cc:650
 msgid "Are you sure you wish to exit the editor?"
-msgstr ""
+msgstr "Ĉu vi certas, ke vi volas eliri el la redaktilo?"
 
 #: ../../../../src/editor/editorinteractive.cc:1283
 #: ../../../../src/logic/addons.cc:48 ../../../../src/ui_basic/dropdown.cc:358
@@ -689,12 +689,12 @@ msgid ""
 "\n"
 "Please report this problem to help us improve Widelands. You will find related messages in the standard output (stdout.txt on Windows). You are using version %2$s.\n"
 "Please add this information to your report."
-msgstr ""
+msgstr "Eraro okazis. La erarmesaĝo estas:\n\n%1$s\n\nBonvolu raporti ĉi tiun problemon por helpi nin plibonigi Widelands. Vi trovos rilatajn mesaĝojn en la norma eligo (stdout.txt en Vindozo). Vi uzas la version %2$s.\nBonvolu aldoni ĉi tiun informon al via raporto."
 
 #: ../../../../src/editor/editorinteractive.cc:1321
 #, c-format
 msgid "Loading map “%s”…"
-msgstr "Ŝargante mapon “%s”…"
+msgstr "Ŝargante la mapon “%s”…"
 
 #. * TRANSLATORS: Default name for new map
 #: ../../../../src/editor/editorinteractive.cc:1343
@@ -703,7 +703,7 @@ msgstr "Ŝargante mapon “%s”…"
 #: ../../../../src/editor/ui_menus/main_menu_save_map.cc:144
 #: ../../../../src/logic/map.h:232 ../../../../src/wui/mapdata.cc:50
 msgid "No Name"
-msgstr "Nenia nomo"
+msgstr "Sennoma"
 
 #. * TRANSLATORS: Map author name when it hasn't been set yet
 #: ../../../../src/editor/editorinteractive.cc:1346
@@ -722,11 +722,11 @@ msgstr "Ŝargante mondon..."
 #: ../../../../src/editor/editorinteractive.cc:1552
 #, c-format
 msgid "Tool gaps: %u%%"
-msgstr ""
+msgstr "Ilaj interspacoj: %u%%"
 
 #: ../../../../src/editor/editorinteractive.cc:1575
 msgid "Publish Map"
-msgstr ""
+msgstr "Publikigi Mapon"
 
 #: ../../../../src/editor/editorinteractive.cc:1576
 #, c-format
@@ -738,54 +738,54 @@ msgid ""
 "Author: %3$s\n"
 "Description: %4$s\n"
 "Hint: %5$s\n"
-msgstr ""
+msgstr "Ĉu vi certas, ke vi volas publikigi ĉi tiun mapon rete?\n\nNomo: %1$s\nInterna nomo: %2$s\nAŭtoro: %3$s\nPriskribo: %4$s\nKonsilo: %5$s\n"
 
 #: ../../../../src/editor/editorinteractive.cc:1600
 msgid "Login Error"
-msgstr ""
+msgstr "Ensaluteraro"
 
 #: ../../../../src/editor/editorinteractive.cc:1605
 msgid "Uploading Add-On…"
-msgstr ""
+msgstr "Alŝutante kromprogramon…"
 
 #: ../../../../src/editor/editorinteractive.cc:1606
 msgid "Saving map…"
-msgstr ""
+msgstr "Konservante mapon…"
 
 #: ../../../../src/editor/editorinteractive.cc:1625
 #: ../../../../src/editor/ui_menus/main_menu_save_map.cc:315
 #: ../../../../src/editor/ui_menus/main_menu_save_map.cc:370
 msgid "Error Saving Map!"
-msgstr "Eraro dum konservado de mapo!"
+msgstr "Eraro dum konservado de la mapo!"
 
 #: ../../../../src/editor/editorinteractive.cc:1631
 msgid "Packaging add-on…"
-msgstr ""
+msgstr "Pakumante kromprogramon…"
 
 #: ../../../../src/editor/editorinteractive.cc:1682
 msgid "Add-On Generation Error"
-msgstr ""
+msgstr "Eraro dum generado de la kromprogramo"
 
 #: ../../../../src/editor/editorinteractive.cc:1683
 msgid "The add-on could not be written to the disk."
-msgstr ""
+msgstr "La kromprogramo ne povis esti skribita sur la disko."
 
 #: ../../../../src/editor/editorinteractive.cc:1690
 #: ../../../../src/ui_fsmenu/addons/screenshot_upload.cc:108
 msgid "Uploading…"
-msgstr ""
+msgstr "Alŝutante..."
 
 #: ../../../../src/editor/editorinteractive.cc:1696
 msgid "Upload Error"
-msgstr ""
+msgstr "Alŝuteraro"
 
 #: ../../../../src/editor/editorinteractive.cc:1718
 msgid "Success"
-msgstr ""
+msgstr "Sukceso"
 
 #: ../../../../src/editor/editorinteractive.cc:1719
 msgid "The add-on was uploaded successfully."
-msgstr ""
+msgstr "La kromprogramo alŝutiĝis sukcese."
 
 #: ../../../../src/editor/map_generator.cc:754
 msgid "Random Player"

--- a/data/i18n/translations/widelands_console/ar.po
+++ b/data/i18n/translations/widelands_console/ar.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: 425467bb0c9da71484550c3c99a0865a_432023a <42ebb87f8d673776150a6c232428c0ac_329642>, 2017-2018\n"
 "Language-Team: Arabic (http://app.transifex.com/widelands/widelands/language/ar/)\n"
@@ -56,7 +56,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -146,87 +146,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -234,254 +234,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -489,12 +490,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/bg.po
+++ b/data/i18n/translations/widelands_console/bg.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Любомир Василев, 2017-2018\n"
 "Language-Team: Bulgarian (http://app.transifex.com/widelands/widelands/language/bg/)\n"
@@ -56,7 +56,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -138,7 +138,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -146,87 +146,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -234,254 +234,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Графични настройки:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Параметри на вътрешния мениджър на прозорци:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -489,12 +490,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/br.po
+++ b/data/i18n/translations/widelands_console/br.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Irriep Nala Novram <per.morvan.bzh29@gmail.com>, 2016\n"
 "Language-Team: Breton (http://app.transifex.com/widelands/widelands/language/br/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ca.po
+++ b/data/i18n/translations/widelands_console/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Juanjo, 2015-2024\n"
 "Language-Team: Catalan (http://app.transifex.com/widelands/widelands/language/ca/)\n"
@@ -53,7 +53,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "NOMCARPETA"
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Executa l’script Lua donat després de l’inici. Només vàlid amb --scenario, --loadgame o --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Inicia el programa amb el so desactivat."
 
@@ -143,87 +143,87 @@ msgstr "Inicia el programa amb el so desactivat."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Reprodueix la música d'inici i mostra una imatge fins que acabi."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Força una fallada del Widelands quan hi hagi un error Lua."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Esborra les repeticions automàticament quan han passat «n» setmanes."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Activa el mode entrenament de la IA. Vegeu https://www.widelands.org/wiki/Ai%20Training/ per una explicació completa de la lògica d’entrenament de la IA."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Ajusta la velocitat de la partida automàticament depenent de l’endarreriment de la IA. Només s’ha d’usar per provar les IA o per entrenament (conjuntament amb --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Habilita la consola de scripts i el mode de trampes."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Opcions de la partida:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Nota: Els valors nous s’escriuran al fitxer de configuració."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Desa automàticament cada «n» minuts."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Usa «n» fitxers per les autodesades."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "No creïs una desada automàtica quan l'usuari estigui inactiu des de l'última desada automàtica."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "No desis els fitxers com a arxius zip binaris."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Desa els fitxers en format zip binari."
 
@@ -231,254 +231,255 @@ msgstr "Desa els fitxers en format zip binari."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Indica si es desa l'historial de missatges enviats per xat en un fitxer."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Mostra el nom dels fitxers a la pantalla de repetició."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Estableix si s’ha de mostrar un avís a l’editor si hi ha massa jugadors."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Posa la partida en pausa quan l'usuari estigui `n` minuts inactiu."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Passa al mode de construcció de camins després de plantar una bandera."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Màscara de bits per establir la configuració visual de noves partides."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Mou el mapa quan el cursor estigui prop de la vora de la pantalla."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Inverteix la direcció de moviment amb clic + arrossega."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Permet el moviment en diagonal amb el teclat numèric."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Mostra l’hora del sistema al panell d’informació."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Empra el mode de vista única."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Mostra el xat de partida amb fons transparent."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Màscara de bits per establir la posició de la barra d’eines i el mode."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Connexió en xarxa:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Connecteu-vos a un metaservidor per jugar per Internet."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Port número «n» del metaservidor per jugar per Internet"
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Nom de l’última partida com a hoste"
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "L’àlies usat per a partides LAN i en línia"
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Nom de l’autor del mapa"
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Últim hoste al que s’ha connectat"
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Indica si el nom d’usuari usat és d’un usuari registrat del metaservidor."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "La contrasenya codificada amb hash per a inicis de sessió en línia"
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Connecta amb adreces a diferents servidors des del gestor de complements."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Connecta amb ports de diferents servidors des del gestor de complements."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Inclou els fluxos de sincronització per ajudar a depurar les partides en xarxa."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Opcions gràfiques:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Fes servir tota la pantalla per al joc."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Inicia el joc en una finestra maximitzada."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Amplada «x» de la finestra en píxels."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Alçada «y» de la finestra en píxels."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Indica si s'ha de deixar que sigui el sistema qui dibuixi el cursor del ratolí. Desactiveu-ho només si el cursor no es veu bé o si voleu que sigui visible a les captures de pantalla o reproduccions de vídeo."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Estableix si els indicadors de funció són apegalosos."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "El camí del tema actiu de la interfície relatiu a la carpeta base del Widelands."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Opcions per al gestor de finestres intern:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Determina si els moviments automàtics del mapa s’han d’animar."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Mou una finestra a la vora de la pantalla quan la vora estigui a una distància «n»."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Habilita/deshabilita l’acoblament a la vora de la pantalla quan la vora d’alguna finestra estigui a prop de la vora de la pantalla."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Mou una finestra a la vora del panell quan la vora estigui a una distància «n» del costat d’un panell."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Habilita els missatges de depuració descriptius."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Altres:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Mostra una llista de com s’han traduït totes les cadenes. Això ajuda a buscar errors en les traduccions."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Només mostra la versió i surt."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Mostra aquesta ajuda."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Mostra aquesta ajuda amb totes les opcions de configuració disponibles."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr " Carrega directament la desada o repetició. Útil per l’associació de fitxers amb extensions .wgf/.wry. No funciona amb altres opcions. Vegeu també --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Aquesta és la versió %s del Widelands."
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/cs.po
+++ b/data/i18n/translations/widelands_console/cs.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Václav Černý <vaclav.vatoz.cerny@gmail.com>, 2024\n"
 "Language-Team: Czech (http://app.transifex.com/widelands/widelands/language/cs/)\n"
@@ -61,7 +61,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "DIRNAME"
 
@@ -143,7 +143,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Spusť zadaný Lua skript po inicializaci. Platné pouze s --scenario, --loadgame, nebo --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Spustí hru bez zvuku."
 
@@ -151,87 +151,87 @@ msgstr "Spustí hru bez zvuku."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[ano*|ne]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Vynutí pád aplikace Widelands v případě výskytu chyby v Lua."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Aktivuje režim AI training. Stránka                      https://www.widelands.org/wiki/Ai%20Training/ obsahuje podrobnější informace k jeho využití."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Průběžně upravuj rychlost hry podle zpoždění UI. Používá se pouze při testování nebo výcviku (společně s --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Volby hry:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Poznámka: Nové hodnoty budou zapsány do konfiguračního souboru"
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Automaticky ukládat každých `n` minut"
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Použij `n` souborů pro automatické ukládání."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Neukládat soubory jako binární zip archivy."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -239,254 +239,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[ano|ne*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Zobrazuj názvy souborů v okně záznamů."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Zda by mělo být v editoru zobrazeno varování o velkém množství hráčů"
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Začít budovat cestu po umístění vlajky."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Bitová maska zobrazovacích přepínačů pro novou hru."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Posunovat pohled, pokud se kurzor myši přiblíží k okraji obrazovky."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Otoč pohyb mapy při kliknutí a táhnutí."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Povolit diagonální posun prostřednictvím numerické klávesnice."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Zobrazit místní čas systému na informačním panelu."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Použít mód jednoduchého pohledového okna."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Zobrazit ve hře chat s průhledným pozadím."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bitová maska k nastavení pozice a módu nástrojové lišty."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Síť:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Připojit k vybranému metaserveru pro hru přes internet."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Číslo portu `n` metaserveru pro hru přes internet."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Název poslední hostované hry."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "Přezdívka použitá pro LAN a online hry."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Jméno autora mapy."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Poslední připojený hostitel."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Zda použité metaserver přihlášení je pro registrovaného uživatele."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Zahashované heslo pro online přihlášení."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Připojit se k jiné adrese serveru ze správce rozšíření."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Připojit se k jinému portu serveru ze správce rozšíření."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Vytváří soubory s výpisem syncstream, určené pro kontrolu desynchronizací při ladění síťových her."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Grafické volby:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Šířka `x` okna v pixelech."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Výška `y` okna v pixelech."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Zda používat přichytávající se nápovědy."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Cesta k aktivnímu motivu uživatelského rozhraní, relativně k domovskému adresáři Widelands."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Volby pro interního správce oken:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Zda animovat automatické pohyby mapy."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Přichyť okno k okraji obrazovky, když se okraj okna dostane do vzdálenosti `n` od okraje obrazovky."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Odstraňuj okraj okna, když se blíží k okraji obrazovky."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Posuň okno k okraji panelu, pokud se okraj okna dostane do vzdálenosti `n` od okraje panelu."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Povolí generování podrobných ladících zpráv"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Další:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Vytiskni všechny textové řetězce i s překladem. To pomůže při vyhledávání chyb v lokalizaci."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Pouze vypíše verzi a ukončí se."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Zobrazí tuto nápovědu."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Zobrazí tuto nápovědu se všemi dostupnými možnostmi nastavení."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -494,12 +495,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Toto je verze Widelands %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/da.po
+++ b/data/i18n/translations/widelands_console/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Joe Hansen <joedalton2@yahoo.dk>, 2016-2021\n"
 "Language-Team: Danish (http://app.transifex.com/widelands/widelands/language/da/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "MAPPENAVN"
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[sand*|falsk]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Spilindstillinger:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[sand|falsk*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Netværk:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Grafikindstillinger:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Indstillinger for den interne vindueshåndtering:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Aktiver uddybende fejlsøgningsbeskeder"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Andre:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/de.po
+++ b/data/i18n/translations/widelands_console/de.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Stephan Lutz <stephan-lutz@gmx.de>, 2018,2020-2024\n"
 "Language-Team: German (http://app.transifex.com/widelands/widelands/language/de/)\n"
@@ -64,7 +64,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "VERZEICHNISNAME"
 
@@ -146,7 +146,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Führt ein Lua-Skript nach der Initialisierung aus. Nur gültig mit --scenario, --loadgame oder --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Starte das Spiel mit deaktiviertem Ton."
 
@@ -154,87 +154,87 @@ msgstr "Starte das Spiel mit deaktiviertem Ton."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Spiele die Einführungsmusik zu Beginn und zeige das Startbild bis sie endet."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Absturz von Widelands erzwingen, wenn ein Lua-Fehler auftritt."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Lösche Aufzeichnungnen automatisch nach `n` Wochen."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Aktiviert den KI-Trainingsmodus. Siehe https://www.widelands.org/wiki/Ai%20Training/ für eine ausführliche Beschreibung der KI-Trainingslogik."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Passe die Spielgeschwindigkeit basierend auf der Verzögerung in der KI konstant automatisch an. Nur zum Testen oder Trainieren (in Verbindung mit --ai_training) der KI zu verwenden."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Aktiviere die Skriptkonsole und den Schummelmodus. "
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Spieloptionen:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Hinweis: Der neue Wert wird in die config-Datei geschrieben."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Speichert automatisch alle `n` Minuten."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Benutze `n` Dateien für das rollierende Autospeichern."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Speichere keinen automatischen Spielstand wenn der Spieler seit der letzten automatischen Speicherung inaktiv war."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Speichert Dateien nicht als Zip-Archive."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Speichere Dateien als Zip-Archive."
 
@@ -242,254 +242,255 @@ msgstr "Speichere Dateien als Zip-Archive."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Ob der Verlauf der gesendeten Chat Nachrichten in einer Datei gespeichert wird."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Zeige die Dateinamen im Aufzeichnungsmenü."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Ob eine Warnung im Editor bei zu vielen Spielern gezeigt wird."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Pausiere das Spiel nach `n` Minuten Inaktivität des Spielers."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Beginne mit dem Straßenbau nach dem Flaggensetzen."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Bitmaske für zu setzende Anzeigebits neuer Spiele."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Ansicht verschieben, wenn der Mauszeiger in der Nähe des Bildschirmrands ist."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Invertiere die Kartenbewegungsrichtung beim geklickten Ziehen der Karte."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Diagonalen Bildlauf mit Nummernblocktasten erlauben."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Zeige die Systemzeit in der Infotafel."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Zeige nur ein Beobachtungsfenster."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Zeige den Chat im Spiel mit transparentem Hintergrund."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bitmaske zum Setzen von Modus und Ort der Werkzeugleiste."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Netzwerkoptionen:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Stelle die Verbindung zu einem alternativen Metaserver für ein Internetspiel her."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Portnummer `n` des Metaservers für das Internetspiel."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Der Name des letzten bereitgestellten Spiels."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "Der Spielername für Netzwerk und Internetspiele."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Der Name des Kartenautors."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Der letzte Host zu dem verbunden wurde."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Ob die benutzte Anmeldung im Metaserver zu einem registrierten Nutzer gehört."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Das mit einem Hashwert verschlüsselte Passwort für die Anmeldung im Internetspiel."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Stelle die Verbindung vom Erweiterungsmanager zu einer alternativen Serveradresse her."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Stelle die Verbindung vom Erweiterungsmanager zu einem alternativen Serverport her."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Erstelle Syncstream-Speicherauszüge zum Debuggen von Netzwerkspielen."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Grafik-Optionen:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Nutze den Vollbildmodus im Spiel."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Starte das Spiel in einem maximierten Fenster."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Breite `x` des Fensters in Pixeln."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Höhe `y` des Fensters in Pixeln."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Ob das System den Mauszeiger zeichnen darf. Schalten sie dies nur ab, wenn der Cursor nicht richtig dargestellt wird, oder wenn er auch in Bildschirmfotos oder Bildschirmvideos zu sehen sein soll."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Ob die Kurzhilfe festgestellt werden soll."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Der Pfad zum aktuellen Thema der Nutzerschnittstelle, relativ zum Heimverzeichnis."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Einstellungen für den internen Fenstermanager:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Ob automatische Kartenbewegungen animiert werden sollen."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Verschiebe ein Fenster zum Bildschirmrand, wenn der Rand des Fensters in eine Entfernung von `n` zum Bildschirmrand kommt."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Lässt den Fensterrand verschwinden, wenn sich das Fenster nahe dem Bildschirmrand befindet."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Verschiebe ein Fenster zum Rand des Panels wenn der Rand des Fensters in eine Entfernung von `n` zum Rand des Panels kommt."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Verwendet ausführliche Debugmeldungen"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Sonstige:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Alle Zeichenfolgen so ausgeben, wie sie übersetzt sind. Dies hilft in der Nachverfolgung von Bugs in der Internationalisierung."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Nur die Version ausgeben und verlassen."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Zeige diese Hilfe."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Zeige diese Hilfe mit allen Konfigurationsoptionen."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -497,12 +498,12 @@ msgid ""
 msgstr "Lädt direkt das gegebene gespeicherte Spiel oder die gegebene Aufzeichnung. Nützlich für die Zuordnung der „.wgf“-/„.wry“-Dateinamenerweiterung. Funktioniert nicht mit anderen Optionen. Siehe auch --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Das ist Widelands Version %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/el.po
+++ b/data/i18n/translations/widelands_console/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Alexandros Koutroulis, 2024\n"
 "Language-Team: Greek (http://app.transifex.com/widelands/widelands/language/el/)\n"
@@ -53,7 +53,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "ΟΝΟΜΑ_ΚΑΤΑΛΟΓΟΥ"
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/en_GB.po
+++ b/data/i18n/translations/widelands_console/en_GB.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Andi Chandler <andi@gowling.com>, 2016-2018,2024\n"
 "Language-Team: English (United Kingdom) (http://app.transifex.com/widelands/widelands/language/en_GB/)\n"
@@ -54,7 +54,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "DIRNAME"
 
@@ -136,7 +136,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Run the given Lua script after initialisation. Only valid with --scenario, --loadgame, or --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Start the game with sound disabled."
 
@@ -144,87 +144,87 @@ msgstr "Start the game with sound disabled."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Play the intro music at startup and show splash image until it ends."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Force Widelands to crash when a Lua error occurs."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Delete replays automatically after `n` weeks."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ for a full description of the AI training logic."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Constantly adjust the game speed automatically depending on AI delay. Only to be used for AI testing or training (in conjunction with --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Enable the Script Console and Cheating Mode."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Game options:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Note: New values will be written to the config file."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Automatically save each `n` minutes."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Use `n` files for rolling autosaves."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Do not create an autosave when the user has been inactive since the last autosave."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Do not save files as binary zip archives."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Save files as binary zip archives."
 
@@ -232,254 +232,255 @@ msgstr "Save files as binary zip archives."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Whether to save the history of sent chat messages to a file."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Show filenames in the replay screen."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Whether a warning should be shown in the editor if there are too many players."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Pause the game after `n` minutes of user inactivity."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Start building a road after placing a flag."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Bitmask of display flags to set for new games."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Scroll when the mouse cursor is near the screen edge."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Invert click-and-drag map movement direction."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Allow diagonal scrolling with the numeric keypad."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Display system time in the info panel."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Use single watchwindow mode."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Show in-game chat with transparent background."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bitmask to set the toolbar location and mode."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Networking:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Connect to a different metaserver for Internet gaming."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Port number `n` of the metaserver for Internet gaming."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "The name of the last hosted game."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "The nickname used for LAN and online games."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Name of map author."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "The last host connected to."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Whether the used metaserver login is for a registered user."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "The hashed password for online logins."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Connect to a different server address from the add-ons manager."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Connect to a different server port from the add-ons manager."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Create syncstream dump files to help debug network games."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Graphic options:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Use the whole display for the game screen."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Start the game in a maximised window."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Width `x` of the window in pixel."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Height `y` of the window in pixel."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Whether to let the system draw the mouse cursor. Disable it only if the cursor doesn't appear right, or if you want it to be visible in screenshots or screencasts."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Whether to use sticky tooltips."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "The path to the active UI theme, relative to the Widelands home directory."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Options for the internal window manager:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Whether automatic map movements should be animated."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Move a window to the edge of the screen when the edge of the window comes within a distance `n` from the edge of the screen."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Eliminate a window’s border towards the edge of the screen when the edge of the window is next to the edge of the screen."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Move a window to the edge of the panel when the edge of the window comes within a distance of `n` from the edge of the panel."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Enable verbose debug messages"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Others:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Print all strings as they are translated. This helps with tracing down bugs with internationalisation."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Only print version and exit."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Show this help."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Show this help with all available config options."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -487,12 +488,12 @@ msgid ""
 msgstr "Load the given savegame or replay directly. Useful for .wgf/.wry file extension association. Does not work with other options. Also see --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "This is Widelands version %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/en_US.po
+++ b/data/i18n/translations/widelands_console/en_US.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (United States) (http://app.transifex.com/widelands/widelands/language/en_US/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/eo.po
+++ b/data/i18n/translations/widelands_console/eo.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: GunChleoc, 2016\n"
 "Language-Team: Esperanto (http://app.transifex.com/widelands/widelands/language/eo/)\n"
@@ -55,7 +55,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -145,87 +145,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -233,254 +233,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -488,12 +489,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/es.po
+++ b/data/i18n/translations/widelands_console/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Jhonatan Hurtado, 2024\n"
 "Language-Team: Spanish (http://app.transifex.com/widelands/widelands/language/es/)\n"
@@ -61,7 +61,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "DIRNAME"
 
@@ -143,7 +143,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Ejecute el script Lua proporcionado después de la inicialización. Solo aplicable con --scenario, --loadgame o --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Inicia el juego con el sonido desactivado."
 
@@ -151,87 +151,87 @@ msgstr "Inicia el juego con el sonido desactivado."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Obliga a Widelands a fallar cuando se produce un error de Lua."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Elimina las repeticiones automáticamente después de `n` semanas."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Habilite el modo de entrenamiento de IA. Consulte https://www.widelands.org/wiki/Ai%20Training/ para obtener una descripción completa de la lógica de entrenamiento de IA."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Ajuste automático de la velocidad del juego dependiendo del retraso de la IA. Solo para ser utilizado para pruebas o entrenamiento de IA (junto con --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Habilite la consola de script y el modo de trampa (cheating)."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Opciones del juego:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Nota: Los nuevos valores se escribirán en el archivo de configuración."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Guarda automáticamente cada `n` minutos."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Utilizar `n` archivos para realizar guardados automáticos continuos."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "No cree un guardado automático cuando el usuario haya estado inactivo desde el último guardado automático."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "No guarde archivos como archivos zip binarios."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -239,254 +239,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Si se guarda el historial de mensajes de chat enviados en un archivo."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Muestra nombres de archivos en la pantalla de reproducción."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Si se debe mostrar una advertencia en el editor si hay demasiados jugadores."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Pausa el juego después de `n` minutos de inactividad del usuario."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Comienza a construir un camino después de colocar una bandera."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Máscara de bits de indicadores de visualización para configurar para juegos nuevos."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Desplazar cuando el cursor del ratón esté cerca del borde de la pantalla."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Inviertir la dirección del movimiento del mapa al hacer click y arrastrar."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Permitir el desplazamiento diagonal con el teclado numérico."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Muestra la hora del sistema en el panel de información."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Utilice el modo de ventana de vigilancia única."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Mostrar el chat del juego con fondo transparente."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Máscara de bits para configurar la ubicación y el modo de la barra de herramientas."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Redes:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Conéctese a un metaservidor diferente para jugar en Internet."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Número de puerto `n` del metaservidor para juegos en Internet."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "El nombre del último juego alojado."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "El apodo utilizado para LAN y juegos en línea."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Nombre del autor del mapa."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "El último host conectado."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Si el inicio de sesión del metaservidor utilizado es para un usuario registrado."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "La contraseña hash para inicios de sesión en línea."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Conéctese a una dirección de servidor diferente desde el administrador de complementos."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Conéctese a un puerto de servidor diferente al del administrador de complementos."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Cree archivos de volcado de sincronización para ayudar a depurar juegos en red."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Opciones de gráficos:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Usa toda la pantalla para la ventana del juego."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Inicia el juego en una ventana maximizada."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Ancho `x` de la ventana en píxeles."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Alto `x` de la ventana en píxeles."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Si se debe utilizar información sobre herramientas adhesiva."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "La ruta al tema de la interfaz de usuario activo, relativa al directorio de inicio de Widelands."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Opciones para el gestor de ventanas internas:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Si los movimientos automáticos del mapa deben animarse."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Mueva una ventana al borde de la pantalla cuando el borde de la ventana esté a una distancia \"n\" del borde de la pantalla."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Elimina el borde de una ventana hacia el borde de la pantalla cuando el borde de la ventana está al lado del borde de la pantalla."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Mueva una ventana al borde del panel cuando el borde de la ventana esté a una distancia de \"n\" del borde del panel."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Habilitar mensajes de depuración detallados"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Otros:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Imprime todas las cadenas a medida que se traducen. Esto ayuda a localizar errores con la internacionalización."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Sólo imprimir la versión y salir."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Mostrar esta ayuda."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Muestre esta ayuda con todas las opciones de configuración disponibles."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -494,12 +495,12 @@ msgid ""
 msgstr "Carga la partida guardada proporcionada o vuelve a jugarla directamente. Útil para la asociación de extensiones de archivos '.wgf/.wry'. No funciona con otras opciones. Consulte también --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Esta es la Versión %s de Widelands"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/eu.po
+++ b/data/i18n/translations/widelands_console/eu.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Basque (http://app.transifex.com/widelands/widelands/language/eu/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/fa.po
+++ b/data/i18n/translations/widelands_console/fa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: GunChleoc, 2014\n"
 "Language-Team: Persian (http://app.transifex.com/widelands/widelands/language/fa/)\n"
@@ -54,7 +54,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -144,87 +144,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -232,254 +232,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -487,12 +488,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/fi.po
+++ b/data/i18n/translations/widelands_console/fi.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Oi Suomi On! <oisuomion@protonmail.com>, 2023\n"
 "Language-Team: Finnish (http://app.transifex.com/widelands/widelands/language/fi/)\n"
@@ -60,7 +60,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "HAKEMISTONIMI"
 
@@ -142,7 +142,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Aja annettu Lua-komentosarja käynnistyksen jälkeen. Kelpo ainoastaan vipujen --scenario, --loadgame, tai --editor kanssa."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Aloita peli ilman ääniä."
 
@@ -150,87 +150,87 @@ msgstr "Aloita peli ilman ääniä."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[tosi*|epätosi]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Pakota Widelands kaatumaan mikäli ilmenee Lua-virhe."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Poista pelitoisinnot automaattisesti `n` viikon jälkeen."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Kytke päälle TK-älyllinen harjoitustila. Katso https://www.widelands.org/wiki/Ai%20Training/ nähdäksesi täydellisen kuvauksen tuon TK-älyn logiikasta."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Säädä alati pelinopeutta ja automaattisesti riippuen TK-älyn viiveestä. Tulisi käyttää ainoastaan TK-älyn testaamiseen tai harjoittelussa (yhdistettynä vipuun --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Kytke päälle komentosarjakehote ja huijaustila. "
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Peliasetukset:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Huomautus: uudet arvot kirjoitetaan asetustiedostoon."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Tallenna automaattisesti `n` minuutin välein."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Käytä `n` tiedostoja rullaavien automaattitallennusten kanssa."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Älä luo automaattitallennusta kun käyttäjä on ollut toimeton viimeisimmän automaattitallennuksen jälkeen."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Älä tallenna tiedostoja binäärisinä zip-arkistoina."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -238,254 +238,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[tosi|epätosi*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Josko lähetettyjen keskusteluviestien historia tallennetaan tiedostoon."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Näytä tiedostonimet toisintoikkunassa."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Näytetäänkö editorissa varoitus jos pelaajia on liikaa."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Tauota peli `n` minuutin toimettomuuden jälkeen."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Aloita tienrakennus lipun asettamisen jälkeen."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Ruudun lippujen bittimaskitus uusille peleille."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Vieritä kun osoitin on lähellä ruudun reunaa."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Tee napsauta-ja-raahaa karttaliikutus käänteiseksi."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Salli vaakavierittäminen numeronäppäimistöltä."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Näytä järjestelmän aika infopaneelissa."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Käytä yksittäistä tarkkaile ikkunaa -tilaa."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Näytä pelinsisäinen chat-keskustelu läpikuultavalla taustalla."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bittimaski asettaa työkalurivin sijainnin ja tilan."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Verkko:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Yhdistä eri metapalvelimelle internet-pelaamista varten."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Metapalvelimen porttinumero `n` internet-pelaamista varten."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Edellisen isännöidyn pelin nimi."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "Lempinimi jota käytetään lähiverkkopelaamisessa ja internet-pelaamisessa."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Kartan luojan nimi."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Viimeisin palvelin johon oltiin yhteydessä."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Onko käytetty metapalvelimen kirjautuminen rekisteröityneelle käyttäjälle."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "hash-hajautettu salasana internet-kirjautumisiin."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP-osoite"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Yhdistä eri palvelinosoitteeseen lisäosa-hallinnasta."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Yhdistä eri palvelinporttiin lisäosa-hallinnasta."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Luo syncstream-otostiedostoja auttamaan virheenkorjauksessa verkkopelatessa."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Grafiikkavallinnat:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Ikkunan leveys `x` pikseleinä."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Ikkunan korkeus `y` pikseleinä."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Käytetäänkö kiinnitettyjä työkaluvinkkejä."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Toiminnassa olevan käyttöliittymän teeman tiedostopolku, suhteessa Widelandsin kotihakemistoon."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Sisäisen ikkunointijärjestelmän asetukset:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Animoidaanko automaattiset kartan liikkeet."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Siirrä ikkuna ruudun äärireunaan kun ikkunan reunus tulee etäisyydelle `n` ruudunreunasta. "
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Poista ikkunan raja kohti ruudun reunusta kun ikkunan reuna on ruudun reunuksen vieressä."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Siirrä ikkuna paneelin reunaan kun ikkunan reuna tulee etäisyyteen `n` paneelin reunasta."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Kytke päälle monisanaiset virheenseurannan viestit"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Muut:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Tulosta kaikki langat kuten ne on kielellesi käännetty. Tämä auttaa hahmottamaan virheitä jotka liittyvät kansainvälistykseen."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Näytä versiotiedot ja poistu."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Näytä tämä opas."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Näytä tämä apu kaikkien asetusvaihtoehtojen kanssa."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -493,12 +494,12 @@ msgid ""
 msgstr "Lataa annettu pelitallennus- tai pelitoisinto suoraan. Käytännöllinen .wgf/.wry tiedostopäätteiden suhteen. Ei toimi muiden vaihtoehtojen kanssa. Katso myös --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Tämä on Widelandsin julkaisu %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/fr.po
+++ b/data/i18n/translations/widelands_console/fr.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Renaud Bouchard, 2015-2022,2024\n"
 "Language-Team: French (http://app.transifex.com/widelands/widelands/language/fr/)\n"
@@ -67,7 +67,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "NOMDUDOSSIER"
 
@@ -149,7 +149,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Lance le Script Lua indiqué après initiallisation. Ne fonctionne qu'avec --scenario, --loadgame, ou --editor"
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Démarre le jeu avec le son désactivé."
 
@@ -157,87 +157,87 @@ msgstr "Démarre le jeu avec le son désactivé."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[vrai*|faux]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Jouer la musique d'intro au démarrage et afficher l'image d'accueil jusqu'à la fin."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Force Widelands à crasher quand une erreur Lua survient."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Supprimer les rediffusions automatiquement après `n` semaines."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Active le mode entrainement de l'IA. Voir https://www.widelands.org/wiki/Ai%20Training/ pour une description complète de la logique d'apprentissage de l'IA."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Ajuste la vitesse de jeu en permanence et automatiquement en fonction du délai de l'IA. À n'utiliser que pour tester ou entraîner l'IA (avec --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Activer le script en console et le mode triche"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Options de jeu :"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Remarque : Les nouvelles valeurs seront écrites dans le fichier de configuration."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Enregistrez automatiquement toutes les `n` minutes."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Utiliser 'n' fichiers pour la rotation des sauvegardes automatiques."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Ne pas créer de sauvegarde automatique lorsque l'utilisateur a été inactif depuis la dernière sauvegarde automatique."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Ne pas sauver les fichiers en archives zip binaires."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Sauver les fichiers en tant qu'archives zip binaires."
 
@@ -245,254 +245,255 @@ msgstr "Sauver les fichiers en tant qu'archives zip binaires."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[vrai|faux*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "S'il faut enregistrer l'historique des messages de chat envoyés dans un fichier"
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Afficher les noms de fichiers dans l'écran de relecture."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Si un avertissement doit être affiché dans l'éditeur s'il y a trop de joueurs."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Mettre le jeu en pause après `n` minutes d'inactivité de l'utilisateur."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Commencez à construire une route après avoir placé un drapeau."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Bitmask des drapeaux d'affichage à définir pour les nouveaux jeux."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Faire défiler lorsque le curseur de la souris est près du bord de l'écran."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Inverser la direction de déplacement de la carte par cliquer-glisser."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Autoriser le défilement en diagonale avec le pavé numérique."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Afficher l'heure du système dans le panneau d'informations."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Utiliser le mode de fenêtre de surveillance unique."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Afficher le chat dans le jeu avec un fond transparent."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bitmask pour définir l'emplacement et le mode de la barre d'outils."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Réseautage :"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Connectez-vous à un autre métaserveur pour les jeux sur Internet."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Port numéro 'n' du métaserveur pour jouer en ligne."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Nom du dernier jeu hébergé."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "Le pseudo utilisé pour les jeux en local et en ligne."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Nom de l'auteur de la carte."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Le dernier hôte connecté."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Si l'identifiant du métaserveur utilisé est pour un utilisateur enregistré."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Le mot de passe haché pour les connexions en ligne."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Connecter à une adresse de serveur différente depuis le gestionnaire d'add-ons."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Connecter à un port de serveur différent depuis le gestionnaire d'add-ons."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Créez des fichiers de dump syncstream pour aider à déboguer les jeux en réseau."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Options graphiques :"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Utiliser l'écran entier pour l'écran du jeu."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Démarre le jeu dans une fenêtre agrandie au maximum."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Largeur 'x' de la fenêtre en pixels."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Hauteur 'y' de la fenêtre en pixels."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Laisser ou non le système dessiner le curseur de la souris. Ne désactiver que si le curseur n'apparait pas correctement, ou s'il vous voulez qu'il soit visible dans les captures d'écran et les diffusions."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Si vous souhaitez utiliser des info-bulles collantes."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Chemin d'accès au thème d'IU actif, par rapport au répertoire d'accueil de Widelands."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Options pour le gestionnaire de fenêtre interne :"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Si les mouvements automatiques de la carte doivent être animés."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Déplace une fenêtre vers le bord de l'écran lorsque le bord de la fenêtre se trouve à une distance `n` du bord de l'écran."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Élimine la bordure d'une fenêtre vers le bord de l'écran lorsque le bord de la fenêtre est à côté du bord de l'écran."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Déplace une fenêtre vers le bord du panneau lorsque le bord de la fenêtre se trouve à une distance de `n` du bord du panneau."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Activer les messages de débogage détaillés"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Autres :"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "écrire toutes les chaines de caractères quand elles sont traduites. Ceci aide à identifier les problèmes avec l'internationalisation."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Juste indiquer la version et quitter."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Afficher cette aide."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Afficher cette aide avec toutes les options de configurations disponibles."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -500,12 +501,12 @@ msgid ""
 msgstr "Charge la sauvegarde indiquée ou la rejoue directement. Utile pour l'association d'extension de fichiers .wgf/.wry. Ne fonctionne pas avec d'autres options. Voir aussi --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Ceci est la version%sde Widelands"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/fy.po
+++ b/data/i18n/translations/widelands_console/fy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Luitzen Hietkamp <luitzenhietkamp@gmail.com>, 2017\n"
 "Language-Team: Western Frisian (http://app.transifex.com/widelands/widelands/language/fy/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ga.po
+++ b/data/i18n/translations/widelands_console/ga.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Irish (http://app.transifex.com/widelands/widelands/language/ga/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/gd.po
+++ b/data/i18n/translations/widelands_console/gd.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: GunChleoc, 2016-2018,2021\n"
 "Language-Team: Gaelic, Scottish (http://app.transifex.com/widelands/widelands/language/gd/)\n"
@@ -57,7 +57,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "AINM-PASGAIN"
 
@@ -139,7 +139,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -147,87 +147,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[fìor*|breug]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Roghainnean a’ gheama:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -235,254 +235,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[fìor|breug*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Lìonrachadh:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Roghainnean grafaigeachd:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Roghainnean airson manaidsear nan uinneagan taobh a-staigh:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Cuir teachdaireachdan dì-bhugachaidh briathrach an comas"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Roghainnean eile:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -490,12 +491,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/gl.po
+++ b/data/i18n/translations/widelands_console/gl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Galician (http://app.transifex.com/widelands/widelands/language/gl/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/he.po
+++ b/data/i18n/translations/widelands_console/he.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hebrew (http://app.transifex.com/widelands/widelands/language/he/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/hi.po
+++ b/data/i18n/translations/widelands_console/hi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hindi (http://app.transifex.com/widelands/widelands/language/hi/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/hr.po
+++ b/data/i18n/translations/widelands_console/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Ivan Bižaca <biza@malilosinj.info>, 2023\n"
 "Language-Team: Croatian (http://app.transifex.com/widelands/widelands/language/hr/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Započni igru sa isključenim zvukom"
 
@@ -143,87 +143,87 @@ msgstr "Započni igru sa isključenim zvukom"
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Automatski spremi svakih `n` minuta."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Zaustavi igru nakon `n` minuta neaktivnosti korisnika."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/hu.po
+++ b/data/i18n/translations/widelands_console/hu.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Tóth András <txa-dev@posteo.hu>, 2021-2024\n"
 "Language-Team: Hungarian (http://app.transifex.com/widelands/widelands/language/hu/)\n"
@@ -66,7 +66,7 @@ msgstr "widelands <mentés.wgf>/<visszajátszás.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "KÖNYVTÁR"
 
@@ -148,7 +148,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "A megadott Lua parancsfájl futtatása betöltés után. Csak a --scenario, --loadgame vagy --editor kapcsolókkal együtt használható."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Hang kikapcsolása."
 
@@ -156,87 +156,87 @@ msgstr "Hang kikapcsolása."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "A Widelands összeomlásra kényszerítése Lua hiba esetén."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Visszajátszások automatikus törlése `n` hét után."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "A mesterséges intelligencia tanító mód bekapcsolása. Részletes leírás: https://www.widelands.org/wiki/Ai%20Training/"
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "A játék sebességének automatikus változtatása a mesterséges intelligencia lemaradásától függően. Csak a mesterséges intelligencia teszteléséhez és tanításához használható (az --ai_training kapcsolóval együtt)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "A parancsértelmező ablak és a csalások bekapcsolása."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Játék beállítások:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Megjegyzés: Az új érték el lesz mentve a beállító fájlba."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Automatikus mentés `n` percenként."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Megőrzendő automatikus mentések számának beállítása."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Automatikus mentések kihagyása, ha a felhasználó a legutóbbi mentés óta nem csinált semmit."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "A mentések zip formátumba való tömörítésének kikapcsolása."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "A mentések zip formátumba való tömörítésének bekapcsolása."
 
@@ -244,254 +244,255 @@ msgstr "A mentések zip formátumba való tömörítésének bekapcsolása."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Az elküldött csevegés üzenetek előzményeinek mentése fájlba. (igen/nem)"
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Fájlnevek megjelenítése visszajátszás kiválasztásakor. (igen/nem)"
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Figyelmeztetés a térképszerkesztőben túl sok játékos beállítása esetén. (igen/nem)"
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "A játék megállítása, ha a felhasználó `n` percig nem csinált semmit."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Útépítés megkezdése zászló elhelyezése után."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Megjelenítési beállítások bittérképe új játék indításakor."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Térkép mozgatása amikor az egérmutató a kép szélén van."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Jobb egérgombos térképmozgatás irányának megfordítása."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Átlós térképmozgatás engedélyezése a numerikus billentyűzet használatával."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Valós idő megjelenítése a tálcán."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Egy figyelőablakos mód."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Játék közbeni csevegés átlátszó háttérrel mutatása."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Az eszközsor helyének és beállításának bittérképe."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Hálózat:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Az internetes játékokhoz használandó metakiszolgáló beállítása."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Az internetes játékokhoz használt metakiszolgáló portjának beállítása."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Az utolsó létrehozott hálózati játék neve."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "A helyi és internetes hálózati játékokban használt becenév."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "A térkép szerzője."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Az utoljára használt gazdagép."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Az internetes játékokhoz használt bejelentkezési név regisztrálva van. (igen/nem)"
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Az internetes játékokhoz használt kódolt jelszó."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "<IP-cím>"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "A bővítménykezelő által használandó kiszolgáló címének beállítása."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "A bővítménykezelő által használandó kiszolgáló portjának beállítása."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Szinkronizációs naplófájlok létrehozása a hálózati játékok hibakeresésének megkönnyítésére."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Grafikai kapcsolók:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Teljes képernyős üzemmód használata."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Játék indítása kinagyított ablakban."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "A programablak szélessége képpontokban."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "A programablak magassága képpontokban."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Tartós eszköztippek használata. (igen/nem)"
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Az aktív felhasználói felület téma elérési útja a saját Widelands könyvtártól."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Kapcsolók a belső ablakkezelőhöz:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Automatikus térképmozgások animálása. (igen/nem)"
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Ablakok képernyő széléhez igazítása a megadott távolságon belül."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Ablakok keretének elrejtése, ahol hozzáérnek a képernyő széléhez. (igen/nem)"
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Ablakok tálcához igazítása a megadott távolságon belül."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Bővebb hibakeresési üzenetek használata."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Egyéb:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Minden szöveg kiírása a fordítás betöltésekor a fordítás miatti hibák könnyebb azonosítása érdekében."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Csak a verzió kiírása."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Ennek a súgónak a megjelenítése."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Súgó megjelenítése minden elérhető beállítással."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<mentés.wgf>/<visszajátszás.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -499,12 +500,12 @@ msgid ""
 msgstr "A megadott mentés vagy visszajátszás közvetlen betöltése. A .wgf/.wry fájltípus hozzárendeléséhez használható. Más beállításokkal együtt nem működik. Lásd még: --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Ez a Widelands %s verziója"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/id.po
+++ b/data/i18n/translations/widelands_console/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Gerben Danen <geppyz@gmail.com>, 2024\n"
 "Language-Team: Indonesian (http://app.transifex.com/widelands/widelands/language/id/)\n"
@@ -53,7 +53,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "NAMADIREKTORAT"
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Jalankan skrip Lua yang diberikan setelah inisialisasi. Hanya berlaku dengan --scenario, --loadgame, atau --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Memulai permainan dengan suara dinonaktifkan."
 
@@ -143,87 +143,87 @@ msgstr "Memulai permainan dengan suara dinonaktifkan."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[benar*|salah]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Memaksa Widelands untuk macet saat terjadi kesalahan Lua."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Menghapus pemutaran ulang secara otomatis setelah `n` minggu."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Mengaktifkan mode pelatihan AI. Lihat https://www.widelands.org/wiki/Ai%20Training/ untuk deskripsi lengkap tentang logika pelatihan AI."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Secara konstan menyesuaikan kecepatan permainan secara otomatis tergantung pada penundaan AI. Hanya digunakan untuk pengujian atau pelatihan AI (bersama dengan --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Aktifkan Konsol Naskah dan Mode Curang."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Opsi permainan:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Catatan: Nilai baru akan dituliskan ke file konfigurasi."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Secara otomatis menyimpan setiap `n` menit."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Gunakan file `n` untuk menggulirkan penyimpanan otomatis."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Jangan membuat penyimpanan otomatis ketika pengguna tidak aktif sejak penyimpanan otomatis terakhir."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Jangan menyimpan file sebagai arsip zip biner."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Menyimpan file sebagai arsip zip biner."
 
@@ -231,254 +231,255 @@ msgstr "Menyimpan file sebagai arsip zip biner."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[benar|salah*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Apakah akan menyimpan riwayat pesan obrolan yang dikirim ke file."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Menampilkan nama file di layar pemutaran ulang."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Apakah peringatan harus ditampilkan di editor jika ada terlalu banyak pemain."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Jeda permainan setelah `n` menit tidak ada aktivitas pengguna."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Mulailah membangun jalan setelah memasang bendera."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Bitmask bendera tampilan untuk mengatur game baru."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Hanya versi cetak dan keluar."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Tunjukkan bantuan ini."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Tampilkan bantuan ini dengan semua opsi konfigurasi yang tersedia."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Ini adalah versi Widelands %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ig.po
+++ b/data/i18n/translations/widelands_console/ig.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: AhaNkem Obi <litoretura@gmail.com>, 2017\n"
 "Language-Team: Igbo (http://app.transifex.com/widelands/widelands/language/ig/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/it.po
+++ b/data/i18n/translations/widelands_console/it.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Guybrush88 <erpizzo@alice.it>, 2015,2021\n"
 "Language-Team: Italian (http://app.transifex.com/widelands/widelands/language/it/)\n"
@@ -60,7 +60,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -142,7 +142,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -150,87 +150,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -238,254 +238,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Opzioni grafiche:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Opzioni per il  window manager interno:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -493,12 +494,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ja.po
+++ b/data/i18n/translations/widelands_console/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: tamanegi, 2018\n"
 "Language-Team: Japanese (http://app.transifex.com/widelands/widelands/language/ja/)\n"
@@ -54,7 +54,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -144,87 +144,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -232,254 +232,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "グラフィックオプション:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "内部ウィンドウマネージャーのオプション:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -487,12 +488,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ka.po
+++ b/data/i18n/translations/widelands_console/ka.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Georgian (http://app.transifex.com/widelands/widelands/language/ka/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ko.po
+++ b/data/i18n/translations/widelands_console/ko.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: ks k, 2017,2020-2021\n"
 "Language-Team: Korean (http://app.transifex.com/widelands/widelands/language/ko/)\n"
@@ -58,7 +58,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "번역확인->DIRNAME"
 
@@ -140,7 +140,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -148,87 +148,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "번역확인->n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "놀이 선택사항:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -236,254 +236,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "네트워킹:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "아이피"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "그래픽 선택사항:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "내부 창 관리자 선택사항:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "디버그 메시지를 사용 설정"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "기타:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "번역된 모든 문자열을 인쇄합니다. 이것은 국제화(번역)로 버그를 추적하는 데 도움이 됩니다."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -491,12 +492,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/krl.po
+++ b/data/i18n/translations/widelands_console/krl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Karelian (http://app.transifex.com/widelands/widelands/language/krl/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/la.po
+++ b/data/i18n/translations/widelands_console/la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Leonard Noack, 2016\n"
 "Language-Team: Latin (http://app.transifex.com/widelands/widelands/language/la/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/lt.po
+++ b/data/i18n/translations/widelands_console/lt.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Lithuanian (http://app.transifex.com/widelands/widelands/language/lt/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ms.po
+++ b/data/i18n/translations/widelands_console/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: abuyop <abuyop@gmail.com>, 2015,2017\n"
 "Language-Team: Malay (http://app.transifex.com/widelands/widelands/language/ms/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Pilihan grafik:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Pilihan untuk pengurus tetingkap dalaman:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/nb.po
+++ b/data/i18n/translations/widelands_console/nb.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Gregers K-Hansen <gregers86@me.com>, 2021\n"
 "Language-Team: Norwegian Bokmål (http://app.transifex.com/widelands/widelands/language/nb/)\n"
@@ -54,7 +54,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "DIRNAME"
 
@@ -136,7 +136,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -144,87 +144,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -232,254 +232,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Innstillinger for grafikk:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Valg for intern vindusbehandler:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -487,12 +488,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/nds.po
+++ b/data/i18n/translations/widelands_console/nds.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Benedikt Straub <benedikt-straub@web.de>, 2018-2024\n"
 "Language-Team: Low German (http://app.transifex.com/widelands/widelands/language/nds/)\n"
@@ -53,7 +53,7 @@ msgstr "widelands <Sekert.wgf>/<Upteken.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "VERTEEKNIS"
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Start dat angeven Lua-Skript na de Begünn. Gaht blot mit --scenario, --loadgame of --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Dat Speel sünner all Gedrüüs opmaken."
 
@@ -143,87 +143,87 @@ msgstr "Dat Speel sünner all Gedrüüs opmaken."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[jau*|nee]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Spööl de Begröten-Musik bi’m Starten un wies de Begröten-Billschirm, bit se ennt."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Dwingt Widelands tum Ofstörten, wenn een Lua-Fehler passeert."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Uptekens na `n` Weken automatisk lösken."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Knipst de KS-Öven an. Kiek https://www.widelands.org/wiki/Ai%20Training/ an, um mehr daaröver to lesen."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "De Speel-Gauheid all de Tied an dat Hentrecken vun de künstelk Spelers anpassen. Bruuk dat blot bi’m Utprobeeren of Öven vun de künstelk Spelers (tosamen mit --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "De Ingaav för Schrievens un de Bescheten-Modus verlöven."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Speel-Instellens:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Wahrschau: Neje Weerten worden in de Instellens-Datei schreven."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "All `n` Menüten automatisk sekern."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "`n` Dateien vum automatisk Sekern ofheven."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Nich automatisk sekern, wenn de Bruker sied de leste automatisk Sekern inaktiv wesen is."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Dateien nich as Binäär-Zip-Archiven sekern."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Dateien as Binäär-Zip-Archiven sekern."
 
@@ -231,254 +231,255 @@ msgstr "Dateien as Binäär-Zip-Archiven sekern."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[jau|nee*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Of de Histoorje vun sent Snack-Narichtens in eener Datei sekert worden sall."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Dateinamen im Uptekens-Menü wiesen."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Of de Bewarker nafragen sall, wenn ’t to völe Spelers gifft."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Dat Speel anhollen, wenn de Bruker `n` Menüten inaktiv weer."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Na de Fahnenbauen Straat bauen."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "De Bit-Tosamensetten vun de Wiesen-/Verbargen-Instellens för neje Spelen."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Kaart-Sicht verschuven, wenn de Muuswieser dicht bi de Billschirm-Rand is."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Kaart-Klick-un-Treck-Richtung umdreihen."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Diagonales Kaart-Verschuven mit de Tahlenblock verlöven."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Systeemtied in de Infobalken wiesen."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Blot een Beluren-Fenster bruken."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Wies de Snack im Speel sünner Achtergrund."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bit-Tosamensetten för de Stee un Utsehen vun de Infobalken."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Netwark:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Eenen annern Metaserver för dat Spölen över ’t Internett bruken."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Port-Tahl `n` för de Metaserver för dat Spölen över ’t Internett"
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "De Naam vun de tolest beweert Speel."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "De Spitznaam för all de Internett-Spelen."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Kaart-Schriever-Naam."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "De tolest verbunnen Weert."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Of dat leste Anmellen bi de Metaserver as vermarkt Bruuker weer."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Dat verslötelt Passwoord för ’t Internett-Anmellen."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Vun de Verwiederns-Verwalter mit eener anner Server-Adress verbinnen."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Vun de Verwiederns-Verwalter mit eenem anner Server-Port verbinnen."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Sync-Streamen in Internett-Speelen schrieven, um Verschuvens to unnersöken."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Biller-Instellens:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "De hele Billschirm för dat Speel bruken."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Dat Speel in eenem ganz groten Fenster starten."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Breddt `x` vun de Fenster, in Billpunkten."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Höcht `y` vun de Fenster, in Billpunkten."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Of dat Systeem de Muuswieser teken sall. Knips dat blots dann ut, wenn de Muuswieser nich recht tekent word, of wenn dat in Billschirmfotos of Billschirm-Uptekens to sehn wesen sall."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Of Muushülptexten faststeckt worden sallen."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "De Padd to de anknipst Bruker-Schnittstee-Thema vun de Heem-Verteeknis ut."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Instellens för de Fenster-Verwaltung im Speel:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Of automatiske Kaart-Bewegens spöölt worden sallen."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Een Fenster word an de Billschirmrann sett, wenn siene Kant nich wieder as `n` vun de Billschirmrann weg is."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "De Fensterrann word am Billschirmrann nich wiesen, wenn de Fensterrann am Billschirmrann liggt."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Een Fenster word to de Rann vun eenem Paneel sett, wenn sien Rann nich wieder as `n` vun de Rann vun de Paneel weg is."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Unbannig völe Narichten utgeven"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Wat ’t sünst noch so gifft:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "All Texten bi’m Översetten utgeven. Dat hülpt daarbi, Fehlers in de Översetten to finnen."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Blot Versioon utgeven un ennen."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Deese Hülp wiesen."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Deese Hülp un all de Instellens, wat ’t gifft, wiesen."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<Sekert.wgf>/<Upteken.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr "Stracks dat geven sekert Speel of Upteken laden. Gadelk för .wgf-/.wry-Dateinaam-Verknüppens. Anner Instellens worden nich annohmen. Kiek ok an: --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Dat is Widelands-Versioon %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/nl.po
+++ b/data/i18n/translations/widelands_console/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Alex Rijckaert, 2023-2024\n"
 "Language-Team: Dutch (http://app.transifex.com/widelands/widelands/language/nl/)\n"
@@ -58,7 +58,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "FOLDERNAAM"
 
@@ -140,7 +140,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Voer het gegeven Lua-script uit na initialisatie. Alleen geldig met --scenario, --loadgame of --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Start het spel met uitgeschakeld geluid."
 
@@ -148,87 +148,87 @@ msgstr "Start het spel met uitgeschakeld geluid."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Speel de intromuziek af bij het opstarten en laat een splash-afbeelding zien totdat deze eindigt."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Laat Widelands crashen als er een Lua-fout optreedt."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Verwijder herhalingen automatisch na `n` weken."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "AI-trainingsmodus inschakelen. Zie https://www.widelands.org/wiki/Ai%20Training/ voor een volledige beschrijving van de AI-trainingslogica."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Past de spelsnelheid automatisch aan afhankelijk van de AI-vertraging. Alleen te gebruiken voor AI-tests of training (in combinatie met --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Schakel de Scriptconsole en Valsspeelmodus in."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Spel opties:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Opmerking: Nieuwe waarden worden naar het configuratiebestand geschreven."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Automatisch opslaan na `n` minuten."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Gebruik `n` bestanden voor lopende autosaves."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Maak geen autosave aan als de gebruiker inactief is geweest sinds de laatste autosave."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Sla bestanden niet op als binaire zip-archieven."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Bestanden opslaan als binaire zip-archieven."
 
@@ -236,254 +236,255 @@ msgstr "Bestanden opslaan als binaire zip-archieven."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Of de geschiedenis van verzonden chatberichten moet worden opgeslagen in een bestand."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Bestandsnamen weergeven in het afspeelscherm."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Of er een waarschuwing moet worden weergegeven in de editor als er te veel spelers zijn."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Het spel pauzeren na `n` minuten van inactiviteit van de gebruiker."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Begin met het bouwen van een weg na het plaatsen van een vlag."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Bitmask van weergave-flags om in te stellen voor nieuwe spellen."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Scrollen wanneer de muiscursor zich dicht bij de schermrand bevindt."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "De bewegingsrichting van de klik-en-sleep-kaart omkeren."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Sta diagonaal scrollen toe met het toestenblok"
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Systeemtijd weergeven in het infopaneel."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Gebruik de enkelvoudige watchwindow-modus."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "In-game chat weergeven met transparante achtergrond."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bitmask om de locatie en modus van de werkbalk in te stellen."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Netwerk:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Maak verbinding met een andere metaserver voor internetgaming."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Poortnummer `n` van de metaserver voor internetgaming."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "De naam van het laatst gehoste spel."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "De bijnaam die wordt gebruikt voor LAN- en onlinespellen."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Naam van de maker van de kaart."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "De laatste host waarmee verbinding is gemaakt."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Of de gebruikte metaserver login voor een geregistreerde gebruiker is."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Het gecodeerde wachtwoord voor online inloggen."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Maak verbinding met een ander serveradres vanuit de add-ons manager."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Maak verbinding met een andere serverpoort vanuit de add-ons manager."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Maak synchronisatie-dumpbestanden om te helpen bij het debuggen van netwerkspellen."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Grafische opties:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Gebruik het hele scherm voor het gamescherm."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Start het spel in een gemaximaliseerd venster."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Breedte `x` van het venster in pixels."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Hoogte `y` van het venster in pixels."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Of het systeem de muiscursor mag tekenen. Schakel dit alleen uit als de cursor niet goed verschijnt, of als je wilt dat deze zichtbaar is in screenshots of screencasts."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Of klevende tooltips moeten worden gebruikt."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Het pad naar het actieve UI-thema, ten opzichte van de Widelands thuismap."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Opties voor de interne vensterbeheerder:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Of automatische kaartbewegingen moeten worden geanimeerd."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Verplaats een venster naar de rand van het scherm als de rand van het venster binnen een afstand `n` van de rand van het scherm komt."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Elimineer de rand van een venster naar de rand van het scherm wanneer de rand van het venster zich naast de rand van het scherm bevindt."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Verplaats een venster naar de rand van het paneel wanneer de rand van het venster binnen een afstand van `n` van de rand van het paneel komt."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Activeer uitgebreide debug berichten"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Overige:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Print allle zinnen als ze worden vertaald. Dit helpt met het opsporen van fouten in de internationalisering."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Alleen versie afdrukken en afsluiten."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Toon deze help."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Toon deze help met alle beschikbare configuratieopties."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -491,12 +492,12 @@ msgid ""
 msgstr "Laadt de opgegeven savegame of replay direct. Nuttig voor .wgf/.wry bestandsextensie associatie. Werkt niet met andere opties. Zie ook --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Dit is Widelands versie %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/nn.po
+++ b/data/i18n/translations/widelands_console/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Thorbjørn Bruarøy, 2015\n"
 "Language-Team: Norwegian Nynorsk (http://app.transifex.com/widelands/widelands/language/nn/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/pl.po
+++ b/data/i18n/translations/widelands_console/pl.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Leszek Szary, 2024\n"
 "Language-Team: Polish (http://app.transifex.com/widelands/widelands/language/pl/)\n"
@@ -63,7 +63,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "NAZWAKATALOGU"
 
@@ -145,7 +145,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Uruchom dany skrypt Lua po inicjalizacji. Obowiązuje tylko z --scenariusz, --wczytajgrę lub --edytor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Uruchom grę z wyłączonym dźwiękiem."
 
@@ -153,87 +153,87 @@ msgstr "Uruchom grę z wyłączonym dźwiękiem."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Odtwórz muzykę intro przy uruchomieniu i wyświetlaj obraz powitalny dopóki się nie zakończy."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Wymuś wysypanie się Widelands kiedy nastąpi błąd Lua."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Usunięcie powtórki autmatycznie po `n` tygodniach."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Włącz tryb szkolenia SI. Zobacz na https://www.widelands.org/wiki/Ai%20Training/ po pełny opis szkolenia logicznego SI."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Automatycznie dopasowywuj na bieżąco prędkość gry zależnie od opóźnienia SI. Używaj tylko dla testowania lub treningu SI (w połączeniu z --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Aktywuj Skrypy konsolowy i Tryb Oszukiwania"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Opcje gry:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Notka: Nowe wartości zostaną zapisane do pliku konfiguracyjnego."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Automatycznie zapisuj co `n` minut."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Użyj `n` plików do automatycznych zapisów."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Nie tworzy autozapisu automatycznie kiedy użytkownik był nieaktywny od czasu ostatniego autozapisu."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Nie zapisuj plików jako binarnych archiwów zip."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Zapisz pliki jaki binarne archiwa zip."
 
@@ -241,254 +241,255 @@ msgstr "Zapisz pliki jaki binarne archiwa zip."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Zapisz historię wysłanych wiadomości na chacie do pliku."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Pokaż nazwy plików w ekranie powtórek."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Czy ostrzeżenie powinno być pokazane w edytorze jeśli jest za dużo graczy."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Zatrzymaj grę po `n` minutach nieaktywności użytkownika."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Zacznij budować drogę po ustawieniu flagi."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Ustaw wyświetlanie maski bitowej flag dla nowej gry."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Przewijaj kiedy kursor myszy jest u krawędzi ekranu."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Odwróć kliknij-i-przeciągnij kierunki ruchu mapy."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Pozwól na przesuwanie po skosie używając klawiszy numerycznych."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Wyświetlaj czas systemu w panelu informacyjnym."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Użyj trybu pojedynczego okna wyświetlania."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Pokazuj okno czatu w grze z przezroczystym tłem."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Ustawienia Bitmaski do lokacji i trybu paska narzędzi."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Sieć:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Połącz z innym metaserwerem dla gry internetowej."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Port numer `n` metaserwera dla gry internetowej."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Nazwa ostatniej hostowanej gry."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "Nick użyty w grze LAN oraz gry internetowej."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Imię autora mapy."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Ostatni połączony host."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Czy login metaserwera jest dla zarejestrowanego użytkownika."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Zahaszowane hasło dla internetowych loginów."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Połącz z innym adresem serwera z menadżera dodatków."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Połącz z innym portem serwera z menadżera dodatków."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Stwórz pliki strumienia synchronizacji by pomóc debugować grę sieciową."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Opcje graficzne:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Użyj pełnego wyświetlania dla ekranu gry."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Uruchom grę w zmaksymalizowanym oknie."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Szerokość `x` okna w pikselach."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Wysokość `y` okna w pikselach."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Określa, czy to system ma rysować kursor myszy. Wyłącz tę opcję tylko wtedy, gdy kursor nie jest wyświetlany prawidłowo lub jeśli chcesz, aby był on widoczny na zrzutach ekranu lub nagraniach."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Czy używać stałych tooltipów."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Ścieżka aktywnego motywu interfejsu, związanego z domowym katalogiem Widelands."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Opcje wewnętrznego menedżera okien:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Czy automatyczne ruchy mapy powinny być animowane."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Przenieś okno do krawędzi ekranu, gdy krawędź okna znajdzie się w odległości `n` od krawędzi ekranu."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Wyeliminuj granicę okna w kierunku krawędzi ekranu, gdy krawędź okna znajduje się obok krawędzi ekranu."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Przenieś okno do krawędzi panelu, gdy krawędź okna znajdzie się w odległości `n` od krawędzi panelu"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Włącz rozwlekłe wiadomości debugowania"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Inne:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Wydrukuj wszystkie strumienie tak jak zostały przetłumaczone.  To pomaga śledzić błędy z różnych krajów."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Wydrukuj tylko wersję i wyjdź."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Pokaż tą pomoc."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Pokaż tą pomoc ze wszystkimi dostępnymi opcjami konfiguracji."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -496,12 +497,12 @@ msgid ""
 msgstr "Załaduj bezpośrednio otrzymane zapisy gry lub powtórki. Użyteczne dla .wgf/.wrpl zrzeszenia rozszerzeń. Nie działa z innymi opcjami. Zobacz także --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Wersja Widelands: %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/pt.po
+++ b/data/i18n/translations/widelands_console/pt.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: GunChleoc, 2015,2020\n"
 "Language-Team: Portuguese (http://app.transifex.com/widelands/widelands/language/pt/)\n"
@@ -57,7 +57,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -139,7 +139,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -147,87 +147,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -235,254 +235,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Opções Gráficas:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Opções para o gestor de janelas interno:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -490,12 +491,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/pt_BR.po
+++ b/data/i18n/translations/widelands_console/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Daniel San <daniel1977.br@gmail.com>, 2017\n"
 "Language-Team: Portuguese (Brazil) (http://app.transifex.com/widelands/widelands/language/pt_BR/)\n"
@@ -54,7 +54,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -144,87 +144,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -232,254 +232,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Opções de vídeo:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Opções do gerenciador interno de janela:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -487,12 +488,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ro.po
+++ b/data/i18n/translations/widelands_console/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Tarța Vasile-Florin <florin13t@gmail.com>, 2016\n"
 "Language-Team: Romanian (http://app.transifex.com/widelands/widelands/language/ro/)\n"
@@ -53,7 +53,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -143,87 +143,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -231,254 +231,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -486,12 +487,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/ru.po
+++ b/data/i18n/translations/widelands_console/ru.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Yuriy Sokolov <lention@mail.ru>, 2015,2022-2024\n"
 "Language-Team: Russian (http://app.transifex.com/widelands/widelands/language/ru/)\n"
@@ -64,7 +64,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "DIRNAME"
 
@@ -146,7 +146,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Выполнить указанный код Lua после инициализации. Действительно только вместе с --scenario, --loadgame или --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Запустить игру с отключенным звуком."
 
@@ -154,87 +154,87 @@ msgstr "Запустить игру с отключенным звуком."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr "Воспроизводить вступительную музыку при запуске и показывать заставку до тех пор, пока она не закончится."
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Принудительно завершить программу, если сценарий Lua вызвал ошибку."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Удалять повторы автоматически через `n` недель."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Включить режим самообучения ИИ. Здесь - https://www.widelands.org/wiki/Ai%20Training/ - описана логика обучения ИИ."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Автоматическая регулировка скорости игры в зависимости от задержки искусственного интеллекта. Используется только для тестирования или обучения ИИ (в сочетании с --ai_trining)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr "Включите консоль скриптов и режим читов."
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Настройка игры:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Заметьте: новые значения будут добавлены в файл настроек."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Автосохранение каждые `n` минут."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Выделить под откатываемое автосохранение `n` файлов."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr "Не создавать автосохранение, если пользователь был неактивен с момента последнего автосохрананения игры."
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Не сжимать сохранения в архивы."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr "Сохранять файлы в zip-архивах."
 
@@ -242,254 +242,255 @@ msgstr "Сохранять файлы в zip-архивах."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr "Следует ли сохранять историю отправленных сообщений чата в файл."
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Показывать названия файлов в окне повторов."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Должно ли отображаться предупреждение в редакторе, если игроков слишком много."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr "Ставить игру на паузу после `n` минут бездействия пользователя."
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Начинать строительство дороги сразу после установки флага."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Битовая маска отображаемых флагов для установки новых игр."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Сдвигать обзор, когда курсор близок к краю экрана."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Обратить движение карты при click-and-drag (щелчке и перетаскивании)"
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Разрешить сдвиг обзора по диагонали с применением цифровых клавиш."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Показывать системное время на информационной панели."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Используйте режим одиночного окна наблюдения."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Показывать внутри-игровой чат на прозрачном фоне."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Битовая маска для установки местоположения и режима панели инструментов."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Сеть:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Подключиться к другому метасерверу для сетевой игры."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Занять порт  `n` метасерером для игры в Интеренете."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Название последней сетевой игры."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "Ник для сетевой игры, будь то LAN или по Интернету."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Имя автора карты."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Последний подключенный сервер."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Используется ли вход на метасервер для зарегистрированного пользователя."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Хэш пароля для сетевых игр."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Подключитесь к другому адресу сервера из менеджера дополнений."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Подключитесь к другому порту сервера из менеджера дополнений."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Создавайте файлы дампа syncstream, чтобы облегчить отладку сетевых игр."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Настройки графики:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr "Использовать весь дисплей в качестве игрового экрана."
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr "Запускать игру в развернутом окне."
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Ширина 'x' окна в пикселях."
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Высота 'y'  окна в пикселях."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr "Разрешает системе отрисовывать курсор мыши. Отключайте это только в том случае, если курсор отображается неправильно или если вы хотите, чтобы он был виден на скриншотах или скринкастах."
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Использовать ли липкие всплывающие подсказки."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Путь к активной теме пользовательского интерфейса относительно домашнего каталога Widelands."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Настройки внутреннего оконного менеджера:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Следует ли анимировать автоматические перемещения карты."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Переместить окно к краю экрана, когда край окна находится на расстоянии `n` от края экрана."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Убрать границу окна со стороны края экрана, когда край окна находится рядом с краем экрана."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Переместите окно к краю панели, когда край окна находится на расстоянии \"n\" от края панели."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Включить подробные отладочные сообщения"
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Прочее:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Вывести все строки по факту перевода. Это поможет в поиске багов в интернационализации игры."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Вывести версию игры и выйти."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Показать справку."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Показать справку со всеми доступными параметрами."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -497,12 +498,12 @@ msgid ""
 msgstr "Загрузить данную сохраненную игру или переиграть её. Работает с расширениями файлов .wgf/.wrpl. Не работает с другими опциями. Также смотрите --loadgame/--replay."
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Это версия Widelands %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/sk.po
+++ b/data/i18n/translations/widelands_console/sk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: Pavol Gono, 2024\n"
 "Language-Team: Slovak (http://app.transifex.com/widelands/widelands/language/sk/)\n"
@@ -57,7 +57,7 @@ msgstr "widelands <hra.wgf>/<zaznam.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "ADRESAR"
 
@@ -139,7 +139,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -147,87 +147,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Herné možnosti:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -235,254 +235,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Zobraziť systémový čas v informačnom paneli."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Sieť:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Možnosti grafiky:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Možnosti vnútorného správcu okien:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Ďalšie:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<hra.wgf>/<zaznam.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -490,12 +491,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Toto je Widelands verzie %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/sl.po
+++ b/data/i18n/translations/widelands_console/sl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Slovenian (http://app.transifex.com/widelands/widelands/language/sl/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/sr.po
+++ b/data/i18n/translations/widelands_console/sr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Serbian (http://app.transifex.com/widelands/widelands/language/sr/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/sr_RS.po
+++ b/data/i18n/translations/widelands_console/sr_RS.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Serbian (Serbia) (http://app.transifex.com/widelands/widelands/language/sr_RS/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/sv.po
+++ b/data/i18n/translations/widelands_console/sv.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: D M <kamera001dm@gmail.com>, 2023\n"
 "Language-Team: Swedish (http://app.transifex.com/widelands/widelands/language/sv/)\n"
@@ -56,7 +56,7 @@ msgstr "widelands <save.wgf>/<replay.wry>"
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr "FOLDER"
 
@@ -138,7 +138,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr "Kör det angivna Lua-scriptet efter initieringen. Bara giltigt med --scenario,  --loadgame eller --editor."
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr "Starta spelet med ljudet avstängt."
 
@@ -146,87 +146,87 @@ msgstr "Starta spelet med ljudet avstängt."
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr "[true*|false]"
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr "Tvinga Widelands att krascha när ett Lua-fel uppkommer."
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr "Tag bort repriser automatiskt efter \"n\" veckor."
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr "n"
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr "Möjliggör träningsläge för AI. Se  https://www.widelands.org/wiki/Ai%20Training/ för en fullständig beskrivning av AI träningslogik."
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr "Gör ständiga justeringar av spelhastigheten automatiskt beroende på AI fördröjning. Ska bara användas för test eller träning av AI (i samband med --ai_training)."
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr "Spelalternativ:"
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr "Notera att nya värden kommer att skrivas till konfigurationsfilen."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr "Spara automatiskt varje gång \"n\" minuter har gått."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr "Använd \"n\" filer för rullande automatsparningar."
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr "Spara inte filer som binära zip-arkiv."
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -234,254 +234,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr "[true|false*]"
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr "Visa filnamn i reprisskärmen."
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr "Om en varning ska visas i redigeraren om det är för många spelare."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr "Börja bygga en väg när en flagga har placerats ut."
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr "Bitmask för inställning av flaggvisning i nya spel."
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr "[...]"
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr "Skrolla när muspekaren är nära skärmens kant."
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr "Inverterad flyttriktning vid klicka och drag."
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr "Tillåt diagonal skrollning med det numeriska tangentbordet."
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr "Visa systemtiden i informationspanelen."
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr "Använd läge för ett ensamt övervakningsfönster."
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr "Visa chatten i spelet med genomskinlig bakgrund."
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr "Bitmask för inställning av verktygslistens placering och utformning."
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr "Nätverkande:"
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr "URI"
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr "Anslut till en annan metaserver för internetspel."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr "Metaserverns port \"n\" för internetspel."
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr "Namn på senaste spelet du var värd för."
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr "Användarnamn använt för LAN och onlinespel."
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr "Namn på kartans upphovsman."
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr "Den senaste värden du anslöt till."
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr "Om den använda metaserverns inloggning är för registrerade användare."
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr "Det hashade lösenordet för inloggning online."
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr "IP"
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr "Anslut till en annan serveradress från tilläggshanteraren."
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr "Anslut till en annan serverport från tilläggshanteraren."
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr "Skapa dumpfiler av synkström för att hjälpa till med felsökning av nätverksspel."
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr "Grafikalternativ:"
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr "x"
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr "Fönstrets bredd \"x\" i antal pixlar. "
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr "y"
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr "Fönstrets höjd \"y\" i antal pixlar."
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr "Om klistrade verktygstips ska användas."
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr "Sökvägen till det aktiva UI-temat, relativt till Widelands hemkatalog."
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Alternativ för den interna fönsterhanteraren:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr "Om automatiska kartförflyttningar ska animeras."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr "Flytta ett fönster till skärmens kant när fönstrets kant kommer inom distansen \"n\" från skärmens kant."
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr "Dölj ett fönsters ram mot skärmens kant när fönstrets kant ligger intill skärmens kant."
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr "Flytta ett fönster till kontrollpanelens kant när fönstrets kant kommer inom avståndet \"n\" från kontrollpanelens kant."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr "Möjliggör mångordiga felsökningsmeddelanden."
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr "Annat:"
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr "Skriv ut alla strängar som de är översatta. Detta hjälper till med att hitta fel i internationaliseringen."
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr "Skriv bara version och avsluta."
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr "Visa denna hjälpen."
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr "Visa denna hjälpen med alla tillgängliga konfigurationsalternativ."
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr "<save.wgf>/<replay.wry>"
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -489,12 +490,12 @@ msgid ""
 msgstr "Ladda in det sparade spel eller den sparade repris som anges omedelbart. Användbart för association av filändelserna .wgf och .wry. Fungerar inte med andra inställningsalternativ. Se även --loadgame/--replay. "
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr "Detta är Widelands version %s"
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/tr.po
+++ b/data/i18n/translations/widelands_console/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Turkish (http://app.transifex.com/widelands/widelands/language/tr/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/uk.po
+++ b/data/i18n/translations/widelands_console/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: GunChleoc, 2016\n"
 "Language-Team: Ukrainian (http://app.transifex.com/widelands/widelands/language/uk/)\n"
@@ -55,7 +55,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -145,87 +145,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -233,254 +233,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr "Параметри внутрішнього менеджера вікна:"
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -488,12 +489,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/widelands_console.pot
+++ b/data/i18n/translations/widelands_console/widelands_console.pot
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands svnVERSION\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <widelands-public@lists.sourceforge.net>\n"
@@ -49,7 +49,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -130,346 +130,347 @@ msgid ""
 "loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
 #. * TRANSLATORS: You may translate true/false, also as on/off or yes/no, but
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
 #. * TRANSLATORS: You may translate true/false, also as on/off or yes/no, but
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
-#. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are used in multiplayer
+#. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are used in
+#. * multiplayer
 #.
 #. * TRANSLATORS: games to make sure that there is no mismatch between the players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see --"
@@ -477,12 +478,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/zh_CN.po
+++ b/data/i18n/translations/widelands_console/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Chinese (China) (http://app.transifex.com/widelands/widelands/language/zh_CN/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"

--- a/data/i18n/translations/widelands_console/zh_TW.po
+++ b/data/i18n/translations/widelands_console/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Widelands\n"
 "Report-Msgid-Bugs-To: https://www.widelands.org/wiki/ReportingBugs/\n"
-"POT-Creation-Date: 2024-06-08 02:37+0000\n"
+"POT-Creation-Date: 2024-10-21 03:01+0000\n"
 "PO-Revision-Date: 2015-02-03 14:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Chinese (Taiwan) (http://app.transifex.com/widelands/widelands/language/zh_TW/)\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: ../../../../src/wlapplication_messages.cc:69
 #: ../../../../src/wlapplication_messages.cc:71
 #: ../../../../src/wlapplication_messages.cc:76
-#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:237
 msgid "DIRNAME"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgid ""
 "--loadgame, or --editor."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:118
+#: ../../../../src/wlapplication_messages.cc:119
 msgid "Start the game with sound disabled."
 msgstr ""
 
@@ -142,87 +142,87 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:122
-#: ../../../../src/wlapplication_messages.cc:148
-#: ../../../../src/wlapplication_messages.cc:159
-#: ../../../../src/wlapplication_messages.cc:161
-#: ../../../../src/wlapplication_messages.cc:167
-#: ../../../../src/wlapplication_messages.cc:176
-#: ../../../../src/wlapplication_messages.cc:189
-#: ../../../../src/wlapplication_messages.cc:229
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:160
+#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:177
+#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:231
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "[true*|false]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:123
+#: ../../../../src/wlapplication_messages.cc:124
 msgid "Play the intro music at startup and show splash image until it ends."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:124
+#: ../../../../src/wlapplication_messages.cc:125
 msgid "Force Widelands to crash when a Lua error occurs."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:125
+#: ../../../../src/wlapplication_messages.cc:126
 msgid "Delete replays automatically after `n` weeks."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for a numerical value
-#: ../../../../src/wlapplication_messages.cc:125
-#: ../../../../src/wlapplication_messages.cc:142
-#: ../../../../src/wlapplication_messages.cc:145
-#: ../../../../src/wlapplication_messages.cc:164
-#: ../../../../src/wlapplication_messages.cc:195
-#: ../../../../src/wlapplication_messages.cc:207
-#: ../../../../src/wlapplication_messages.cc:240
-#: ../../../../src/wlapplication_messages.cc:249
+#: ../../../../src/wlapplication_messages.cc:126
+#: ../../../../src/wlapplication_messages.cc:143
+#: ../../../../src/wlapplication_messages.cc:146
+#: ../../../../src/wlapplication_messages.cc:165
+#: ../../../../src/wlapplication_messages.cc:196
+#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:252
 msgid "n"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:127
+#: ../../../../src/wlapplication_messages.cc:128
 msgid ""
 "Enable AI training mode. See https://www.widelands.org/wiki/Ai%20Training/ "
 "for a full description of the AI training logic."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:131
+#: ../../../../src/wlapplication_messages.cc:132
 msgid ""
 "Constantly adjust the game speed automatically depending on AI delay. Only "
 "to be used for AI testing or training (in conjunction with --ai_training)."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:135
+#: ../../../../src/wlapplication_messages.cc:137
 msgid "Enable the Script Console and Cheating Mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Game options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:138
+#: ../../../../src/wlapplication_messages.cc:139
 msgid "Note: New values will be written to the config file."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:144
+#: ../../../../src/wlapplication_messages.cc:145
 msgid "Automatically save each `n` minutes."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:147
+#: ../../../../src/wlapplication_messages.cc:148
 msgid "Use `n` files for rolling autosaves."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:149
+#: ../../../../src/wlapplication_messages.cc:150
 msgid ""
 "Do not create an autosave when the user has been inactive since the last "
 "autosave."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:151
+#: ../../../../src/wlapplication_messages.cc:152
 msgid "Do not save files as binary zip archives."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:152
+#: ../../../../src/wlapplication_messages.cc:153
 msgid "Save files as binary zip archives."
 msgstr ""
 
@@ -230,254 +230,255 @@ msgstr ""
 #. * TRANSLATORS: it HAS TO BE CONSISTENT with the translation in the
 #. widelands textdomain.
 #. * TRANSLATORS: * marks the default value
-#: ../../../../src/wlapplication_messages.cc:157
-#: ../../../../src/wlapplication_messages.cc:181
-#: ../../../../src/wlapplication_messages.cc:183
-#: ../../../../src/wlapplication_messages.cc:185
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:184
+#: ../../../../src/wlapplication_messages.cc:186
 #: ../../../../src/wlapplication_messages.cc:188
-#: ../../../../src/wlapplication_messages.cc:202
-#: ../../../../src/wlapplication_messages.cc:233
-#: ../../../../src/wlapplication_messages.cc:245
+#: ../../../../src/wlapplication_messages.cc:189
+#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:235
+#: ../../../../src/wlapplication_messages.cc:247
 msgid "[true|false*]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:158
+#: ../../../../src/wlapplication_messages.cc:159
 msgid "Whether to save the history of sent chat messages to a file."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:159
+#: ../../../../src/wlapplication_messages.cc:161
 msgid "Show filenames in the replay screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:162
+#: ../../../../src/wlapplication_messages.cc:163
 msgid ""
 "Whether a warning should be shown in the editor if there are too many "
 "players."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:166
+#: ../../../../src/wlapplication_messages.cc:167
 msgid "Pause the game after `n` minutes of user inactivity."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:168
+#: ../../../../src/wlapplication_messages.cc:169
 msgid "Start building a road after placing a flag."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:172
+#: ../../../../src/wlapplication_messages.cc:173
 msgid "Bitmask of display flags to set for new games."
 msgstr ""
 
 #. * TRANSLATORS: The … character is not used on purpose to increase
 #. readability on monospaced
 #. terminals
-#: ../../../../src/wlapplication_messages.cc:172
-#: ../../../../src/wlapplication_messages.cc:191
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:173
+#: ../../../../src/wlapplication_messages.cc:192
 #: ../../../../src/wlapplication_messages.cc:199
 #: ../../../../src/wlapplication_messages.cc:200
 #: ../../../../src/wlapplication_messages.cc:201
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:202
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "[...]"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:182
+#: ../../../../src/wlapplication_messages.cc:183
 msgid "Scroll when the mouse cursor is near the screen edge."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:183
+#: ../../../../src/wlapplication_messages.cc:185
 msgid "Invert click-and-drag map movement direction."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:186
+#: ../../../../src/wlapplication_messages.cc:187
 msgid "Allow diagonal scrolling with the numeric keypad."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:187
+#: ../../../../src/wlapplication_messages.cc:188
 msgid "Display system time in the info panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:188
+#: ../../../../src/wlapplication_messages.cc:189
 msgid "Use single watchwindow mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:190
+#: ../../../../src/wlapplication_messages.cc:191
 msgid "Show in-game chat with transparent background."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:191
+#: ../../../../src/wlapplication_messages.cc:192
 msgid "Bitmask to set the toolbar location and mode."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "Networking:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:193
+#: ../../../../src/wlapplication_messages.cc:194
 msgid "URI"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:194
+#: ../../../../src/wlapplication_messages.cc:195
 msgid "Connect to a different metaserver for internet gaming."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:197
+#: ../../../../src/wlapplication_messages.cc:198
 msgid "Port number `n` of the metaserver for internet gaming."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:198
+#: ../../../../src/wlapplication_messages.cc:199
 msgid "The name of the last hosted game."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:199
+#: ../../../../src/wlapplication_messages.cc:200
 msgid "The nickname used for LAN and online games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:200
+#: ../../../../src/wlapplication_messages.cc:201
 msgid "Name of map author."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:201
+#: ../../../../src/wlapplication_messages.cc:202
 msgid "The last host connected to."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:203
+#: ../../../../src/wlapplication_messages.cc:204
 msgid "Whether the used metaserver login is for a registered user."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:204
+#: ../../../../src/wlapplication_messages.cc:205
 msgid "The hashed password for online logins."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:205
+#: ../../../../src/wlapplication_messages.cc:206
 msgid "IP"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:206
+#: ../../../../src/wlapplication_messages.cc:207
 msgid "Connect to a different server address from the add-ons manager."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:208
+#: ../../../../src/wlapplication_messages.cc:209
 msgid "Connect to a different server port from the add-ons manager."
 msgstr ""
 
 #. * TRANSLATORS: A syncstream is a synchronization stream. Syncstreams are
-#. used in multiplayer
+#. used in
+#. * multiplayer
 #. * TRANSLATORS: games to make sure that there is no mismatch between the
 #. players.
-#: ../../../../src/wlapplication_messages.cc:213
+#: ../../../../src/wlapplication_messages.cc:215
 msgid "Create syncstream dump files to help debug network games."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Graphic options:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:216
+#: ../../../../src/wlapplication_messages.cc:218
 msgid "Use the whole display for the game screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:218
+#: ../../../../src/wlapplication_messages.cc:220
 msgid "Start the game in a maximized window."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window width
-#: ../../../../src/wlapplication_messages.cc:221
+#: ../../../../src/wlapplication_messages.cc:223
 msgid "x"
 msgstr ""
 
 #. * TRANSLATORS: `x` references a window width placeholder
-#: ../../../../src/wlapplication_messages.cc:223
+#: ../../../../src/wlapplication_messages.cc:225
 msgid "Width `x` of the window in pixel."
 msgstr ""
 
 #. * TRANSLATORS: A placeholder for window height
-#: ../../../../src/wlapplication_messages.cc:226
+#: ../../../../src/wlapplication_messages.cc:228
 msgid "y"
 msgstr ""
 
 #. * TRANSLATORS: `y` references a window height placeholder
-#: ../../../../src/wlapplication_messages.cc:228
+#: ../../../../src/wlapplication_messages.cc:230
 msgid "Height `y` of the window in pixel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:230
+#: ../../../../src/wlapplication_messages.cc:232
 msgid ""
 "Whether to let the system draw the mouse cursor. Disable it only if the "
 "cursor doesn't appear right, or if you want it to be visible in screenshots "
 "or screencasts."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:233
+#: ../../../../src/wlapplication_messages.cc:235
 msgid "Whether to use sticky tooltips."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:236
+#: ../../../../src/wlapplication_messages.cc:238
 msgid ""
 "The path to the active UI theme, relative to the Widelands home directory."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:238
+#: ../../../../src/wlapplication_messages.cc:240
 msgid "Options for the internal window manager:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:239
+#: ../../../../src/wlapplication_messages.cc:241
 msgid "Whether automatic map movements should be animated."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:242
+#: ../../../../src/wlapplication_messages.cc:244
 msgid ""
 "Move a window to the edge of the screen when the edge of the window comes "
 "within a distance `n` from the edge of the screen."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:246
+#: ../../../../src/wlapplication_messages.cc:248
 msgid ""
 "Eliminate a window’s border towards the edge of the screen when the edge of "
 "the window is next to the edge of the screen."
 msgstr ""
 
 #. * TRANSLATORS: `n` references a numerical placeholder
-#: ../../../../src/wlapplication_messages.cc:251
+#: ../../../../src/wlapplication_messages.cc:254
 msgid ""
 "Move a window to the edge of the panel when the edge of the window comes "
 "within a distance of `n` from the edge of the panel."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Enable verbose debug messages"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:255
+#: ../../../../src/wlapplication_messages.cc:258
 msgid "Others:"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:257
+#: ../../../../src/wlapplication_messages.cc:260
 msgid ""
 "Print all strings as they are translated. This helps with tracing down bugs "
 "with internationalization."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:260
+#: ../../../../src/wlapplication_messages.cc:263
 msgid "Only print version and exit."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:261
+#: ../../../../src/wlapplication_messages.cc:264
 msgid "Show this help."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:262
+#: ../../../../src/wlapplication_messages.cc:265
 msgid "Show this help with all available config options."
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:263
+#: ../../../../src/wlapplication_messages.cc:266
 msgid "<save.wgf>/<replay.wry>"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:264
+#: ../../../../src/wlapplication_messages.cc:267
 msgid ""
 "Load the given savegame or replay directly. Useful for .wgf/.wry file "
 "extension association. Does not work with other options. Also see "
@@ -485,12 +486,12 @@ msgid ""
 msgstr ""
 
 #. * TRANSLATORS: %s = version information
-#: ../../../../src/wlapplication_messages.cc:299
+#: ../../../../src/wlapplication_messages.cc:302
 #, c-format
 msgid "This is Widelands version %s"
 msgstr ""
 
-#: ../../../../src/wlapplication_messages.cc:357
+#: ../../../../src/wlapplication_messages.cc:360
 msgid ""
 "Bug reports? Suggestions? Check out the project website:\n"
 "        https://www.widelands.org/\n"


### PR DESCRIPTION
Please fill out the relevant sections below and delete the rest.

**Type of change**
Bugfix for Missing libraries on MacOS 

**Issue(s) closed**

[Fixes #6444](https://github.com/widelands/widelands/issues/6444)

**To reproduce**

Try to run currently build packages (including Release 1.2) on x86 / ARM Mac


**How it works**

Using (again) https://github.com/auriamg/macdylibbundler which does not show this bug.

**Possible regressions**

If this fails we nee to track why the old aproach (based on https://github.com/imrehorvath/bundle-dylibs/issues/3)
fails. (Need to follow some recursive dependency resolution).


