### PR TITLE
test: add pinned note to test_no_double_colonizing.lua to show memory leak

### DIFF
--- a/test/maps/expedition.wmf/scripting/test_no_double_colonizing.lua
+++ b/test/maps/expedition.wmf/scripting/test_no_double_colonizing.lua
@@ -10,6 +10,8 @@ run(function()
    }
    port:set_workers("barbarians_builder", 5)
 
+   p1:place_pinned_note(map:get_field(11, 11), "note in water") -- to be listed as ship dest
+
    create_two_ships()
    port:start_expedition()
    wait_for_message("Expedition")


### PR DESCRIPTION
There is a memory leak rendering the icon for selecting the pinned note as destination of a ship. But maybe another failure will happen (as it does on my machine).

### Type of Change
Demonstration of a bug (or two)

### Issue(s) Closed
Fixes --

### To Reproduce
I often got memory leaks reported when using a debug build.
By reading the trace backs I finally found out it has to do with listing destinations for a ship, when a pinned note is listed.
This test is a try to reproduce this. To my surprise it shows an assertion error currently on my local system.

To reproduce the memory leak yourself:
1. start a recent debug build of widelands (in console, best with `LSAN_OPTIONS='suppressions=./asan_3rd_party_leaks' ./widelands`) 
2. load or create a game where you have ships (a map with sea start conditions "explorer" or "new world" work)
3. create a pinned note in water
4. open the ship window of any ship which can explore (also a war ship)
5. quit the dialog, the game and widelands
6. the console shows a memory leak

### New Behavior
None (Memory leak must be fixed first!)
