### PR TITLE
testsuite: download tests in separate step

### DIFF
--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -84,7 +84,8 @@ jobs:
         mkdir temp_web
         build/src/website/wl_map_object_info temp_web || [ $? -eq 2 ]
         build/src/website/wl_map_info data/maps/Archipelago_Sea.wmf || [ $? -eq 2 ]
+    - name: download savegame testcases
+      run: utils/test/download_loadgame_testcases.sh
     - name: Testsuite
       run: |
-        utils/test/download_loadgame_testcases.sh
         ./regression_test.py


### PR DESCRIPTION
### Type of Change
minor enhancement of test running on github

### Issue(s) Closed
Fixes -

### New Behavior
download tests in separate step, before running test suite.

So that output of test can be found without scrolling (on github),
and test suite log copied to codeberg does not include download results.

### Additional context
looking for failures got too troublesome in places like
https://codeberg.org/wl/widelands/pulls/5146#issuecomment-5416023
https://github.com/widelands/widelands/actions/runs/15685561365/job/44187939232?pr=6786

