### PR TITLE
install-dependencies.sh: Don't error on MacOS when all dependencies already installed.

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -190,7 +190,12 @@ elif [ "$DISTRO" = "homebrew" ]; then
          echo "$PKG is already installed, skipping."
       fi
    done
-   brew install $@ $PKGS
+   if [ -z "$PKGS" ]; then
+       echo
+       echo "All dependencies already installed! Nothing to do ..."
+   else
+       brew install $@ $PKGS
+   fi
 
 elif [ "$DISTRO" = "solus" ]; then
    echo "Installing dependencies for Solus..."

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -192,7 +192,7 @@ elif [ "$DISTRO" = "homebrew" ]; then
    done
    if [ -z "$PKGS" ]; then
        echo
-       echo "All dependencies already installed! Nothing to do ..."
+       echo "All dependencies already installed! Nothing to do."
    else
        brew install $@ $PKGS
    fi


### PR DESCRIPTION
### Type of Change
Bugfix: On MacOS, when all dependencies are already installed, install-dependencies.sh tries to install nothing, leading to an error and the script exiting with a non-zero code, which seems wrong for everything being fine. The fix is as simple as checking if `$PKGS` is empty.

### Issue(s) Closed
Fixes #6622

### To Reproduce
1. Run `install-dependencies.sh` on MacOS
2. Run it again

### New Behavior
The script doesn't error but instead calmly informs the user that all dependencies are already installed


### How it Works
Checks if `$PKGS` is empty and doesn't try to install nothing if it is.

