### PR TITLE
Use all workarounds for hdiutil errors from actions/runner-images#7522

### DIFF
--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -37,8 +37,8 @@ jobs:
         # temporary fix for macos-14 arm failures
         brew install --quiet icu4c
     - name: Building
-      # Export for build_app.sh
-      env: |
+      env:
+        # Export for build_app.sh
         MATRIX_OS: ${{ matrix.os }}
       run: |
         mkdir build_wl

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -37,6 +37,9 @@ jobs:
         # temporary fix for macos-14 arm failures
         brew install --quiet icu4c
     - name: Building
+      env: |
+        # Export for build_app.sh
+        MATRIX_OS: ${{ matrix.os }}
       run: |
         mkdir build_wl
         cd build_wl/

--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -37,8 +37,8 @@ jobs:
         # temporary fix for macos-14 arm failures
         brew install --quiet icu4c
     - name: Building
+      # Export for build_app.sh
       env: |
-        # Export for build_app.sh
         MATRIX_OS: ${{ matrix.os }}
       run: |
         mkdir build_wl


### PR DESCRIPTION
**Type of change**
Bugfix

**Issue(s) closed**
More frequent hdiutil failures on macos 13

**Possible regressions**
macos DMG file creation, reduced ability to inspect the created images on other OSes due to switching to APFS from HFS+

**Additional context**
This now implements all suggested workarounds from https://github.com/actions/runner-images/issues/7522 :
 - [kill XProtect if it misbehaves](https://github.com/actions/runner-images/issues/7522#issuecomment-1556766641)
 - [run hdiutil as root](https://github.com/actions/runner-images/issues/7522#issuecomment-1564467252)
 - [use APFS](https://github.com/actions/runner-images/issues/7522#issuecomment-2299918092)

In addition, verbose output is enabled to get more info on failures and for progress tracking in general.