### PR TITLE
Encyclopedia: Show Experience chain for all workers in the chain

### DIFF
--- a/data/tribes/scripting/help/worker_help.lua
+++ b/data/tribes/scripting/help/worker_help.lua
@@ -165,9 +165,19 @@ function worker_help_string(tribe, worker_description)
 
    -- TODO(GunChleoc): Add "enhanced from" info in one_tribe branch
    local becomes_description = worker_description.becomes
+   local promoted_from_description = worker_description.promoted_from
+   if (promoted_from_description) then
+      becomes_description = worker_description
+      if (promoted_from_description.promoted_from) then
+         becomes_description = promoted_from_description
+         promoted_from_description = promoted_from_description.promoted_from
+      end
+   else
+      promoted_from_description = worker_description
+   end
    if (becomes_description) then
       result = result .. h2(_("Experience levels"))
-      result = result .. help_worker_experience(worker_description, becomes_description)
+      result = result .. help_worker_experience(promoted_from_description, becomes_description)
    end
    -- Soldier properties
    if (worker_description.type_name == "soldier") then

--- a/data/tribes/scripting/help/worker_help.lua
+++ b/data/tribes/scripting/help/worker_help.lua
@@ -163,7 +163,7 @@ function worker_help_string(tribe, worker_description)
 
    result = result .. worker_help_employers_string(worker_description)
 
-   -- TODO(GunChleoc): Add "enhanced from" info in one_tribe branch
+   -- TODO(hessenfarmer): make this work for more then 2 promotion steps
    local becomes_description = worker_description.becomes
    local promoted_from_description = worker_description.promoted_from
    if (promoted_from_description) then

--- a/src/logic/map_objects/tribes/tribe_descr.cc
+++ b/src/logic/map_objects/tribes/tribe_descr.cc
@@ -499,7 +499,7 @@ void TribeDescr::load_workers(const LuaTable& table, Descriptions& descriptions)
 			try {
 				DescriptionIndex workerindex = descriptions.load_worker(workername);
 				if (has_worker(workerindex)) {
-					throw GameDataError("Duplicate definition of worker");
+					throw GameDataError("Duplicate definition of worker '%s'", workername.c_str());
 				}
 
 				// Set default_target_quantity and preciousness (both optional)
@@ -519,6 +519,12 @@ void TribeDescr::load_workers(const LuaTable& table, Descriptions& descriptions)
 
 				// Add helptexts
 				load_helptexts(worker_descr, *worker_table);
+
+				// Register at enhanced building
+				const DescriptionIndex& becomes = worker_descr->becomes();
+				if (becomes != INVALID_INDEX) {
+					descriptions.get_mutable_worker_descr(becomes)->set_promoted_from(workerindex);
+				}
 
 				// Add to tribe
 				workers_.insert(workerindex);

--- a/src/logic/map_objects/tribes/tribe_descr.cc
+++ b/src/logic/map_objects/tribes/tribe_descr.cc
@@ -520,7 +520,7 @@ void TribeDescr::load_workers(const LuaTable& table, Descriptions& descriptions)
 				// Add helptexts
 				load_helptexts(worker_descr, *worker_table);
 
-				// Register at enhanced building
+				// Register at promoted woker
 				const DescriptionIndex& becomes = worker_descr->becomes();
 				if (becomes != INVALID_INDEX) {
 					descriptions.get_mutable_worker_descr(becomes)->set_promoted_from(workerindex);

--- a/src/logic/map_objects/tribes/tribe_descr.cc
+++ b/src/logic/map_objects/tribes/tribe_descr.cc
@@ -520,7 +520,7 @@ void TribeDescr::load_workers(const LuaTable& table, Descriptions& descriptions)
 				// Add helptexts
 				load_helptexts(worker_descr, *worker_table);
 
-				// Register at promoted woker
+				// Register at promoted worker
 				const DescriptionIndex& becomes = worker_descr->becomes();
 				if (becomes != INVALID_INDEX) {
 					descriptions.get_mutable_worker_descr(becomes)->set_promoted_from(workerindex);

--- a/src/logic/map_objects/tribes/worker_descr.h
+++ b/src/logic/map_objects/tribes/worker_descr.h
@@ -54,6 +54,10 @@ public:
 	[[nodiscard]] bool is_buildable() const {
 		return buildable_;
 	}
+	[[nodiscard]] bool is_promoted() const {
+		return promoted_from_ != INVALID_INDEX;
+	}
+
 	[[nodiscard]] const Buildcost& buildcost() const {
 		assert(is_buildable());
 		return buildcost_;
@@ -105,6 +109,15 @@ public:
 		return becomes_;
 	}
 	void set_becomes(Descriptions&, const std::string&);
+
+	// Returns the worker that this worker was promoted from by experience or
+	// INVALID_INDEX if it cannot be promoted by experience.
+	[[nodiscard]] const DescriptionIndex& promoted_from() const {
+		return promoted_from_;
+	}
+	void set_promoted_from(const DescriptionIndex& index) {
+		promoted_from_ = index;
+	}
 	[[nodiscard]] DescriptionIndex worker_index() const;
 	[[nodiscard]] bool can_act_as(DescriptionIndex) const;
 
@@ -159,6 +172,9 @@ private:
 	 * or INVALID_INDEX if the worker cannot level up.
 	 */
 	int32_t needed_experience_;
+
+	DescriptionIndex promoted_from_{
+	   INVALID_INDEX};  // The worker this worker was promoted from, or INVALID_INDEX
 
 	/// Buildings where this worker can work
 	std::set<DescriptionIndex> employers_;

--- a/src/scripting/lua_root.cc
+++ b/src/scripting/lua_root.cc
@@ -1176,13 +1176,14 @@ void LuaDescriptions::do_modify_worker(lua_State* L,
                                        const std::string& property) {
 	Widelands::EditorGameBase& egbase = get_egbase(L);
 	Widelands::Descriptions& descrs = *egbase.mutable_descriptions();
-	Widelands::WorkerDescr& worker_descr =
-	   *descrs.get_mutable_worker_descr(descrs.load_worker(unit_name));
+	const Widelands::DescriptionIndex workerindex = descrs.load_worker(unit_name);
+	Widelands::WorkerDescr& worker_descr = *descrs.get_mutable_worker_descr(workerindex);
 
 	if (property == "experience") {
 		worker_descr.set_needed_experience(luaL_checkuint32(L, 5));
 	} else if (property == "becomes") {
 		worker_descr.set_becomes(descrs, luaL_checkstring(L, 5));
+		descrs.get_mutable_worker_descr(worker_descr.becomes())->set_promoted_from(workerindex);
 	} else if (property == "target_quantity") {
 		worker_descr.set_default_target_quantity(lua_isnil(L, 5) ? Widelands::kInvalidWare :
 		                                                           luaL_checkuint32(L, 5));

--- a/src/scripting/map/lua_building_description.cc
+++ b/src/scripting/map/lua_building_description.cc
@@ -140,7 +140,7 @@ int LuaBuildingDescription::get_enhanced_from(lua_State* L) {
 		   L, egbase.descriptions().get_building_descr(enhanced_from));
 	}
 	lua_pushnil(L);
-	return 0;
+	return 1;
 }
 
 /* RST

--- a/src/scripting/map/lua_worker_description.cc
+++ b/src/scripting/map/lua_worker_description.cc
@@ -103,7 +103,7 @@ int LuaWorkerDescription::get_promoted_from(lua_State* L) {
 		   L, egbase.descriptions().get_worker_descr(promoted_from));
 	}
 	lua_pushnil(L);
-	return 0;
+	return 1;
 }
 
 /* RST

--- a/src/scripting/map/lua_worker_description.cc
+++ b/src/scripting/map/lua_worker_description.cc
@@ -37,7 +37,8 @@ const MethodType<LuaWorkerDescription> LuaWorkerDescription::Methods[] = {
    {nullptr, nullptr},
 };
 const PropertyType<LuaWorkerDescription> LuaWorkerDescription::Properties[] = {
-   PROP_RO(LuaWorkerDescription, becomes),           PROP_RO(LuaWorkerDescription, buildcost),
+   PROP_RO(LuaWorkerDescription, becomes),           PROP_RO(LuaWorkerDescription, promoted),
+   PROP_RO(LuaWorkerDescription, promoted_from),     PROP_RO(LuaWorkerDescription, buildcost),
    PROP_RO(LuaWorkerDescription, employers),         PROP_RO(LuaWorkerDescription, buildable),
    PROP_RO(LuaWorkerDescription, needed_experience), {nullptr, nullptr, nullptr},
 };
@@ -75,6 +76,34 @@ int LuaWorkerDescription::get_becomes(lua_State* L) {
 	}
 	return to_lua<LuaWorkerDescription>(
 	   L, new LuaWorkerDescription(get_egbase(L).descriptions().get_worker_descr(becomes_index)));
+}
+
+/* RST
+   .. attribute:: promoted
+
+      (RO) :const:`true` if the worker is promoted from another worker.
+*/
+int LuaWorkerDescription::get_promoted(lua_State* L) {
+	lua_pushboolean(L, static_cast<int>(get()->is_promoted()));
+	return 1;
+}
+
+/* RST
+   .. attribute:: promoted_from
+
+      (RO) The :class:`WorkerDescription` that this worker was promoted from
+      or :const:`nil` if it is not a promoted woker.
+*/
+int LuaWorkerDescription::get_promoted_from(lua_State* L) {
+	if (get()->is_promoted()) {
+		const Widelands::DescriptionIndex& promoted_from = get()->promoted_from();
+		Widelands::EditorGameBase& egbase = get_egbase(L);
+		assert(egbase.descriptions().worker_exists(promoted_from));
+		return upcasted_map_object_descr_to_lua(
+		   L, egbase.descriptions().get_worker_descr(promoted_from));
+	}
+	lua_pushnil(L);
+	return 0;
 }
 
 /* RST

--- a/src/scripting/map/lua_worker_description.h
+++ b/src/scripting/map/lua_worker_description.h
@@ -46,6 +46,8 @@ public:
 	 * Properties
 	 */
 	int get_becomes(lua_State*);
+	int get_promoted(lua_State*);
+	int get_promoted_from(lua_State*);
 	int get_buildcost(lua_State*);
 	int get_employers(lua_State*);
 	int get_buildable(lua_State*);


### PR DESCRIPTION
### Type of Change
Bugfix 

### Issue(s) Closed
Fixes #6590 (GH) (CB4950)

### New Behavior
now all promotion steps are shown for all workers in a promotion chain


### Possible Regressions
worker help for other workers




