### PR TITLE
Regression test: Improve LSan report

### DIFF
--- a/regression_test.py
+++ b/regression_test.py
@@ -220,7 +220,10 @@ class WidelandsTestCase():
                 f'return code is {widelands.returncode:d}', info_color))
             stdout_file.write('\n')
             self.widelands_returncode = widelands.returncode
-        self.outputs.append(FileToPrint(stdout_filename))
+        if os.getenv('WLRT_HIDE_STDOUT'):
+            self.outputs.append(f'Stdout is: {stdout_filename}')
+        else:
+            self.outputs.append(FileToPrint(stdout_filename))
         return stdout_filename
 
     def run(self):

--- a/regression_test.py
+++ b/regression_test.py
@@ -331,8 +331,13 @@ class WidelandsTestCase():
                 else:
                     idx1 = lsan_log_txt.find('ERROR: ')
                     idx2 = lsan_log_txt.find('\n', idx1)
-                    self.outputs.append(colorize(lsan_log_txt[idx1:idx2], warning_color) +
-                                        f', see in {f_name}\n')
+                    txt = colorize(lsan_log_txt[idx1:idx2], warning_color) + f', see in {f_name}\n'
+                    idx1 = lsan_log_txt.rfind('SUMMARY: ')
+                    idx2 = lsan_log_txt.find('\n', idx1)
+                    if idx2 < 0:
+                        idx2 = None  # till end
+                    txt += '    ' + lsan_log_txt[idx1:idx2] + '\n'
+                    self.outputs.append(txt)
                     self.out_status('Info ', f'ASan log: {f_name}')
                 if not self.report_header:
                     # set header, as else the output will not be shown and the files get deleted

--- a/regression_test.py
+++ b/regression_test.py
@@ -351,11 +351,10 @@ class WidelandsTestCase():
     def print_report(self):
         print(f'{colorize(self.result, self.get_result_color())}: {self.test_script}\n')
         print(self.report_header)
-        print(group_start, end='')
-        print(colorize("stdout:", info_color))
         for stdout_fn in self.outputs:
+            print(group_start, colorize("stdout:", info_color))
             print(stdout_fn)
-        print(group_end, end='')
+            print(group_end, end='')
 
 
 # For parallel execution of tests

--- a/regression_test.py
+++ b/regression_test.py
@@ -328,6 +328,8 @@ class WidelandsTestCase():
             if "ERROR: " in lsan_log_txt:
                 if os.getenv('GITHUB_ACTION'):
                     self.outputs.append(FileToPrint(f_name, github_asan_line))
+                elif os.getenv('WLRT_SHOW_ASAN'):
+                    self.outputs.append(FileToPrint(f_name))
                 else:
                     idx1 = lsan_log_txt.find('ERROR: ')
                     idx2 = lsan_log_txt.find('\n', idx1)

--- a/regression_test.py
+++ b/regression_test.py
@@ -147,9 +147,15 @@ class WidelandsTestCase():
             stdout_file.write("\n")
             stdout_file.flush()
 
+            env = dict(os.environ)
+            lsan = env.get("LSAN_OPTIONS", "")
+            if "suppressions=" not in lsan:  # allow to overwrite
+                lsan += f" suppressions={datadir_for_testing()}/asan_3rd_party_leaks"
+            env["LSAN_OPTIONS"] = lsan
+
             start_time = get_time()
             widelands = subprocess.Popen(
-                    args, shell=False, stdout=stdout_file, stderr=subprocess.STDOUT)
+                    args, shell=False, stdout=stdout_file, stderr=subprocess.STDOUT, env=env)
             try:
                 widelands.communicate(timeout = self.timeout)
             except subprocess.TimeoutExpired:

--- a/regression_test.py
+++ b/regression_test.py
@@ -355,7 +355,8 @@ class WidelandsTestCase():
         print(f'{colorize(self.result, self.get_result_color())}: {self.test_script}\n')
         print(self.report_header)
         for stdout_fn in self.outputs:
-            title = getattr(stdout_fn, 'file_path', 'output').replace('_00', '').replace('.txt', '')
+            title = os.path.basename(getattr(stdout_fn, 'file_path', 'output'))\
+                .replace('_00', '').replace('.txt', '')
             print(group_start, colorize(f'{title}:', info_color))
             print(stdout_fn)
             print(group_end, end='')

--- a/regression_test.py
+++ b/regression_test.py
@@ -318,7 +318,9 @@ class WidelandsTestCase():
                 if os.getenv('GITHUB_ACTION'):
                     self.outputs.append(FileToPrint(f_name, False))  # no coloring from here
                 else:
-                    self.outputs.append(colorize('lsan errors', warning_color) +
+                    idx1 = lsan_log_txt.find('ERROR: ')
+                    idx2 = lsan_log_txt.find('\n', idx1)
+                    self.outputs.append(colorize(lsan_log_txt[idx1:idx2], warning_color) +
                                         f', see in {f_name}\n')
                 if not self.report_header:
                     self.report_header = 'lsan'  # might be overwritten, which is no problem

--- a/regression_test.py
+++ b/regression_test.py
@@ -332,6 +332,7 @@ class WidelandsTestCase():
                     idx2 = lsan_log_txt.find('\n', idx1)
                     self.outputs.append(colorize(lsan_log_txt[idx1:idx2], warning_color) +
                                         f', see in {f_name}\n')
+                self.out_status('Info ', f'ASan log: {f_name}')
                 if not self.report_header:
                     self.report_header = 'lsan'  # might be overwritten, which is no problem
             # else it is information about what was skipped matching suppression file

--- a/regression_test.py
+++ b/regression_test.py
@@ -335,7 +335,9 @@ class WidelandsTestCase():
                                         f', see in {f_name}\n')
                     self.out_status('Info ', f'ASan log: {f_name}')
                 if not self.report_header:
-                    self.report_header = 'lsan'  # might be overwritten, which is no problem
+                    # set header, as else the output will not be shown and the files get deleted
+                    # The header might get overwritten, which is no problem.
+                    self.report_header = f'Memory problem or memory leak. ASan log is: {f_name}'
             # else it is information about what was skipped matching suppression file
 
         # Catch instabilities with SDL in CI environment

--- a/regression_test.py
+++ b/regression_test.py
@@ -288,16 +288,17 @@ class WidelandsTestCase():
 
     def out_result(self, stdout_filename):
         self.out_status(self.statuses[self.result], f'{self.result} in {self.duration}')
-        if self.keep_output_around:
+        if self.keep_output_around or self.report_header and not os.getenv('GITHUB_ACTION'):
+            # files are kept in this cases, show early that the user can examine them already
             self.out_status('Info ', f'stdout: {stdout_filename}')
 
     def fail(self, short, long, stdout_filename):
         self.success = False
         self.result = short
-        self.out_result(stdout_filename)
         long = colorize(long, self.status_colors['FAIL '])
         self.report_header = f'{long} Analyze the files in {self.run_dir} to see why this test case failed.\n'
         self.report_header += colorize(f'Stdout is: {stdout_filename}', info_color)
+        self.out_result(stdout_filename)  # after report_header is set
 
     def step_success(self, stdout_filename):
         old_result = self.result

--- a/regression_test.py
+++ b/regression_test.py
@@ -341,7 +341,7 @@ class WidelandsTestCase():
                 if self.widelands_returncode == LSAN_ERROR and self.ignore_error_code:
                     self.out_status(' IGN ', f'IGNORING error code {LSAN_ERROR}')
                 else:
-                    self.fail("FAILED", "Widelands exited abnormally.", stdout_filename)
+                    self.fail("FAILED", f"Widelands exited abnormally ({self.widelands_returncode}).", stdout_filename)
                     return
             if not "All Tests passed" in stdout or "lua_errors.cc" in stdout:
                 self.fail("FAILED", "Not all tests pass.", stdout_filename)

--- a/regression_test.py
+++ b/regression_test.py
@@ -352,7 +352,8 @@ class WidelandsTestCase():
         print(f'{colorize(self.result, self.get_result_color())}: {self.test_script}\n')
         print(self.report_header)
         for stdout_fn in self.outputs:
-            print(group_start, colorize("stdout:", info_color))
+            title = getattr(stdout_fn, 'file_path', 'output').replace('_00', '').replace('.txt', '')
+            print(group_start, colorize(f'{title}:', info_color))
             print(stdout_fn)
             print(group_end, end='')
 

--- a/regression_test.py
+++ b/regression_test.py
@@ -301,6 +301,7 @@ class WidelandsTestCase():
         if self.keep_output_around or self.report_header and not os.getenv('GITHUB_ACTION'):
             # files are kept in this cases, show early that the user can examine them already
             self.out_status('Info ', f'stdout: {stdout_filename}')
+            # ASan info should be printed here instead of verify_success(), but data is not here
 
     def fail(self, short, long, stdout_filename):
         self.success = False
@@ -332,7 +333,7 @@ class WidelandsTestCase():
                     idx2 = lsan_log_txt.find('\n', idx1)
                     self.outputs.append(colorize(lsan_log_txt[idx1:idx2], warning_color) +
                                         f', see in {f_name}\n')
-                self.out_status('Info ', f'ASan log: {f_name}')
+                    self.out_status('Info ', f'ASan log: {f_name}')
                 if not self.report_header:
                     self.report_header = 'lsan'  # might be overwritten, which is no problem
             # else it is information about what was skipped matching suppression file


### PR DESCRIPTION
### Type of Change
Enhancement of test environment

### Issue(s) Closed
Fixes --

### New Behavior
Memory leaks reported by ASan are handled and shown clearer.

### How it Works
The environment variable LSAN_OPTIONS is used to get better output in case of memory leaks.

### Possible Regressions
???

### Screenshots
part of output from run on console (with -i)

<pre>1/1 Start test_lua_in_game.lua: test/maps/lua_testsuite.wmf/scripting/test_lua_in_game.lua starting ...
1/1 <span style="color:#A2734C"> IGN </span> test_lua_in_game.lua: <span style="color:#A2734C">IGNORING error code 58</span>
1/1 <span style="color:#26A269">Done </span> test_lua_in_game.lua: <span style="color:#26A269">Passed in 0:00:27.338353</span>
1/1 <span style="color:#2AA1B3">Info </span> test_lua_in_game.lua: <span style="color:#2AA1B3">stdout: /tmp/widelands_regression_test_uwu8r5r4/stdout_00.txt</span>

<span style="color:#A347BA">---------------------------------------------------------------------------</span>

<span style="color:#26A269">Passed</span>: test/maps/lua_testsuite.wmf/scripting/test_lua_in_game.lua

lsan

 <span style="color:#2AA1B3">stdout:</span>
Running widelands binary: ./widelands --verbose --datadir=/home/wl/code/widelands/data --datadir_for_testing=. --homedir=/tmp/widelands_regression_test_uwu8r5r4 --nosound --fail-on-lua-error --fail-on-errors --language=en --scenario=test/maps/lua_testsuite.wmf --script=test/maps/lua_testsuite.wmf/scripting/test_lua_in_game.lua 
This is Widelands version 1.3~git27030 (3898585@lua_api_include_return) Debug
Adding home directory: /tmp/widelands_regression_test_uwu8r5r4
[00:00:00.000 real] INFO: Set home directory: /tmp/widelands_regression_test_uwu8r5r4</pre>
...
<pre>[00:00:00.463 game] DEBUG: Player: 4; Jobs: 1; delay: 0; gamespeed: 1000 
[00:00:25.472 real] INFO: lastserial: 0

<span style="color:#2AA1B3">test_lua_in_game.lua: Returned from Widelands in 0:00:27.338353, return code is 58</span>


 <span style="color:#2AA1B3">output:</span>
<span style="color:#A2734C">ERROR: LeakSanitizer: detected memory leaks</span>, see in /tmp/widelands_regression_test_uwu8r5r4/lsan_00.110983.txt


<span style="color:#A347BA">---------------------------------------------------------------------------</span>

Ran 1 test cases in 23.519 s, <span style="color:#26A269">all tests passed.</span>
</pre>

Expected output on GitHub (with -i):
<pre>1/1 Start test_lua_in_game.lua: test/maps/lua_testsuite.wmf/scripting/test_lua_in_game.lua starting ...
1/1 <span style="color:#A2734C"> IGN </span> test_lua_in_game.lua: <span style="color:#A2734C">IGNORING error code 58</span>
1/1 <span style="color:#26A269">Done </span> test_lua_in_game.lua: <span style="color:#26A269">Passed in 0:00:27.338353</span>
1/1 <span style="color:#2AA1B3">Info </span> test_lua_in_game.lua: <span style="color:#2AA1B3">stdout: /tmp/widelands_regression_test_uwu8r5r4/stdout_00.txt</span>

<span style="color:#A347BA">---------------------------------------------------------------------------</span>

<span style="color:#26A269">Passed</span>: test/maps/lua_testsuite.wmf/scripting/test_lua_in_game.lua

lsan
</pre>
:small_red_triangle_down: `stdout:`
:small_red_triangle_down:  `lsan.110983:`
<pre>
<span style="color:#A347BA">---------------------------------------------------------------------------</span>

Ran 1 test cases in 23.519 s, <span style="color:#26A269">all tests passed.</span>
</pre>
( legend: :small_red_triangle_down: expands on click to show content of stdout/lsan_report)

### Additional context
This could help to handle memory leaks shown by #6805 easier because they are shown clearer.

