### PR TITLE
Fix for 6444 using mac dylibbundler to packe the .app Bundle

### DIFF
--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -5,6 +5,8 @@ on:
 jobs:
   macos:
     strategy:
+      # NOCOM: let all of them run through until we fix them
+      fail-fast: false
       matrix:
         config: [debug, release]
         compiler: [clang]

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -5,7 +5,6 @@ on:
 jobs:
   macos:
     strategy:
-      # NOCOM: let all of them run through until we fix them
       fail-fast: false
       matrix:
         config: [debug, release]

--- a/utils/macos/build_app.sh
+++ b/utils/macos/build_app.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-USAGE="See compile.sh"
+# USAGE="See compile.sh" usage will be cared for by compile.sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SOURCE_DIR=$DIR/../../
@@ -31,12 +31,12 @@ if ! which python > /dev/null; then
       echo "No python executable found!"
    fi
 fi
-WLVERSION=`$PYTHON $DIR/../detect_revision.py`
+WLVERSION=$("$PYTHON" "$DIR"/../detect_revision.py)
 
 DESTINATION="WidelandsRelease"
 
-if [[ -f $SOURCE_DIR/WL_RELEASE ]]; then
-   WLVERSION="$(cat $SOURCE_DIR/WL_RELEASE)"
+if [[ -f "$SOURCE_DIR"/WL_RELEASE ]]; then
+   WLVERSION="$(cat "$SOURCE_DIR"/WL_RELEASE)"
 fi
 
 WLVERSION="${WLVERSION//\//\~}"  # Fix problems with slashes in branch names
@@ -59,7 +59,7 @@ function MakeDMG {
    UP=$(dirname $DESTINATION)
 
    echo "Copying COPYING"
-   cp $SOURCE_DIR/COPYING  $DESTINATION/COPYING.txt
+   cp "$SOURCE_DIR"/COPYING  "$DESTINATION"/COPYING.txt
 
    echo "Creating DMG ..."
    if [ -n "$GITHUB_ACTION" ]; then
@@ -78,7 +78,7 @@ function MakeDMG {
          return
       fi
       # EBUSY is error code 16. We only allow that, all others should fail immediately.
-      if [ $HDI_RESULT -ne 16 -o $HDI_TRY -eq $HDI_MAX_TRIES]; then
+      if [ $HDI_RESULT -ne 16 ] || [ $HDI_TRY -eq $HDI_MAX_TRIES ]; then
          exit $HDI_RESULT
       fi
       if [ -n "$GITHUB_ACTION" ]; then
@@ -91,15 +91,15 @@ function MakeDMG {
 
 function MakeAppPackage {
    echo "Making $DESTINATION/Widelands.app now."
-   rm -Rf $DESTINATION/
+   rm -Rf ${DESTINATION:?}/
 
-   mkdir $DESTINATION/
-   mkdir $DESTINATION/Widelands.app/
-   mkdir $DESTINATION/Widelands.app/Contents/
-   mkdir $DESTINATION/Widelands.app/Contents/Resources/
-   mkdir $DESTINATION/Widelands.app/Contents/MacOS/
-   cp $SOURCE_DIR/data/images/logos/widelands.icns $DESTINATION/Widelands.app/Contents/Resources/widelands.icns
-   ln -s /Applications $DESTINATION/Applications
+   mkdir "$DESTINATION"/
+   mkdir "$DESTINATION"/Widelands.app/
+   mkdir "$DESTINATION"/Widelands.app/Contents/
+   mkdir "$DESTINATION"/Widelands.app/Contents/Resources/
+   mkdir "$DESTINATION"/Widelands.app/Contents/MacOS/
+   cp "$SOURCE_DIR"/data/images/logos/widelands.icns "$DESTINATION"/Widelands.app/Contents/Resources/widelands.icns
+   ln -s /Applications "$DESTINATION"/Applications
 
    cat > $DESTINATION/Widelands.app/Contents/Info.plist << EOF
 {
@@ -117,16 +117,16 @@ function MakeAppPackage {
 EOF
 
    echo "Copying data files ..."
-   rsync -Ca $SOURCE_DIR/data $DESTINATION/Widelands.app/Contents/MacOS/
+   rsync -Ca "$SOURCE_DIR"/data "$DESTINATION"/Widelands.app/Contents/MacOS/
 
    echo "Copying binary ..."
-   cp -a $SOURCE_DIR/widelands $DESTINATION/Widelands.app/Contents/MacOS/
+   cp -a "$SOURCE_DIR"/widelands $DESTINATION/Widelands.app/Contents/MacOS/
 
    # Locate ASAN Library by asking llvm (nice trick by SirVer I suppose)
    ASANLIB=$(echo "int main(void){return 0;}" | xcrun clang -fsanitize=address \
        -xc -o/dev/null -v - 2>&1 |   tr ' ' '\n' | grep libclang_rt.asan_osx_dynamic.dylib)
 
-   ASANPATH=`dirname $ASANLIB`
+   ASANPATH=$(dirname "$ASANLIB")
 
    echo "Copying and fixing dynamic libraries... "
    # $SOURCE_DIR/utils/macos/bundle-dylibs.sh \
@@ -135,9 +135,9 @@ EOF
 
    # Alternative Tool to use
    dylibbundler --overwrite-dir --bundle-deps --no-codesign \
-	--search-path $ASANPATH \
-	--fix-file $DESTINATION/Widelands.app/Contents/MacOS/widelands \
-	--dest-dir $DESTINATION/Widelands.app/Contents/libs
+	--search-path "$ASANPATH" \
+	--fix-file "$DESTINATION/Widelands.app/Contents/MacOS/widelands" \
+	--dest-dir "$DESTINATION/Widelands.app/Contents/libs"
 
    echo "Re-sign libraries with an 'ad-hoc signing' see man codesign"
    codesign --sign - --force $DESTINATION/Widelands.app/Contents/libs/*
@@ -148,21 +148,21 @@ EOF
 
 function BuildWidelands() {
    PREFIX_PATH=$(brew --prefix)
-   eval "$($PREFIX_PATH/bin/brew shellenv)"
+   eval "$("$PREFIX_PATH/bin/brew shellenv")"
    export CMAKE_PREFIX_PATH="${PREFIX_PATH}/opt/icu4c"
 
    echo "FIXED ICU Issue $CMAKE_PREFIX_PATH"
 
-   pushd $SOURCE_DIR
+   pushd "$SOURCE_DIR"
    ./compile.sh \
       -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING="$OSX_MIN_VERSION" \
       -DCMAKE_OSX_SYSROOT:PATH="$SDK_DIRECTORY" \
-      $@
+      "$@"
    popd
 
    echo "Done building."
 }
 
-BuildWidelands $@
+BuildWidelands "$@"
 MakeAppPackage
 MakeDMG

--- a/utils/macos/build_app.sh
+++ b/utils/macos/build_app.sh
@@ -129,9 +129,15 @@ EOF
    ASANPATH=`dirname $ASANLIB`
 
    echo "Copying and fixing dynamic libraries... "
-   $SOURCE_DIR/utils/macos/bundle-dylibs.sh \
-      -l ../libs \
-      $DESTINATION/Widelands.app
+   # $SOURCE_DIR/utils/macos/bundle-dylibs.sh \
+   #  -l ../libs \
+   #  $DESTINATION/Widelands.app
+
+   # Alternative Tool to use
+   dylibbundler --overwrite-dir --bundle-deps --no-codesign \
+	--search-path $ASANPATH \
+	--fix-file $DESTINATION/Widelands.app/Contents/MacOS/widelands \
+	--dest-dir $DESTINATION/Widelands.app/Contents/libs
 
    echo "Re-sign libraries with an 'ad-hoc signing' see man codesign"
    codesign --sign - --force $DESTINATION/Widelands.app/Contents/libs/*

--- a/utils/macos/build_app.sh
+++ b/utils/macos/build_app.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# USAGE="See compile.sh" usage will be cared for by compile.sh
+# Command line parameters will be passed to compile.sh, check its help for usage
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SOURCE_DIR=$DIR/../../
@@ -78,7 +78,7 @@ function MakeDMG {
          return
       fi
       # EBUSY is error code 16. We only allow that, all others should fail immediately.
-      if [ $HDI_RESULT -ne 16 ] || [ $HDI_TRY -eq $HDI_MAX_TRIES ]; then
+      if [ $HDI_RESULT -ne 16 -o $HDI_TRY -eq $HDI_MAX_TRIES ]; then
          exit $HDI_RESULT
       fi
       if [ -n "$GITHUB_ACTION" ]; then
@@ -91,13 +91,13 @@ function MakeDMG {
 
 function MakeAppPackage {
    echo "Making $DESTINATION/Widelands.app now."
-   rm -Rf ${DESTINATION:?}/
+   rm -Rf "$DESTINATION"
 
-   mkdir "$DESTINATION"/
-   mkdir "$DESTINATION"/Widelands.app/
-   mkdir "$DESTINATION"/Widelands.app/Contents/
-   mkdir "$DESTINATION"/Widelands.app/Contents/Resources/
-   mkdir "$DESTINATION"/Widelands.app/Contents/MacOS/
+   mkdir "$DESTINATION"
+   mkdir "$DESTINATION"/Widelands.app
+   mkdir "$DESTINATION"/Widelands.app/Contents
+   mkdir "$DESTINATION"/Widelands.app/Contents/Resources
+   mkdir "$DESTINATION"/Widelands.app/Contents/MacOS
    cp "$SOURCE_DIR"/data/images/logos/widelands.icns "$DESTINATION"/Widelands.app/Contents/Resources/widelands.icns
    ln -s /Applications "$DESTINATION"/Applications
 

--- a/utils/macos/bundle-dylibs.sh
+++ b/utils/macos/bundle-dylibs.sh
@@ -2,7 +2,6 @@
 
 # Copyright (c) 2021 Imre Horvath <imi [dot] horvath [at] gmail [dot] com>
 # MIT License
-# https://github.com/imrehorvath/bundle-dylibs
 # Should work with /bin/sh or /bin/bash too.
 # Inspired by:
 # https://github.com/renard/emacs-build-macosx/blob/master/build-emacs
@@ -12,7 +11,7 @@ set -e
 
 relpath="../Frameworks"  # dylibs go to @executable_path/../Frameworks by default
 
-usage_text="Usage: $(basename $0) [-h] [-l relative_path] path_to_app
+usage_text="Usage: $(basename "$0") [-h] [-l relative_path] path_to_app
 
 -h Show this usage description and exit.
 
@@ -69,13 +68,12 @@ process_dylibs() {
 	    process_dylibs "$(list_dylibs $dest)" "$dest"
 	fi
 	install_name_tool -change "$dylib" "@rpath/$name" "$file"
-	echo "Adding $dylib"
     done
 }
 
 process_executable() {
     local executable="$1"
-    local dylibs="$(list_dylibs $executable)"
+    local dylibs="$(list_dylibs "$executable")"
     if [[ -n $dylibs ]]; then
 	mkdir -p "$libdir"
 	process_dylibs "$dylibs" "$executable"
@@ -83,16 +81,16 @@ process_executable() {
     fi
 }
 
-if [[ $(basename $bundlepath) =~ [.]app$ ]] &&
+if [[ $(basename "$bundlepath") =~ [.]app$ ]] &&
        [[ -f $bundlepath/Contents/Info.plist ]] &&
        [[ -d $bundlepath/Contents/MacOS ]]; then
-    for executable in $(find "$bundlepath/Contents/MacOS" -type f -perm +111); do
-	if [[ $(file $executable) =~ Mach-O.*executable ]]; then
+    find "$bundlepath/Contents/MacOS" -type f -perm +111 -print0 | while IFS= read -r -d '' executable; do
+	if [[ $(file "$executable") =~ Mach-O.*executable ]]; then
 	    process_executable "$executable"
 	fi
     done
 else
-    echo "\"$bundlepath\" does not apper to be an application bundle." 1>&2
+    echo "\"$bundlepath\" does not appear to be an application bundle." 1>&2
     exit 1
 fi
 

--- a/utils/macos/packages
+++ b/utils/macos/packages
@@ -14,3 +14,4 @@ sdl2_image
 sdl2_mixer
 sdl2_ttf
 zlib
+dylibbundler


### PR DESCRIPTION
**Type of change**

Bugfix for Missing libraries on MacOS

**Issue(s) closed**

https://github.com/widelands/widelands/issues/6444

**To reproduce**

Try to run currently build packages (including Release 1.2) on x86 / ARM Mac

**How it works**

Using (again) https://github.com/auriamg/macdylibbundler which does not show this bug.

**Possible regressions**

If this fails we need to track why the old approach (based on https://github.com/imrehorvath/bundle-dylibs/issues/3)
fails. (Need to follow some recursive dependency resolution).