### PR TITLE
Memory leak summary from GitHub log

### DIFF
--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -87,5 +87,13 @@ jobs:
     - name: download savegame testcases
       run: utils/test/download_loadgame_testcases.sh
     - name: Testsuite
+      id: testsuite
+      shell: bash  # to have pipefail enabled
       run: |
-        ./regression_test.py --ignore-error-code  # TODO(aDiscoverer) memory leaks ignored temporary until #6807 is fixed (see also #6805)
+        ./regression_test.py --ignore-error-code | tee ../testsuite_log.txt
+        # TODO(aDiscoverer) memory leaks ignored temporary until #6807 is fixed (see also #6805)
+        # output ASAN_FAILURE is written by ./regression_test.py
+    - name: ASan Memory Leak Summary
+      if: steps.testsuite.outputs.ASAN_FAILURE && ! cancelled()
+      run: |
+        utils/test/memory_leak_summary_from_gh_log.py ../testsuite_log.txt

--- a/regression_test.py
+++ b/regression_test.py
@@ -378,12 +378,15 @@ class WidelandsTestCase():
     def print_report(self):
         print(f'{colorize(self.result, self.get_result_color())}: {self.test_script}\n')
         print(self.report_header)
+        lsan_report = False
         for stdout_fn in self.outputs:
             title = os.path.basename(getattr(stdout_fn, 'file_path', 'output'))\
                 .replace('_00', '').replace('.txt', '')
             print(group_start, colorize(f'{title}:', info_color))
             print(stdout_fn)
             print(group_end, end='')
+            lsan_report = lsan_report or title.startswith('lsan.')
+        return lsan_report
 
 
 # For parallel execution of tests
@@ -614,17 +617,21 @@ def main():
 
     nr_errors = 0
     results = dict()
+    lsan_report = False
     for test_case in test_cases:
         # Skipped test cases are logged, but don't count as failure
         if test_case.report_header != None:
             print(separator)
-            test_case.print_report()
+            lsan_report = test_case.print_report() or lsan_report
             if test_case.result in results.keys():
                 results[test_case.result].append(test_case.test_script)
             else:
                 results[test_case.result] = [ test_case.test_script ]
         if not test_case.success:
             nr_errors += 1
+    if lsan_report and os.getenv('GITHUB_OUTPUT'):
+        with open(os.getenv('GITHUB_OUTPUT'), 'a') as gh_out:
+            gh_out.write('ASAN_FAILURE=true\n')
 
     print(separator)
 

--- a/regression_test.py
+++ b/regression_test.py
@@ -74,7 +74,7 @@ def github_asan_line(text):
     # GitHub only supports 10 error and 10 warning annotations per step. This might be too few.
     # Therefore only annotate the summary line of ASan.
     if 'SUMMARY' in text:
-        return '::warning title=ASan error::' + text
+        return '::warning::' + text
     return text
 
 

--- a/regression_test.py
+++ b/regression_test.py
@@ -71,7 +71,7 @@ def colorize_log(text):
 
 def github_asan_line(text):
     "annotates asan summary on GitHub"
-    # GitHub only supports 10 error and 10 warning annotations per step. This might be too few.
+    # GitHub only lists 10 error and 10 warning annotations per step. This might be too few.
     # Therefore only annotate the summary line of ASan.
     if 'SUMMARY' in text:
         return '::warning::' + text

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -57,7 +57,17 @@ class GithubASan:
             if os.getenv('GITHUB_STEP_SUMMARY'):
                 write_summary('    our origin: ', text)
             cls.found_local_tb = True
-            return f'::notice title=memory leak origin::{text}'
+            if os.getenv('WLRT_ANNOTATE_LINE'):  # with strategy.job-index == 0 from workflow
+                # annotate only one test job to not have many dublicate messages on one line
+                # unfortunately the jobs can not coordinate
+                f_name = text.rsplit(f'/{compile_d}/', 1)[1]
+                if f_name == text:
+                    f_name = 'src/' + text.rsplit(' src/', 1)[1]
+                f_name, line_no = f_name.rsplit(':', 2)[:2]
+                return f'::notice file={f_name}, line={line_no}, title=memory leak origin::{text}'
+            else:
+                # only mark in log
+                return f'::notice title=memory leak origin::{text}'
         return text
 
     @classmethod

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -40,7 +40,7 @@ class GithubASan:
                 write_summary('\n', text)
             return '::warning title=ASan error::' + text
         if 'irect leak of ' in text and os.getenv('GITHUB_STEP_SUMMARY'):  # Direct or Indirect leak
-            write_summary('+ ', text)  # this text is colored
+            write_summary('+ ', text.replace(' allocated from:', '', 1))  # this text is colored
             cls.found_local_tb = False
         if not cls.found_local_tb and '/widelands/src/' in text and '/third_party/' not in text:
             if os.getenv('GITHUB_STEP_SUMMARY'):

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -1,0 +1,84 @@
+#!/bin/env python3
+"""write github job summary from github log
+
+pipe to this script input like from:
+- unzip -p .../wl_logs_run_41823906582.zip
+    '10_testsuite _ testsuite (Debug, ubuntu-24.04, g++-13).txt'
+    # zip fetched from github, with "download log archive"
+- curl https://github.com/widelands/widelands/commit/$C_HASH/checks/$JOB_NUM_ID/logs
+    # one way to get a raw log by url
+- gh run view --log --job 456789  # maybe, unchecked
+- cat /tmp/widelands_regression_test_XXX/lsan_XX.XXX.txt  # file created by ./regression_test.py
+"""
+
+import enum
+import sys
+import os
+
+
+class GithubASan:
+    @classmethod
+    def github_asan_line(cls, text):
+        "annotates asan summary on GitHub and writes more info to the steps summary file"
+        # GitHub only supports 10 error and 10 warning annotations per step. This might be too few.
+        # Therefore only annotate the summary line of ASan and write other info to the steps summary
+        def write_summary(arg1, *args):
+            "write to github summary file"
+            with open(os.getenv('GITHUB_STEP_SUMMARY'), 'a') as summary_file:
+                summary_file.write(arg1)
+                for arg in args:
+                    summary_file.write(arg)
+
+        if 'ERROR: ' in text and os.getenv('GITHUB_STEP_SUMMARY'):
+            write_summary('### ', text)  # this text is colored
+        if 'SUMMARY' in text:
+            if os.getenv('GITHUB_STEP_SUMMARY'):
+                write_summary('\n', text)
+            return '::warning title=ASan error::' + text
+        if 'irect leak of ' in text and os.getenv('GITHUB_STEP_SUMMARY'):  # Direct or Indirect leak
+            write_summary('+ ', text)  # this text is colored
+        return text
+
+
+def create_summary_one_runner():
+    class ReadingMode(enum.Enum):
+        BEGIN = enum.auto()
+        INSIDE = enum.auto()
+        RT_HEADER = enum.auto()
+        RT_LOGS = enum.auto()
+        LSAN = enum.auto()
+
+    def get_log_line(line):
+        "get the log line without timestamp"
+        return line.split('Z ', 1)[-1]
+
+    r_mode: ReadingMode = ReadingMode.BEGIN
+    for line in sys.stdin:
+        match r_mode:
+            case ReadingMode.BEGIN:
+                if '========' in line:  # directly a log as input
+                    r_mode = ReadingMode.LSAN
+                elif line != '\n':  # when not an empty line
+                    r_mode = ReadingMode.INSIDE
+            case ReadingMode.INSIDE:
+                if ' ##[group]Run ' in line and 'regression_test.py' in line:
+                    r_mode = ReadingMode.RT_HEADER
+            case ReadingMode.RT_HEADER:
+                if '------' in line:
+                    r_mode = ReadingMode.RT_LOGS
+            case ReadingMode.RT_LOGS:
+                if ' ##[group]' in line and 'lsan.' in line:
+                    r_mode = ReadingMode.LSAN
+            case ReadingMode.LSAN:
+                if ' ##[endgroup]' in line:
+                    r_mode = ReadingMode.RT_LOGS
+                else:
+                    GithubASan.github_asan_line(get_log_line(line))
+
+
+def main():
+    create_summary_one_runner()
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -78,7 +78,7 @@ class GithubASan:
             if cls.summary_file and cls.counted_leaks > 0:
                 summary_tag = f'\n<summary>{cls.counted_leaks} leaks</summary>\n'
                 write_summary(summary_tag, '</details>\n', text)
-            return f'''::warning file={cls.test_script or "??"}::''' + text
+            return f'''::warning file={cls.test_script or '??'}::''' + text
         if 'irect leak of ' in text and cls.summary_file:  # Direct or Indirect leak
             if cls.counted_leaks == 0:
                 write_summary('<details>\n\n')  # needs empty line for the following list

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -76,7 +76,8 @@ class GithubASan:
                 # add code part in `` to avoid invalid html
                 to_write = ')`'.join(text.rsplit(')', 1)).replace(
                     ' in ', '` in `', 1).replace('#', '`#', 1)
-                write_summary('    our origin: ', to_write)
+                write_summary('    our origin: ', to_write.replace(
+                    f_name_line, f'[{f_name_line}](<#user-content-{f_name_line.lower()}> "to grouped")'))
                 data = {'tb': to_write, 'test': cls.test_script}
                 cls.leaks_by_origin.setdefault(f_name_line, []).append(data)
             if os.getenv('WLRT_ANNOTATE_LINE'):  # with strategy.job-index == 0 from workflow
@@ -101,7 +102,7 @@ class GithubASan:
         with open(os.getenv('GITHUB_STEP_SUMMARY'), 'a') as summary_file:
             summary_file.write('\n\n## memory leaks by origin\n\n')
             for origin in sorted(cls.leaks_by_origin):
-                summary_file.write(f'#### {origin}\n')
+                summary_file.write(f'#### {origin} <a name="{origin}"></a>\n')
                 for data in cls.leaks_by_origin[origin]:
                     summary_file.write(f'+{data["tb"]}    triggered by {data["test"]}\n')
                 summary_file.write('\n')

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -133,7 +133,7 @@ class GithubASan:
                 search_on_gh = ('/' + os.getenv('GITHUB_REPOSITORY', 'widelands/widelands') +
                                 '/issues?q=' + to_query_str(
                     f'is:issue state:open label:"memory & performance" '
-                    f'''"{origin.rsplit(':', 1)[0]}"'''))
+                    f'''"{origin.rsplit(':', 2)[0]}"'''))
                 summary_file.write(
                     f'\n<details><summary>\n\n#### {origin} <a name="{origin}"></a>\n</summary>\n\n'
                     f'[search issue on gh](<{search_on_gh}>)\n')

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -12,6 +12,7 @@ pipe to this script input like from:
 - cat /tmp/widelands_regression_test_XXX/lsan_XX.XXX.txt  # file created by ./regression_test.py
 
 Or give a file in this format as argument.
+
 """
 
 import enum
@@ -119,12 +120,13 @@ class GithubASan:
             return txt.translate({ord(':'): '%3A', ord('"'): '%22', ord('&'): '%26'})
 
         def key_path_of_tb(data):
-            """for sorting by path in traceback line (ignoring memory address)"""
+            """for sorting by path in traceback line (ignoring memory
+            address)"""
             # sort by: called code, then test
             return data['tb'].split(' in ', 1)[-1], data['test']
 
         def key_file_line_col(file_line_col):
-            """for sorting by line numerically"""
+            """for sorting by line numerically."""
             return [int(e) if e.isdecimal() else e for e in file_line_col.rsplit(':', 2)]
 
         if not cls.leaks_by_origin or not cls.summary_file:
@@ -169,6 +171,7 @@ def create_summary_one_runner(in_file):
         """get the normal log line.
 
         without timestamp and github label
+
         """
         if 'Z ##[' in line:
             line, cnt = re.subn('^.*Z ##\[[^]]+\]', '', line, 1)
@@ -177,7 +180,7 @@ def create_summary_one_runner(in_file):
         return line.split('Z ', 1)[-1]
 
     def get_log_line_local(line):
-        """for when input is not from github"""
+        """for when input is not from github."""
         if '::' in line and line.startswith('::'):
             idx = line.find('::', 2)
             if idx > 0:

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -57,9 +57,10 @@ class GithubASan:
             if os.getenv('GITHUB_STEP_SUMMARY'):
                 write_summary('    our origin: ', text)
             cls.found_local_tb = True
-            f_name_line = text.rsplit(f'/{compile_d}/', 1)[1]
-            if f_name_line == text:
+            if ' src/' in text:  # stipped by ASAN_OPTIONS='strip_path_prefix=/...
                 f_name_line = 'src/' + text.rsplit(' src/', 1)[1].rstrip()
+            else:
+                f_name_line = text.rsplit(f'/{compile_d}/', 1)[1].rstrip()
             if os.getenv('WLRT_ANNOTATE_LINE'):  # with strategy.job-index == 0 from workflow
                 # annotate only one test job to not have many dublicate messages on one line
                 # unfortunately the jobs can not coordinate

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -191,8 +191,12 @@ def create_summary_one_runner(in_file):
     if not os.getenv('GITHUB_STEP_SUMMARY') and not '/dev/' in os.devnull:
         print('set environment variable GITHUB_STEP_SUMMARY to get output', sys.stderr)
         os.exit(19)  # exit with "no such device exists" (stdout file not found)
+    step_summary_p = os.getenv('GITHUB_STEP_SUMMARY')
+    if step_summary_p and os.path.isfile(step_summary_p) and os.stat(step_summary_p).st_size > 0:
+        with open(step_summary_p, 'a') as summary_file:
+            summary_file.write('\n\n\n\n')  # write separating empty lines
+        print('WARNING: ' + step_summary_p + ' has content', file=sys.stderr)
     GithubASan.set_summary_file(os.getenv('GITHUB_STEP_SUMMARY', '/dev/stdout'))
-    # TODO summary file should be empty
 
     if in_file.isatty():
         print(f'  hint: program expects input on {in_file.name}', file=sys.stderr)

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -215,6 +215,7 @@ def create_summary_one_runner(in_file):
                 if '------' in line:
                     if r_mode == ReadingMode.RT_HEADER_L:
                         r_mode = ReadingMode.RT_LOGS_L
+                        get_log_line = get_log_line_local
                     else:
                         r_mode = ReadingMode.RT_LOGS
             case ReadingMode.RT_LOGS | ReadingMode.RT_LOGS_L:
@@ -223,7 +224,6 @@ def create_summary_one_runner(in_file):
                     r_mode = ReadingMode.LSAN
                 elif '::group:: ' in line and 'lsan' in line:
                     r_mode = ReadingMode.LSAN
-                    get_log_line = get_log_line_local
                 elif ': ' in line and ('Passed' in line or 'FAILED' in line or 'TIMED OUT' in line):
                     # this is before stdout
                     idx = line.find(': ')
@@ -236,7 +236,7 @@ def create_summary_one_runner(in_file):
                 if ' ##[endgroup]' in line:
                     r_mode = ReadingMode.RT_LOGS
                 elif '::endgroup::' in line:
-                    r_mode = ReadingMode.RT_LOGS
+                    r_mode = ReadingMode.RT_LOGS_L
                 else:
                     GithubASan.github_asan_line(get_log_line(line))
     GithubASan.summarize_origins()

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -254,7 +254,7 @@ def create_summary_one_runner(in_file):
 
 def main():
     in_file = None
-    if len(sys.argv) == 0:
+    if len(sys.argv) == 1:
         pass
     elif sys.argv[1] in ('-h', '--help'):
         print(__doc__)

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -161,7 +161,7 @@ def create_summary_one_runner():
 
         """
         if 'Z ##[' in line:
-            line, cnt = re.subn('^.*Z ##[[][^]]+]', '', line, 1)
+            line, cnt = re.subn('^.*Z ##\[[^]]+\]', '', line, 1)
             if cnt > 0:  # if it really was with github label
                 return line
         return line.split('Z ', 1)[-1]

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -43,7 +43,8 @@ class GithubASan:
             """removes ansi escape sequences (because github summary does not
             support them)"""
             if not cls.ansi_escape_pattern:
-                cls.ansi_escape_pattern = re.compile(r'\x1b[^m]*m')
+                # \x1b is the escape character, the other one the textual representation used by gh
+                cls.ansi_escape_pattern = re.compile(r'[\x1b\u241b][^m]*m')
             return cls.ansi_escape_pattern.sub('', text)
 
         if 'ERROR: ' in text and cls.summary_file:

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -42,7 +42,9 @@ class GithubASan:
         if 'irect leak of ' in text and os.getenv('GITHUB_STEP_SUMMARY'):  # Direct or Indirect leak
             write_summary('+ ', text.replace(' allocated from:', '', 1))  # this text is colored
             cls.found_local_tb = False
-        if not cls.found_local_tb and '/widelands/src/' in text and '/third_party/' not in text:
+        compile_d = os.getenv('WLRT_COMPILE_DIR', 'widelands')  # default is for GitHub
+        if not cls.found_local_tb and '/third_party/' not in text and \
+                (f'/{compile_d}/src/' in text or ' src/' in text):
             if os.getenv('GITHUB_STEP_SUMMARY'):
                 write_summary('    our origin: ', text)
             cls.found_local_tb = True

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -40,7 +40,7 @@ class GithubASan:
     def github_asan_line(cls, text):
         """annotates asan summary on GitHub and writes more info to the steps
         summary file."""
-        # GitHub only supports 10 error and 10 warning annotations per step. This might be too few.
+        # GitHub only lists 10 error and 10 warning annotations per step. This might be too few.
         # Therefore only annotate the summary line of ASan and write other info to the steps summary
         def write_summary(arg1, *args):
             """write to github summary file (markdown format)"""

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -45,7 +45,7 @@ class GithubASan:
         if 'ERROR: ' in text and os.getenv('GITHUB_STEP_SUMMARY'):
             if cls.counted_leaks is None:
                 write_summary(
-                    '## memory leaks\n\n> [!TIP]\n'
+                    '## memory leaks <a name=memory-leak></a>\n\n> [!TIP]\n'
                     '> To find the full traceback, go to the log (from menu `...` on top right of '
                     'this text block) and copy the line from the traceback here in the log\'s '
                     'search field.\n')
@@ -106,6 +106,11 @@ class GithubASan:
                     summary_file.write(f'+{data["tb"]}    triggered by {data["test"]}\n')
                 summary_file.write('\n')
         cls.leaks_by_origin = {}
+        print('\nsee about memory leaks in job summary on',
+              os.getenv('GITHUB_SERVER_URL', 'https://github.com') + '/' +
+              os.getenv('GITHUB_REPOSITORY', 'widelands/widelands') + '/actions/' +
+              ('/runs/' + os.getenv('GITHUB_RUN_ID') if os.getenv('GITHUB_RUN_ID') else '') +
+              '#user-content-memory-leak')
 
 
 def create_summary_one_runner():

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -51,7 +51,7 @@ class GithubASan:
                     'this text block) and copy the line from the traceback here in the log\'s '
                     'search field.\n')
             write_summary('\n### ', remove_ansi_escape_sequences(text))
-            write_summary('triggered by test ', cls.test_script, '\n\n')
+            write_summary('triggered by test ', cls.test_script or '???', '\n\n')
             cls.counted_leaks = 0
         if 'SUMMARY' in text:
             if cls.summary_file and cls.counted_leaks > 0:
@@ -119,7 +119,7 @@ class GithubASan:
                     f'\n<details><summary>\n\n#### {origin} <a name="{origin}"></a>\n</summary>\n\n'
                     f'[search issue on gh](<{search_on_gh}>)\n')
                 for data in cls.leaks_by_origin[origin]:
-                    summary_file.write(f'+{data["tb"]}    triggered by {data["test"]}\n')
+                    summary_file.write(f'+{data["tb"]}    triggered by {data["test"] or "???"}\n')
                 summary_file.write('</details>\n')
         cls.leaks_by_origin = {}
         summary_hint = '\nsee about memory leaks in job summary on'

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -59,8 +59,9 @@ class GithubASan:
         if not cls.found_local_tb and '/third_party/' not in text and \
                 (f'/{compile_d}/src/' in text or ' src/' in text):
             if os.getenv('GITHUB_STEP_SUMMARY'):
-                # add code part in `` to avoid invalid html
-                to_write = ')`'.join(text.rsplit(')', 1)).replace(' in ', ' in `', 1)
+                # add code part in `` to avoid invalid html and also #7 to avoid issue references
+                to_write = ')`'.join(text.rsplit(')', 1)).replace(
+                    ' in ', '` in `', 1).replace('#', '`#', 1)
                 write_summary('    our origin: ', to_write)
             cls.found_local_tb = True
             if ' src/' in text:  # stipped by ASAN_OPTIONS='strip_path_prefix=/...

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -116,7 +116,8 @@ class GithubASan:
             return txt.translate({ord(':'): '%3A', ord('"'): '%22', ord('&'): '%26'})
 
         def key_path_of_tb(data):
-            "for sorting by path in traceback line (ignoring memory address and code)"
+            """for sorting by path in traceback line (ignoring memory address
+            and code)"""
             return data['tb'].rsplit('` ', 1)[-1], data['test']
 
         if not cls.leaks_by_origin or not cls.summary_file:

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -45,11 +45,17 @@ class GithubASan:
 
         if 'ERROR: ' in text and cls.summary_file:
             if cls.counted_leaks is None:
+                goto_txt = 'go to the log'
+                if os.getenv('GITHUB_ACTION'):
+                    goto_txt = goto_txt + ' (from menu `...` on top right of this text block)'
+                elif os.getenv('WLRT_LOG_URL'):
+                    goto_txt = f'({goto_txt})[os.getenv(WLRT_LOG_URL)]'
+                else:
+                    goto_txt = goto_txt + ' (you gave as input)'
                 write_summary(
                     '## memory leaks <a name=memory-leak></a>\n\n> [!TIP]\n'
-                    '> To find the full traceback, go to the log (from menu `...` on top right of '
-                    'this text block) and copy the line from the traceback here in the log\'s '
-                    'search field.\n')
+                    f'> To find the full traceback, {goto_txt} '
+                    'and copy the line from the traceback here in the log\'s search field.\n')
             write_summary('\n### ', remove_ansi_escape_sequences(text))
             write_summary('triggered by test ', cls.test_script or '???', '\n\n')
             cls.counted_leaks = 0

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -59,7 +59,7 @@ class GithubASan:
             cls.found_local_tb = True
             f_name_line = text.rsplit(f'/{compile_d}/', 1)[1]
             if f_name_line == text:
-                f_name_line = 'src/' + text.rsplit(' src/', 1)[1]
+                f_name_line = 'src/' + text.rsplit(' src/', 1)[1].rstrip()
             if os.getenv('WLRT_ANNOTATE_LINE'):  # with strategy.job-index == 0 from workflow
                 # annotate only one test job to not have many dublicate messages on one line
                 # unfortunately the jobs can not coordinate

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -18,11 +18,11 @@ import re
 
 
 class GithubASan:
-    found_local_tb = True
+    found_local_tb = True  # true if not looking for our line in current traceback
     test_script = None
-    ansi_escape_pattern = None
-    counted_leaks = None
-    leaks_by_origin = {}
+    ansi_escape_pattern = None  # for remove_ansi_escape_sequences()
+    counted_leaks = None  # counts memory leaks from one run of widelands
+    leaks_by_origin = {}  # memory leaks grouped by origin
 
     @classmethod
     def github_asan_line(cls, text):

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -128,12 +128,13 @@ class GithubASan:
                 search_on_gh = ('/' + os.getenv('GITHUB_REPOSITORY', 'widelands/widelands') +
                                 '/issues?q=' + to_query_str(
                     f'is:issue state:open label:"memory & performance" '
-                    f'"{origin.rsplit(':', 1)[0]}"'))
+                    f'''"{origin.rsplit(':', 1)[0]}"'''))
                 summary_file.write(
                     f'\n<details><summary>\n\n#### {origin} <a name="{origin}"></a>\n</summary>\n\n'
                     f'[search issue on gh](<{search_on_gh}>)\n')
                 for data in sorted(cls.leaks_by_origin[origin], key=key_path_of_tb):
-                    summary_file.write(f'+{data['tb']}    triggered by {data['test'] or '???'}\n')
+                    summary_file.write(
+                        f'''+{data['tb']}    triggered by {data['test'] or '???'}\n''')
                 summary_file.write('</details>\n')
         cls.leaks_by_origin = {}
         summary_hint = '\nsee about memory leaks in job summary on'

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -157,6 +157,9 @@ def create_summary_one_runner():
     GithubASan.set_summary_file(os.getenv('GITHUB_STEP_SUMMARY', '/dev/stdout'))
     # TODO summary file should be empty
 
+    if sys.stdin.isatty():
+        print('  hint: program expects input on stdin', file=sys.stderr)
+
     r_mode: ReadingMode = ReadingMode.BEGIN
     for line in sys.stdin:
         match r_mode:

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -142,7 +142,13 @@ def create_summary_one_runner():
         LSAN = enum.auto()
 
     def get_log_line(line):
-        "get the log line without timestamp"
+        """get the normal log line
+
+        without timestamp and github label"""
+        if 'Z ##[' in line:
+            line, cnt = re.subn('^.*Z ##[[][^]]+]', '', line, 1)
+            if cnt > 0:  # if it really was with github label
+                return line
         return line.split('Z ', 1)[-1]
 
     if not os.getenv('GITHUB_STEP_SUMMARY') and not '/dev/' in os.devnull:

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -135,10 +135,14 @@ class GithubASan:
             """for sorting by line numerically."""
             return [int(e) if e.isdecimal() else e for e in file_line_col.rsplit(':', 2)]
 
-        if not cls.leaks_by_origin or not cls.summary_file:
+        if not cls.leaks_by_origin and not cls.counted_leaks or not cls.summary_file:
             return
         with open(cls.summary_file, 'a') as summary_file:
-            summary_file.write('\n\n## memory leaks by origin\n\n')
+            summary_file.write('\n\n## memory leaks by origin\n\n'
+                               f'from {len(cls.leaks_by_origin)} origins\n')
+            if len(cls.leaks_by_origin) == 0:
+                summary_file.write('(No origin detected. Set WLRT_COMPILE_DIR to the name of the '
+                                   'directory widelands was compiled in.)')
             for origin in sorted(cls.leaks_by_origin, key=key_file_line_col):
                 search_on_gh = ('/' + os.getenv('GITHUB_REPOSITORY', 'widelands/widelands') +
                                 '/issues?q=' + to_query_str(

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -13,6 +13,11 @@ pipe to this script input like from:
 
 Or give a file in this format as argument.
 
+If not running on GitHub, those variables might be helpful:
+WLRT_COMPILE_DIR: Name of the directory widelands was compiled in. Default is widelands.
+                  Origins are not found in traceback if this value is wrong.
+GITHUB_SHA: commit hash for widelands. Used in links for searching or creating issues.
+WLRT_LOG_URL: url to the log, used in one link
 """
 
 import enum
@@ -248,7 +253,12 @@ def create_summary_one_runner(in_file):
 
 def main():
     in_file = None
-    if len(sys.argv) > 1 and sys.argv[1] != '-':
+    if len(sys.argv) == 0:
+        pass
+    elif sys.argv[1] in ('-h', '--help'):
+        print(__doc__)
+        return
+    elif sys.argv[1] != '-':
         in_file = open(sys.argv[1])
     try:
         create_summary_one_runner(in_file or sys.stdin)

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -56,7 +56,7 @@ class GithubASan:
                 if os.getenv('GITHUB_ACTION'):
                     goto_txt = goto_txt + ' (from menu `...` on top right of this text block)'
                 elif os.getenv('WLRT_LOG_URL'):
-                    goto_txt = f'({goto_txt})[os.getenv(WLRT_LOG_URL)]'
+                    goto_txt = f'''({goto_txt})[{os.getenv('WLRT_LOG_URL')}]'''
                 else:
                     goto_txt = goto_txt + ' (you gave as input)'
                 write_summary(

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -78,7 +78,7 @@ class GithubASan:
             if cls.summary_file and cls.counted_leaks > 0:
                 summary_tag = f'\n<summary>{cls.counted_leaks} leaks</summary>\n'
                 write_summary(summary_tag, '</details>\n', text)
-            return '::warning title=ASan error::' + text
+            return f'''::warning file={cls.test_script or "??"}::''' + text
         if 'irect leak of ' in text and cls.summary_file:  # Direct or Indirect leak
             if cls.counted_leaks == 0:
                 write_summary('<details>\n\n')  # needs empty line for the following list

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -218,9 +218,10 @@ def create_summary_one_runner(in_file):
                     else:
                         r_mode = ReadingMode.RT_LOGS
             case ReadingMode.RT_LOGS | ReadingMode.RT_LOGS_L:
-                if ' ##[group]' in line and 'lsan.' in line:
+                if ' ##[group] ' in line and 'lsan' in line:
+                    # matching on "lsan.245:" and "lsan_01.732:"
                     r_mode = ReadingMode.LSAN
-                elif '::group::' in line and 'lsan.' in line:
+                elif '::group:: ' in line and 'lsan' in line:
                     r_mode = ReadingMode.LSAN
                     get_log_line = get_log_line_local
                 elif ': ' in line and ('Passed' in line or 'FAILED' in line or 'TIMED OUT' in line):

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -57,17 +57,18 @@ class GithubASan:
             if os.getenv('GITHUB_STEP_SUMMARY'):
                 write_summary('    our origin: ', text)
             cls.found_local_tb = True
+            f_name_line = text.rsplit(f'/{compile_d}/', 1)[1]
+            if f_name_line == text:
+                f_name_line = 'src/' + text.rsplit(' src/', 1)[1]
             if os.getenv('WLRT_ANNOTATE_LINE'):  # with strategy.job-index == 0 from workflow
                 # annotate only one test job to not have many dublicate messages on one line
                 # unfortunately the jobs can not coordinate
-                f_name = text.rsplit(f'/{compile_d}/', 1)[1]
-                if f_name == text:
-                    f_name = 'src/' + text.rsplit(' src/', 1)[1]
-                f_name, line_no = f_name.rsplit(':', 2)[:2]
-                return f'::notice file={f_name}, line={line_no}, title=memory leak origin::{text}'
+                f_name, line_no = f_name_line.rsplit(':', 2)[:2]
+                return f'::notice file={f_name}, line={line_no}::memory leak from {f_name_line}\n' \
+                    f'{text}'
             else:
                 # only mark in log
-                return f'::notice title=memory leak origin::{text}'
+                return f'::notice::memory leak from {f_name_line}\n{text}'
         return text
 
     @classmethod

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -115,6 +115,10 @@ class GithubASan:
             """only escape what is needed for our case."""
             return txt.translate({ord(':'): '%3A', ord('"'): '%22', ord('&'): '%26'})
 
+        def key_path_of_tb(data):
+            "for sorting by path in traceback line (ignoring memory address and code)"
+            return data['tb'].rsplit('` ', 1)[-1], data['test']
+
         if not cls.leaks_by_origin or not cls.summary_file:
             return
         with open(cls.summary_file, 'a') as summary_file:
@@ -127,7 +131,7 @@ class GithubASan:
                 summary_file.write(
                     f'\n<details><summary>\n\n#### {origin} <a name="{origin}"></a>\n</summary>\n\n'
                     f'[search issue on gh](<{search_on_gh}>)\n')
-                for data in cls.leaks_by_origin[origin]:
+                for data in sorted(cls.leaks_by_origin[origin], key=key_path_of_tb):
                     summary_file.write(f'+{data['tb']}    triggered by {data['test'] or '???'}\n')
                 summary_file.write('</details>\n')
         cls.leaks_by_origin = {}

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -18,6 +18,7 @@ WLRT_COMPILE_DIR: Name of the directory widelands was compiled in. Default is wi
                   Origins are not found in traceback if this value is wrong.
 GITHUB_SHA: commit hash for widelands. Used in links for searching or creating issues.
 WLRT_LOG_URL: url to the log, used in one link
+
 """
 
 import enum

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -1,5 +1,5 @@
 #!/bin/env python3
-"""write github job summary from github log
+"""write github job summary from github log.
 
 pipe to this script input like from:
 - unzip -p .../wl_logs_run_41823906582.zip
@@ -9,6 +9,7 @@ pipe to this script input like from:
     # one way to get a raw log by url
 - gh run view --log --job 456789  # maybe, unchecked
 - cat /tmp/widelands_regression_test_XXX/lsan_XX.XXX.txt  # file created by ./regression_test.py
+
 """
 
 import enum
@@ -27,18 +28,20 @@ class GithubASan:
 
     @classmethod
     def github_asan_line(cls, text):
-        "annotates asan summary on GitHub and writes more info to the steps summary file"
+        """annotates asan summary on GitHub and writes more info to the steps
+        summary file."""
         # GitHub only supports 10 error and 10 warning annotations per step. This might be too few.
         # Therefore only annotate the summary line of ASan and write other info to the steps summary
         def write_summary(arg1, *args):
-            "write to github summary file (markdown format)"
+            """write to github summary file (markdown format)"""
             with open(cls.summary_file, 'a') as summary_file:
                 summary_file.write(arg1)
                 for arg in args:
                     summary_file.write(arg)
 
         def remove_ansi_escape_sequences(text):
-            "removes ansi escape sequences (because github summary does not support them)"
+            """removes ansi escape sequences (because github summary does not
+            support them)"""
             if not cls.ansi_escape_pattern:
                 cls.ansi_escape_pattern = re.compile(r'\x1b[^m]*m')
             return cls.ansi_escape_pattern.sub('', text)
@@ -109,7 +112,7 @@ class GithubASan:
     @classmethod
     def summarize_origins(cls):
         def to_query_str(txt):
-            "only escape what is needed for our case"
+            """only escape what is needed for our case."""
             return txt.translate({ord(':'): '%3A', ord('"'): '%22', ord('&'): '%26'})
 
         if not cls.leaks_by_origin or not cls.summary_file:
@@ -120,12 +123,12 @@ class GithubASan:
                 search_on_gh = ('/' + os.getenv('GITHUB_REPOSITORY', 'widelands/widelands') +
                                 '/issues?q=' + to_query_str(
                     f'is:issue state:open label:"memory & performance" '
-                    f'"{origin.rsplit(":", 1)[0]}"'))
+                    f'"{origin.rsplit(':', 1)[0]}"'))
                 summary_file.write(
                     f'\n<details><summary>\n\n#### {origin} <a name="{origin}"></a>\n</summary>\n\n'
                     f'[search issue on gh](<{search_on_gh}>)\n')
                 for data in cls.leaks_by_origin[origin]:
-                    summary_file.write(f'+{data["tb"]}    triggered by {data["test"] or "???"}\n')
+                    summary_file.write(f'+{data['tb']}    triggered by {data['test'] or '???'}\n')
                 summary_file.write('</details>\n')
         cls.leaks_by_origin = {}
         summary_hint = '\nsee about memory leaks in job summary on'
@@ -148,9 +151,11 @@ def create_summary_one_runner():
         LSAN = enum.auto()
 
     def get_log_line(line):
-        """get the normal log line
+        """get the normal log line.
 
-        without timestamp and github label"""
+        without timestamp and github label
+
+        """
         if 'Z ##[' in line:
             line, cnt = re.subn('^.*Z ##[[][^]]+]', '', line, 1)
             if cnt > 0:  # if it really was with github label

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -17,6 +17,7 @@ import os
 
 
 class GithubASan:
+    found_local_tb = True
     test_script = None
 
     @classmethod
@@ -40,6 +41,12 @@ class GithubASan:
             return '::warning title=ASan error::' + text
         if 'irect leak of ' in text and os.getenv('GITHUB_STEP_SUMMARY'):  # Direct or Indirect leak
             write_summary('+ ', text)  # this text is colored
+            cls.found_local_tb = False
+        if not cls.found_local_tb and '/widelands/src/' in text and '/third_party/' not in text:
+            if os.getenv('GITHUB_STEP_SUMMARY'):
+                write_summary('    our origin: ', text)
+            cls.found_local_tb = True
+            return f'::notice title=memory leak origin::{text}'
         return text
 
     @classmethod

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -43,15 +43,17 @@ class GithubASan:
             return cls.ansi_escape_pattern.sub('', text)
 
         if 'ERROR: ' in text and os.getenv('GITHUB_STEP_SUMMARY'):
-            write_summary('### ', remove_ansi_escape_sequences(text))
-            write_summary('triggered by test ', cls.test_script, '\n\n<details>\n')
+            write_summary('\n### ', remove_ansi_escape_sequences(text))
+            write_summary('triggered by test ', cls.test_script, '\n\n')
             cls.counted_leaks = 0
         if 'SUMMARY' in text:
-            if os.getenv('GITHUB_STEP_SUMMARY'):
+            if os.getenv('GITHUB_STEP_SUMMARY') and cls.counted_leaks > 0:
                 summary_tag = f'\n<summary>{cls.counted_leaks} leaks</summary>\n'
-                write_summary(summary_tag, '</details>\n', text, '\n')
+                write_summary(summary_tag, '</details>\n', text)
             return '::warning title=ASan error::' + text
         if 'irect leak of ' in text and os.getenv('GITHUB_STEP_SUMMARY'):  # Direct or Indirect leak
+            if cls.counted_leaks == 0:
+                write_summary('<details>\n\n')  # needs empty line for the following list
             write_summary('+ ', remove_ansi_escape_sequences(
                 text.replace(' allocated from:', '', 1)))
             cls.found_local_tb = False

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -43,6 +43,12 @@ class GithubASan:
             return cls.ansi_escape_pattern.sub('', text)
 
         if 'ERROR: ' in text and os.getenv('GITHUB_STEP_SUMMARY'):
+            if cls.counted_leaks is None:
+                write_summary(
+                    '## memory leaks\n\n> [!TIP]\n'
+                    '> To find the full traceback, go to the log (from menu `...` on top right of '
+                    'this text block) and copy the line from the traceback here in the log\'s '
+                    'search field.\n')
             write_summary('\n### ', remove_ansi_escape_sequences(text))
             write_summary('triggered by test ', cls.test_script, '\n\n')
             cls.counted_leaks = 0

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -180,7 +180,7 @@ def create_summary_one_runner(in_file):
 
         """
         if 'Z ##[' in line:
-            line, cnt = re.subn('^.*Z ##\[[^]]+\]', '', line, 1)
+            line, cnt = re.subn(r'^.*Z ##\[[^]]+\]', '', line, 1)
             if cnt > 0:  # if it really was with github label
                 return line
         return line.split('Z ', 1)[-1]

--- a/utils/test/memory_leak_summary_from_gh_log.py
+++ b/utils/test/memory_leak_summary_from_gh_log.py
@@ -102,10 +102,12 @@ class GithubASan:
         with open(os.getenv('GITHUB_STEP_SUMMARY'), 'a') as summary_file:
             summary_file.write('\n\n## memory leaks by origin\n\n')
             for origin in sorted(cls.leaks_by_origin):
-                summary_file.write(f'#### {origin} <a name="{origin}"></a>\n')
+                summary_file.write(
+                    f'\n<details><summary>\n\n#### {origin} <a name="{origin}"></a>\n</summary>\n\n'
+                )
                 for data in cls.leaks_by_origin[origin]:
                     summary_file.write(f'+{data["tb"]}    triggered by {data["test"]}\n')
-                summary_file.write('\n')
+                summary_file.write('</details>\n')
         cls.leaks_by_origin = {}
         print('\nsee about memory leaks in job summary on',
               os.getenv('GITHUB_SERVER_URL', 'https://github.com') + '/' +


### PR DESCRIPTION
### Type of Change
Enhancement for testing

### Issue(s) Closed
Fixes --

### New Behavior
Whit this util script, a (github) summary can be created to better see memory leaks detected by ASan.
The script ~could~ _can_ finally run on github. With the last commits, it gets called. But as it is it can also be run locally with input from GitHub, allowing to create a summary without having the script in an official branch.


### How it Works
pipe the github log to the util.
See in the comment at the start of the util for more hints.
Preview the summary by pasting the markdown content in any comment field on GitHub and doing preview.

### Screenshots
https://github.com/widelands/widelands/pull/6210#issuecomment-3085594597
https://github.com/widelands/widelands/pull/6210#issuecomment-3085594597


### Additional context
No idea if this script will end up in the repo. Maybe it stays a temporary util only, until the leaks are fixed.

Originally the code was part of the file ./regression_test.py (ideas in #6805), but it seemed to get too much code for only ASan memory leaks.