### PR TITLE
Fix player.end_result

### DIFF
--- a/src/scripting/lua_game.cc
+++ b/src/scripting/lua_game.cc
@@ -238,7 +238,11 @@ int LuaPlayer::get_resigned(lua_State* L) {
 int LuaPlayer::get_end_result(lua_State* L) {
 	const Widelands::PlayerEndStatus* p =
 	   get_egbase(L).player_manager()->get_player_end_status(player_number());
-	lua_pushinteger(L, static_cast<int>(p->result));
+	if (p == nullptr) {
+		lua_pushinteger(L, 255);
+	} else {
+		lua_pushinteger(L, static_cast<int>(p->result));
+	}
 	return 1;
 }
 

--- a/test/maps/lua_testsuite.wmf/player_position
+++ b/test/maps/lua_testsuite.wmf/player_position
@@ -2,7 +2,7 @@
 
 [global]
 packet_version="2"
-player_1="10 10"
+player_1="60 10"
 player_2="30 10"
 player_3="50 10"
 player_4="0 30"

--- a/test/maps/lua_testsuite.wmf/scripting/cplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/cplayer.lua
@@ -21,6 +21,14 @@ function player_tests:test_number_property()
    assert_equal(3, player3.number)
 end
 
+function player_tests:test_basic_properties()
+   assert_equal(false, player1.defeated, "defeated")
+   assert_equal(false, player1.resigned, "resigned")
+   print("checking p1.end_result")
+   assert_equal(255, player1.end_result, "end result")
+   assert_not_nil(player1.color)
+end
+
 function player_tests:test_ai_type()
    local default_ai = "very_weak"
    local no_ai_human = ""

--- a/test/maps/lua_testsuite.wmf/scripting/cplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/cplayer.lua
@@ -22,10 +22,6 @@ function player_tests:test_number_property()
 end
 
 function player_tests:test_basic_properties()
-   assert_equal(false, player1.defeated, "defeated")
-   assert_equal(false, player1.resigned, "resigned")
-   print("checking p1.end_result")
-   assert_equal(255, player1.end_result, "end result")
    assert_not_nil(player1.color)
 end
 

--- a/test/maps/lua_testsuite.wmf/scripting/cplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/cplayer.lua
@@ -21,10 +21,6 @@ function player_tests:test_number_property()
    assert_equal(3, player3.number)
 end
 
-function player_tests:test_basic_properties()
-   assert_not_nil(player1.color)
-end
-
 function player_tests:test_ai_type()
    local default_ai = "very_weak"
    local no_ai_human = ""

--- a/test/maps/lua_testsuite.wmf/scripting/flag.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/flag.lua
@@ -147,7 +147,7 @@ end
 -- buildings and roads
 -- ===================
 function flag_tests:roads_and_buildings_test()
-   local field = map:get_field(4,14)
+   local field = map:get_field(54,14)
    self.w = player1:place_building("barbarians_warehouse", field)
    self.f1 = self.w.flag
    local road = player1:place_road("normal", self.f1, "br", "br", "br")

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -8,6 +8,12 @@ function player_tests:test_name_property()
    assert_equal("Awesome Atlantean", egbase.players[3].name)
 end
 
+function player_tests:test_winner_properties()
+   assert_equal(false, player1.defeated, "defeated")
+   assert_equal(false, player1.resigned, "resigned")
+   assert_equal(255, player1.end_result, "end result")
+end
+
 -- =========================
 -- Forbid & Allow buildings
 -- =========================

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -11,6 +11,7 @@ end
 function player_tests:test_basic_properties()
    -- winner/looser
    assert_equal(false, player1.defeated, "defeated")
+   -- in case defeated is true, check if the head quarter was removed by a test before
    assert_equal(false, player1.resigned, "resigned")
    assert_equal(255, player1.end_result, "end result")
    -- other

--- a/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/gplayer.lua
@@ -8,10 +8,13 @@ function player_tests:test_name_property()
    assert_equal("Awesome Atlantean", egbase.players[3].name)
 end
 
-function player_tests:test_winner_properties()
+function player_tests:test_basic_properties()
+   -- winner/looser
    assert_equal(false, player1.defeated, "defeated")
    assert_equal(false, player1.resigned, "resigned")
    assert_equal(255, player1.end_result, "end result")
+   -- other
+   assert_not_nil(player1.color, "color")
 end
 
 -- =========================

--- a/test/maps/lua_testsuite.wmf/scripting/init.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/init.lua
@@ -77,6 +77,13 @@ end
 include "map:scripting/table.lua"
 include "map:scripting/set.lua"
 
+local tc_at_end = lunit.TestCase("check at end")
+function tc_at_end.test_not_missing()
+   -- check that important initial things are still here
+   local at_startpos = map.player_slots[1].starting_field.immovable
+   assert_equal("barbarians_headquarters", at_startpos and at_startpos.descr.name, "on start field")
+end
+
 -- ============
 -- Test Runner
 -- ============

--- a/test/maps/lua_testsuite.wmf/scripting/map.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/map.lua
@@ -29,7 +29,7 @@ function test_map:test_playerslots_tribes()
 end
 
 function test_map:test_playerslots_starting_field()
-   assert_equal(map:get_field(10,10), map.player_slots[1].starting_field)
+   assert_equal(map:get_field(60,10), map.player_slots[1].starting_field)
    assert_equal(map:get_field(30,10), map.player_slots[2].starting_field)
    assert_equal(map:get_field(50,10), map.player_slots[3].starting_field)
 end

--- a/test/maps/lua_testsuite.wmf/scripting/militarysite.lua
+++ b/test/maps/lua_testsuite.wmf/scripting/militarysite.lua
@@ -14,7 +14,7 @@ end
 militarysite_tests = lunit.TestCase("MilitarySite Tests")
 local offset_y = 0
 function militarysite_tests:setup()
-   self.f1 = map:get_field(6, 5 + offset_y) -- move down, to have remaining bobs on a separate field
+   self.f1 = map:get_field(56, 5 + offset_y) -- move down, to have remaining bobs on a separate field
    offset_y = offset_y + 1
 
    self.fortress = player1:place_building("barbarians_fortress", self.f1)


### PR DESCRIPTION
### Type of Change
Bugfix

### Issue(s) Closed
Fixes an issue reported here

### To Reproduce
1. start any game in widelands (using a debug build) (let nobody win)
2. open the debug console (Ctrl-Space)
3. type `print(wl.Game().players[1].end_result)` and enter
4. widelands will crash

### New Behavior
playerX.end_result will be 255 as long as winners are not yet known. This is what I understand the doc (of get_end_result) tells should happen.


### How it Works
Instead of calling a method for a nullpointer, 255 is returned to lua.