### PR TITLE
Temporary windows build fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ shallow_clone: false
 branches:
   only:
     - master
+    - temporary_windows_build_fix
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,14 +29,12 @@ install:
   - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER:\\=/%/install-dependencies.sh msys%BITS% --noconfirm\""
   # Downgrade incompatible packages to working version
   # - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/mingw%BITS%/mingw-w64-%MINGWSUFFIX%-SDL2_image-2.8.0-1-any.pkg.tar.zst\""
-  - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-svt-av1-2.2.1-1-any.pkg.tar.zst\""
 
 shallow_clone: false
 
 branches:
   only:
     - master
-    - temporary_windows_build_fix
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ install:
   - cmd: "bash --login -c \"%APPVEYOR_BUILD_FOLDER:\\=/%/install-dependencies.sh msys%BITS% --noconfirm\""
   # Downgrade incompatible packages to working version
   # - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/mingw%BITS%/mingw-w64-%MINGWSUFFIX%-SDL2_image-2.8.0-1-any.pkg.tar.zst\""
+  - cmd: "bash --login -c \"pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-svt-av1-2.2.1-1-any.pkg.tar.zst\""
 
 shallow_clone: false
 

--- a/utils/windows/mingw_deps
+++ b/utils/windows/mingw_deps
@@ -7,7 +7,7 @@ cmake:      c-ares brotli libunistring libidn2 libpsl libtasn1 p11-kit ca-certif
 asio:
 SDL2_ttf:   vulkan-headers vulkan-loader SDL2 libpng wineditline pcre2 glib2 harfbuzz freetype
 SDL2_mixer: libogg flac lame libvorbis mpg123 opus libsndfile portaudio fluidsynth libmodplug opusfile
-SDL2_image: aom dav1d rav1e libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
+SDL2_image: aom dav1d rav1e svt-av1[=2.2.1] libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
 glew:
 glbinding:
 icu:

--- a/utils/windows/mingw_deps
+++ b/utils/windows/mingw_deps
@@ -7,7 +7,7 @@ cmake:      c-ares brotli libunistring libidn2 libpsl libtasn1 p11-kit ca-certif
 asio:
 SDL2_ttf:   vulkan-headers vulkan-loader SDL2 libpng wineditline pcre2 glib2 harfbuzz freetype
 SDL2_mixer: libogg flac lame libvorbis mpg123 opus libsndfile portaudio fluidsynth libmodplug opusfile
-SDL2_image: aom dav1d rav1e svt-av1[=2.2.1] libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
+SDL2_image: aom dav1d rav1e svt-av1[=2.2.1-1] libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
 glew:
 glbinding:
 icu:

--- a/utils/windows/mingw_deps
+++ b/utils/windows/mingw_deps
@@ -7,7 +7,7 @@ cmake:      c-ares brotli libunistring libidn2 libpsl libtasn1 p11-kit ca-certif
 asio:
 SDL2_ttf:   vulkan-headers vulkan-loader SDL2 libpng wineditline pcre2 glib2 harfbuzz freetype
 SDL2_mixer: libogg flac lame libvorbis mpg123 opus libsndfile portaudio fluidsynth libmodplug opusfile
-SDL2_image: aom dav1d rav1e svt-av1[=2.2.1-1] libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
+SDL2_image: aom dav1d rav1e svt-av1=2.2.1-1 libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
 glew:
 glbinding:
 icu:

--- a/utils/windows/mingw_deps
+++ b/utils/windows/mingw_deps
@@ -7,7 +7,8 @@ cmake:      c-ares brotli libunistring libidn2 libpsl libtasn1 p11-kit ca-certif
 asio:
 SDL2_ttf:   vulkan-headers vulkan-loader SDL2 libpng wineditline pcre2 glib2 harfbuzz freetype
 SDL2_mixer: libogg flac lame libvorbis mpg123 opus libsndfile portaudio fluidsynth libmodplug opusfile
-SDL2_image: aom dav1d rav1e svt-av1=2.2.1-1 libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
+SDL2_image: aom dav1d rav1e libjpeg-turbo libyuv giflib jbigkit lerc libdeflate libtiff libwebp libavif highway lcms2 imath openexr libjxl
 glew:
 glbinding:
 icu:
+svt-av1=2.2.1-1:

--- a/utils/windows/mingw_deps
+++ b/utils/windows/mingw_deps
@@ -11,4 +11,5 @@ SDL2_image: aom dav1d rav1e libjpeg-turbo libyuv giflib jbigkit lerc libdeflate 
 glew:
 glbinding:
 icu:
+# TODO(hessenfarmer): remove again after libavif package is version higher then 1.1.1
 svt-av1=2.2.1-1:


### PR DESCRIPTION
**Type of change**
Fixes the windows mingw64 build failures by downgrading the svt-av1 library to the last compatible version


