### PR TITLE
Update clang to version 12 for build_appimage.yaml as well

### DIFF
--- a/.github/workflows/build_appimage.yaml
+++ b/.github/workflows/build_appimage.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         config: [Debug, Release]
-        compiler: [clang-10]
+        compiler: [clang-12]
     # Must run on the oldest still-supported Ubuntu LTS release
     runs-on: ubuntu-22.04
     env:


### PR DESCRIPTION
### Type of Change
Bugfix

### Issue(s) Closed
updtae of appimage workflow to new clang version


