### PR TITLE
Workflow testsuite: optimize xvfb

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -15,10 +15,7 @@ if [ "${GITHUB_JOB}" = "testsuite" ]; then
     ${CXX} \
     libwayland-egl1-mesa  \
     mesa-utils  \
-    xserver-xorg  \
-    xserver-xorg-core \
-    xserver-xorg-input-all  \
-    xserver-xorg-video-all"
+    "
 fi
 
 if [ "${GITHUB_JOB}" = "appimage" ]; then

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -84,13 +84,14 @@ jobs:
         while [ $(( i++ )) -lt 60 ]
         do
           sleep 1
-          if xset q 2>/dev/null >/dev/null # ask some config
-          then
+          # glxinfo is installed by .github/scrips/install_deps.sh
+          if glxinfo 2>/dev/null >/dev/null || [ $? -eq 127 ]
+          then  # successful or command not found
             break
           fi
         done
-        sleep 5 # some extra time
-        xset q >/dev/null # report error if it is still there
+        sleep 2 # some extra time
+        glxinfo >/dev/null # report error if it still occurs
     - name: Website Binaries
       run: |
         # Ignore transient SDL errors (exit code 2)

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -76,10 +76,12 @@ jobs:
         make -j$(nproc) DESTDIR=${TEST_INSTALL_DIR} install
         make -j$(nproc) DESTDIR=${TEST_INSTALL_DIR} uninstall
         test ! -d ${TEST_INSTALL_DIR}
-    - name: Website Binaries
+    - name: Start xvfb
       run: |
         /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 800x600x24 -ac +extension GLX
         sleep 1m
+    - name: Website Binaries
+      run: |
         # Ignore transient SDL errors (exit code 2)
         mkdir temp_web
         build/src/website/wl_map_object_info temp_web || [ $? -eq 2 ]

--- a/.github/workflows/build_testsuite.yaml
+++ b/.github/workflows/build_testsuite.yaml
@@ -79,7 +79,18 @@ jobs:
     - name: Start xvfb
       run: |
         /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 800x600x24 -ac +extension GLX
-        sleep 1m
+        # wait for start of xvfb:
+        i=0
+        while [ $(( i++ )) -lt 60 ]
+        do
+          sleep 1
+          if xset q 2>/dev/null >/dev/null # ask some config
+          then
+            break
+          fi
+        done
+        sleep 5 # some extra time
+        xset q >/dev/null # report error if it is still there
     - name: Website Binaries
       run: |
         # Ignore transient SDL errors (exit code 2)


### PR DESCRIPTION
<!-- Please fill out the relevant sections below and delete the rest. -->

### Type of Change
Enhancement of testsuite

### Issue(s) Closed
Fixes -

### New Behavior
- wait with checking till xvfb is started (less than 10s) instead of a fixed time of 60sec
- do not install xserver for testsuite, xvfb is installed
    (probably minor speedup, most if dependencies of xserver are outdated and get therefore updated)

### Possible Regressions
?

### Screenshots
https://github.com/SimonHeimberg/widelands/actions/runs/16468278683/job/46551136506?pr=18#step:6:1