### PR TITLE
explain about trade in tutorial04 that batch is in one transport

### DIFF
--- a/data/campaigns/tutorial04_economy.wmf/scripting/texts.lua
+++ b/data/campaigns/tutorial04_economy.wmf/scripting/texts.lua
@@ -641,6 +641,7 @@ trading_8 = {
    title = _("Trading"),
    body = (
       p(_([[Lastly, select how many batches of the selected wares will be exchanged. You can also set the trade to run indefinitely using the Infinity icon.]])) ..
+      p(_([[A batch will be delivered in one transport, each ware needing a donkey.]])) ..
       p(_([[When you have configured everything, click the ‘Propose’ button to send the trade offer to the other player. He can then decide whether to accept or reject your proposal.]])) ..
       p(_([[Try it out!]]))
    ),


### PR DESCRIPTION
### Type of Change
minor enhancement

### Issue(s) Closed
related to GH #6840 (see a comment there)

### To Reproduce
The tutorial instructs to select the wares to trade, and their numbers. It does not tell that this is one batch nor mention the term batch. Then it tells to select the number of batches.

I try to make a bit clearer what a batch is, in one sentence.

### Additional context
In my first try, I did a trading proposal requiring me about 40 donkeys for transportation. It took me quite a while to get why it did not start.