### PR TITLE
do not build installers on translation only changes in build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,9 @@ jobs:
               # not 'utils/download_asio.sh', called by install-dependencies.sh for some other arch
             - &installer
               - *src_cmake_dependencies
-              - 'data/**'
+              # data/ except of translations, because they change frequently
+              - 'data/!(i18n/translations)/**'
+              - 'data/*' # do not ignore files directly inside
             - &ubuntu_dependencies
               - *src_cmake_dependencies
               - 'utils/ubuntu/packages'


### PR DESCRIPTION
Translations are updated automatically frequently. Building installers for this changes is not really necessary.

### Type of Change
Enhancement of build system

### Issue(s) Closed
Fixes -

### New Behavior
Installers are not built if only translation files change. (They are changed by workflow .github/workflows/i18n.yaml)
This reduces load on build system.

This probably means that job "dev_release" copies all the old release binaries. Should it be skipped in this case?

### Possible Regressions
People downloading this installers _might_ miss current translations.

### Additional context
discussion started in https://github.com/widelands/widelands/pull/6314#issuecomment-3097260063
To be continued here.
