### PR TITLE
Directly include cstring in machdep.h (#4978)

### DIFF
--- a/src/io/machdep.h
+++ b/src/io/machdep.h
@@ -19,6 +19,8 @@
 #ifndef WL_IO_MACHDEP_H
 #define WL_IO_MACHDEP_H
 
+#include <cstring>
+
 #include <SDL_endian.h>
 
 #include "base/macros.h"


### PR DESCRIPTION
### Type of Change
Bugfix/Refactoring: As of now, machdep.h only indirectly includes `memcpy` from `cstring` through `SDL_Endian.h`. This PR makes the dependency direct and also fixes issues that have arisen with the SDL2 compatibility layer regarding `memcpy`. This was discussed in the linked issue.

### Issue(s) Closed
Fixes #6618

### To Reproduce
1. Install Arch or another rolling release distro that has the sdl3 and sdl2-compat packages
2. Try to build widelands using `compile.sh`
3. Errors because `memcpy` is not in scope

### New Behavior
`machdep.h` directly includes `<cstring>` instead of indirectly through `SDL_Endian.h`

