### PR TITLE
Workflow testsuite reports memory leak

### DIFF
--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -88,4 +88,4 @@ jobs:
       run: utils/test/download_loadgame_testcases.sh
     - name: Testsuite
       run: |
-        ./regression_test.py
+        ./regression_test.py --ignore-error-code  # TODO(aDiscoverer) memory leaks ignored temporary until #6807 is fixed (see also #6805)

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -44,7 +44,7 @@ jobs:
       # TODO: Under Xvfb, the usual X11 memory leaks show up as an unsymbolized
       # <unknown module> making them impossible to suppress. So we disable all
       # memory leaks checking in the testsuite for now in ubuntu-22.04
-      ASAN_OPTIONS: "detect_leaks=${{ matrix.os == 'ubuntu-22.04' && 0 || 1 }}"
+      ASAN_OPTIONS: "detect_leaks=${{ matrix.os == 'ubuntu-22.04' && '0' || '1' }}"
       LSAN_OPTIONS: 'suppressions=${{ github.workspace }}/asan_3rd_party_leaks'
       CXX: '${{ matrix.compiler }}'
     steps:

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -43,8 +43,8 @@ jobs:
       DISPLAY: ':99.0'
       # TODO: Under Xvfb, the usual X11 memory leaks show up as an unsymbolized
       # <unknown module> making them impossible to suppress. So we disable all
-      # memory leaks checking in the testsuite for now.
-      ASAN_OPTIONS: 'detect_leaks=0'
+      # memory leaks checking in the testsuite for now in ubuntu-22.04
+      ASAN_OPTIONS: 'detect_leaks=${{ matrix.os == "ubuntu-22.04" && 0 || 1 }}'
       LSAN_OPTIONS: 'suppressions=${{ github.workspace }}/asan_3rd_party_leaks'
       CXX: '${{ matrix.compiler }}'
     steps:

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -44,7 +44,7 @@ jobs:
       # TODO: Under Xvfb, the usual X11 memory leaks show up as an unsymbolized
       # <unknown module> making them impossible to suppress. So we disable all
       # memory leaks checking in the testsuite for now in ubuntu-22.04
-      ASAN_OPTIONS: 'detect_leaks=${{ matrix.os == "ubuntu-22.04" && 0 || 1 }}'
+      ASAN_OPTIONS: "detect_leaks=${{ matrix.os == 'ubuntu-22.04' && 0 || 1 }}"
       LSAN_OPTIONS: 'suppressions=${{ github.workspace }}/asan_3rd_party_leaks'
       CXX: '${{ matrix.compiler }}'
     steps:


### PR DESCRIPTION
### Type of Change
Enhancement of test environment

### Issue(s) Closed
Enhances TODO from comment in build_testsuite.yaml

### New Behavior
A short test on my GitHub repo showed that running on 24.04 does not report failures with source `<unknown module>`, so enable leak detection there.

### How it Works
environment variable ASAN_OPTIONS is set to "detect_leaks=0" for ubuntu-22.04 (as before this pr) and else to "detect_leaks=1".

### Possible Regressions
Several tests will fail because of memory leaks.
Preview of result already on https://github.com/SimonHeimberg/widelands/actions/runs/15935218586/job/44953698609?pr=17

### Notes
Not sure if now is the right time to merge this. There is already a lot to do to get the next release ready.