### PR TITLE
Fix memory leaks of src/graphic/text/rt_parse.cc

### DIFF
--- a/src/graphic/text/CMakeLists.txt
+++ b/src/graphic/text/CMakeLists.txt
@@ -1,6 +1,7 @@
 # TODO(GunChleoc): This unit testing project is currently unmaintained
+# ... except of tests for memleak
 # Reactivate in debian/rules too once work resumes on this
-# add_subdirectory(test)
+add_subdirectory(test)
 
 wl_library(graphic_text
   SRCS

--- a/src/graphic/text/rt_parse.cc
+++ b/src/graphic/text/rt_parse.cc
@@ -191,7 +191,7 @@ void Tag::parse_content(TextStream& ts, TagConstraints& tcs, const TagSet& allow
 			throw SyntaxErrorImpl(line, col, "an allowed tag", child->name(), ts.peek(100, cpos));
 		}
 
-		children_.push_back(new Child(child.get()));
+		children_.push_back(new Child(child.release()));
 	}
 }
 
@@ -605,7 +605,7 @@ Tag* Parser::parse(std::string text, const TagSet& allowed_tags) {
 	std::unique_ptr<Tag> rv(new Tag());
 	rv->parse(*text_stream_, tag_constraints_, allowed_tags);
 
-	return rv.get();
+	return rv.release();
 }
 std::string Parser::remaining_text() {
 	if (text_stream_ == nullptr) {

--- a/src/graphic/text/rt_parse.cc
+++ b/src/graphic/text/rt_parse.cc
@@ -179,7 +179,7 @@ void Tag::parse_content(TextStream& ts, TagConstraints& tcs, const TagSet& allow
 			break;
 		}
 
-		Tag* child = new Tag();
+		std::unique_ptr<Tag> child(new Tag());
 		line = ts.line();
 		col = ts.col();
 		size_t cpos = ts.pos();
@@ -191,7 +191,7 @@ void Tag::parse_content(TextStream& ts, TagConstraints& tcs, const TagSet& allow
 			throw SyntaxErrorImpl(line, col, "an allowed tag", child->name(), ts.peek(100, cpos));
 		}
 
-		children_.push_back(new Child(child));
+		children_.push_back(new Child(child.get()));
 	}
 }
 
@@ -602,10 +602,10 @@ Tag* Parser::parse(std::string text, const TagSet& allowed_tags) {
 
 	text_stream_->skip_ws();
 	text_stream_->rskip_ws();
-	Tag* rv = new Tag();
+	std::unique_ptr<Tag> rv(new Tag());
 	rv->parse(*text_stream_, tag_constraints_, allowed_tags);
 
-	return rv;
+	return rv.get();
 }
 std::string Parser::remaining_text() {
 	if (text_stream_ == nullptr) {

--- a/src/graphic/text/rt_parse.cc
+++ b/src/graphic/text/rt_parse.cc
@@ -162,13 +162,13 @@ void Tag::parse_content(TextStream& ts, TagConstraints& tcs, const TagSet& allow
 					children_.push_back(new Child(text.substr(0, match_start)));
 				}
 
-				Tag* child = new Tag();
+				std::unique_ptr<Tag> child(new Tag());
 				std::string url = text.substr(match_start, match_len);
 				TextStream linktext(format(
 				   "<link type=url target=%1$s mouseover=\"%2$s\"><font underline=1>%3$s</font></link>",
 				   url, url, url));
 				child->parse(linktext, tcs, allowed_tags);
-				children_.push_back(new Child(child));
+				children_.push_back(new Child(child.release()));
 
 				text = text.substr(match_start + match_len);
 				autolink_protection = false;

--- a/src/graphic/text/rt_parse.cc
+++ b/src/graphic/text/rt_parse.cc
@@ -126,7 +126,10 @@ void Tag::parse_attribute(TextStream& ts, std::unordered_set<std::string>& allow
 	attribute_map_.add_attribute(aname, new Attr(aname, ts.parse_string()));
 }
 
-void Tag::parse_content(TextStream& ts, TagConstraints& tcs, const TagSet& allowed_tags, const bool autolink_protection) {
+void Tag::parse_content(TextStream& ts,
+                        TagConstraints& tcs,
+                        const TagSet& allowed_tags,
+                        const bool autolink_protection) {
 	TagConstraint tc = tcs[name_];
 
 	for (;;) {
@@ -192,7 +195,10 @@ void Tag::parse_content(TextStream& ts, TagConstraints& tcs, const TagSet& allow
 	}
 }
 
-void Tag::parse(TextStream& ts, TagConstraints& tcs, const TagSet& allowed_tags, const bool autolink_protection) {
+void Tag::parse(TextStream& ts,
+                TagConstraints& tcs,
+                const TagSet& allowed_tags,
+                const bool autolink_protection) {
 	parse_opening_tag(ts, tcs);
 
 	TagConstraint tc = tcs[name_];

--- a/src/graphic/text/rt_parse.h
+++ b/src/graphic/text/rt_parse.h
@@ -86,11 +86,11 @@ public:
 	}
 
 private:
-	void parse(TextStream& ts, TagConstraints& tcs, const TagSet&, const bool autolink_protection);
+	void parse(TextStream& ts, TagConstraints& tcs, const TagSet&, bool autolink_protection);
 	void parse_opening_tag(TextStream& ts, TagConstraints& tcs);
 	void parse_closing_tag(TextStream& ts);
 	void parse_attribute(TextStream& ts, std::unordered_set<std::string>&);
-	void parse_content(TextStream& ts, TagConstraints& tc, const TagSet&, const bool autolink_protection);
+	void parse_content(TextStream& ts, TagConstraints& tc, const TagSet&, bool autolink_protection);
 
 	std::string name_;
 	AttrMap attribute_map_;

--- a/src/graphic/text/rt_parse.h
+++ b/src/graphic/text/rt_parse.h
@@ -81,13 +81,16 @@ public:
 	[[nodiscard]] const std::string& name() const;
 	[[nodiscard]] const AttrMap& attrs() const;
 	[[nodiscard]] const ChildList& children() const;
-	void parse(TextStream& ts, TagConstraints& tcs, const TagSet&);
+	void parse(TextStream& ts, TagConstraints& tcs, const TagSet& allowed_tags) {
+		parse(ts, tcs, allowed_tags, false);
+	}
 
 private:
+	void parse(TextStream& ts, TagConstraints& tcs, const TagSet&, const bool autolink_protection);
 	void parse_opening_tag(TextStream& ts, TagConstraints& tcs);
 	void parse_closing_tag(TextStream& ts);
 	void parse_attribute(TextStream& ts, std::unordered_set<std::string>&);
-	void parse_content(TextStream& ts, TagConstraints& tc, const TagSet&);
+	void parse_content(TextStream& ts, TagConstraints& tc, const TagSet&, const bool autolink_protection);
 
 	std::string name_;
 	AttrMap attribute_map_;

--- a/src/graphic/text/test/CMakeLists.txt
+++ b/src/graphic/text/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # TODO(GunChleoc): This unit testing project is currently unmaintained
-# Reactivate in parent directory once work resumes on this
+# ... except of tests for memleak
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/paths.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/paths.h)
 
@@ -28,4 +28,14 @@ wl_library(graphic_text_test_render
     graphic
     graphic_text
     io_filesystem
+)
+
+wl_test(test_graphic_text
+  SRCS
+    text_test_main.cc
+    test_rt_parse_memleak.cc
+  DEPENDS
+    base_macros
+    base_test
+    graphic_text
 )

--- a/src/graphic/text/test/CMakeLists.txt
+++ b/src/graphic/text/test/CMakeLists.txt
@@ -35,7 +35,6 @@ wl_test(test_graphic_text
     text_test_main.cc
     test_rt_parse_memleak.cc
   DEPENDS
-    base_macros
     base_test
     graphic_text
 )

--- a/src/graphic/text/test/render.cc
+++ b/src/graphic/text/test/render.cc
@@ -39,7 +39,7 @@ StandaloneRenderer::StandaloneRenderer() {
 
 	texture_cache_.reset(new TextureCache(500 << 20));  // 500 MB
 	image_cache_.reset(new ImageCache());
-	renderer_.reset(new RT::Renderer(image_cache_.get(), texture_cache_.get(), fontsets));
+	renderer_.reset(new RT::Renderer(image_cache_.get(), texture_cache_.get(), &fontsets));
 }
 
 StandaloneRenderer::~StandaloneRenderer() {

--- a/src/graphic/text/test/render_richtext.cc
+++ b/src/graphic/text/test/render_richtext.cc
@@ -85,12 +85,13 @@ int parse_arguments(int argc,
 		return 1;
 	}
 
-	*w = strtol(argv[1], 0, 10);
+	*w = strtol(argv[1], nullptr, 10);
 	outname = argv[2];
 	inname = argv[3];
 
-	for (int i = 4; i < argc; i++)
+	for (int i = 4; i < argc; i++) {
 		allowed_tags.insert(argv[i]);
+	}
 
 	return 0;
 }
@@ -101,7 +102,7 @@ void initialize() {
 	g_fs->add_file_system(&FileSystem::create(INSTALL_DATADIR));
 
 	g_gr = new Graphic();
-	g_gr->initialize(Graphic::TraceGl::kNo, 1, 1, false);
+	g_gr->initialize(Graphic::TraceGl::kNo, -1 /*display*/, 1, 1, false /*fullscreen*/, false /*maximized*/);
 }
 
 }  // namespace
@@ -110,9 +111,11 @@ int main(int argc, char** argv) {
 	int32_t w;
 	std::set<std::string> allowed_tags;
 
-	std::string outname, inname;
-	if (parse_arguments(argc, argv, &w, outname, inname, allowed_tags))
+	std::string outname;
+	std::string inname;
+	if (parse_arguments(argc, argv, &w, outname, inname, allowed_tags) != 0) {
 		return 0;
+	}
 
 	if (SDL_Init(SDL_INIT_VIDEO) < 0) {
 		std::cerr << "SDLInit did not succeed: " << SDL_GetError() << std::endl;
@@ -125,10 +128,11 @@ int main(int argc, char** argv) {
 	}
 
 	std::string txt;
-	if (inname == "-")
+	if (inname == "-") {
 		txt = read_stdin();
-	else
+	} else {
 		txt = read_file(inname);
+	}
 	if (txt.empty()) {
 		return 1;
 	}
@@ -139,7 +143,7 @@ int main(int argc, char** argv) {
 
 	try {
 		std::shared_ptr<const UI::RenderedText> rendered_text =
-		   standalone_renderer.renderer()->render(txt, w, allowed_tags);
+		   standalone_renderer.renderer()->render(txt, w, true /* is_rtl */, allowed_tags);
 		std::unique_ptr<Texture> texture(
 		   new Texture(rendered_text->width(), rendered_text->height()));
 		std::unique_ptr<RenderTarget> dst(new RenderTarget(texture.get()));

--- a/src/graphic/text/test/render_richtext.cc
+++ b/src/graphic/text/test/render_richtext.cc
@@ -102,7 +102,8 @@ void initialize() {
 	g_fs->add_file_system(&FileSystem::create(INSTALL_DATADIR));
 
 	g_gr = new Graphic();
-	g_gr->initialize(Graphic::TraceGl::kNo, -1 /*display*/, 1, 1, false /*fullscreen*/, false /*maximized*/);
+	g_gr->initialize(
+	   Graphic::TraceGl::kNo, -1 /*display*/, 1, 1, false /*fullscreen*/, false /*maximized*/);
 }
 
 }  // namespace

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -61,14 +61,13 @@ TESTCASE(parser_parse) {
 	{
 		try {
 			parser.parse("<a", allowed_tags);
+			check_equal("no error raised", "");
 		/* } catch (RT::EndOfText) {  // reports compile error
-			// expected
 			// */
 		} catch (std::exception& e) {
 			/* if (typeid(e).name().find("EndOfText") < 0) {  // is char* and not std::string
 				throw;  // unexpected, throw it again
-			}  // else expected
-			// */
+			}  // TODO(somebody): check here or above */
 		}
 	}
 #ifdef BASE_HEAP_CHECKER_H_
@@ -78,8 +77,14 @@ TESTCASE(parser_parse) {
 	{
 		try {
 			parser.parse("<rt><p>Title <not_a_tag> more&nbsp;text</p></rt>", allowed_tags);
+			check_equal("no error raised", "");
+		/* } catch (RT::SyntaxError) {  // reports compile error
+			// */
 		} catch (std::exception& e) {
-			std::cout << "DEBUG exception: " << typeid(e).name() << "\n";
+			/* Fails, names are different
+			if (typeid(e).name() != typeid(RT::EndOfText).name()) {
+				throw;  // unexpected, throw it again
+			}  // TODO(somebody): check here or above */
 		}
 	}
 }

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -105,7 +105,8 @@ TESTCASE(parser_parse) {
 	allowed_tags.insert("link");
 	allowed_tags.insert("font");
 	{
-		std::unique_ptr<RT::Tag> tag(parser.parse("<p>some text https://example.com/xxx</p>", allowed_tags));
+		std::unique_ptr<RT::Tag> tag(
+		   parser.parse("<p>some text https://example.com/xxx</p>", allowed_tags));
 		check_equal(tag->name(), "p");
 		check_equal(tag->children().size(), 2);
 		check_equal(tag->children()[0]->tag ? "tag instead of text" : "", "");

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -101,6 +101,22 @@ TESTCASE(parser_parse) {
 		}
 	}
 	end_memory_block();
+	// check normal parsing
+	allowed_tags.insert("link");
+	allowed_tags.insert("font");
+	{
+		std::unique_ptr<RT::Tag> tag(parser.parse("<p>some text https://example.com/xxx</p>", allowed_tags));
+		check_equal(tag->name(), "p");
+		if (tag->children().size() == 1 && tag->children()[0]->tag == nullptr) {
+			std::cerr << "TODO(somebody): autolink_protection in Tag::parse_content() stays true after above exception";
+			return;
+		}
+		check_equal(tag->children().size(), 2);
+		check_equal(tag->children()[0]->tag ? "tag instead of text" : "", "");
+		check_equal(tag->children()[0]->text, "some text ");
+		check_equal(tag->children()[1]->tag ? "" : "tag is nullptr", "");
+		check_equal(tag->children()[1]->tag->name(), "link");
+	}
 }
 
 TESTSUITE_END()

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2007-2025 by the Widelands Development Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+// #include <gperftools/heap-checker.h>  // is outdated, see below
+#include <memory>
+
+#include "base/test.h"
+// #include "graphic/text/rt_errors_impl.h"  // for RT::EndOfText
+#include "graphic/text/rt_parse.h"
+#include "graphic/text/textstream.h"
+
+/******************/
+/* Helper classes */
+/******************/
+
+/*************************************************************************/
+/*                                 TESTS                                 */
+/*************************************************************************/
+// struct WlTestFixture { ... }
+
+TESTSUITE_START(RtParseMemleak)
+
+/*
+ * Simple tests
+ */
+
+TESTCASE(parser_parse) {
+	RT::Parser parser;
+	// std::unique_ptr<RT::Parser()> parser(new RT::Parser());  // wrong, but similar would be better
+	RT::TagSet allowed_tags = RT::TagSet();
+#ifdef BASE_HEAP_CHECKER_H_
+	// HeapLeakChecker became a dummy only since gperftools-2.16.90, TODO(somebody): replace with ...
+	HeapLeakChecker heap_checker("test_parse");
+#endif
+	// leak from Parser::parse()
+	{
+		try {
+			parser.parse("<a", allowed_tags);
+		/* } catch (RT::EndOfText) {  // reports compile error
+			// expected
+			// */
+		} catch (std::exception& e) {
+			/* if (typeid(e).name().find("EndOfText") < 0) {  // is char* and not std::string
+				throw;  // unexpected, throw it again
+			}  // else expected
+			// */
+		}
+	}
+#ifdef BASE_HEAP_CHECKER_H_
+	check_equal(heap_checker.NoLeaks(), true);
+#endif
+	// triggering an other leak (trying)
+	allowed_tags.insert("rt");
+	{
+		try {
+			parser.parse("<a><x>x</x></a>", allowed_tags);
+		} catch (std::exception& e) {
+			std::cout << "DEBUG exception: " << typeid(e).name() << "\n";
+		}
+	}
+}
+
+TESTSUITE_END()

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -87,6 +87,20 @@ TESTCASE(parser_parse) {
 		}
 	}
 	end_memory_block();
+	// leak from Tag::parse_content()
+	allowed_tags.insert("rt");
+	allowed_tags.insert("p");
+	start_memory_block("parse_content");
+	{
+		try {
+			parser.parse("<p>some text https://example.com/xxx</p>", allowed_tags);
+			check_equal("no error raised", "");
+		} catch (RT::SyntaxError&) {
+			// created tag <font> is not in allowed_tags
+			// could test text in exc.what()
+		}
+	}
+	end_memory_block();
 }
 
 TESTSUITE_END()

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -20,7 +20,7 @@
 #include <memory>
 
 #include "base/test.h"
-// #include "graphic/text/rt_errors_impl.h"  // for RT::EndOfText
+#include "graphic/text/rt_errors_impl.h"  // for RT::EndOfText and RT::SyntaxError
 #include "graphic/text/rt_parse.h"
 #include "graphic/text/textstream.h"
 
@@ -71,12 +71,8 @@ TESTCASE(parser_parse) {
 		try {
 			parser.parse("<a", allowed_tags);
 			check_equal("no error raised", "");
-		/* } catch (RT::EndOfText) {  // reports compile error
-			// */
-		} catch (std::exception& e) {
-			/* if (typeid(e).name().find("EndOfText") < 0) {  // is char* and not std::string
-				throw;  // unexpected, throw it again
-			}  // TODO(somebody): check here or above */
+		} catch (RT::EndOfText&) {
+			// could test text in exc.what()
 		}
 	}
 	end_memory_block();
@@ -86,13 +82,8 @@ TESTCASE(parser_parse) {
 		try {
 			parser.parse("<rt><p>Title <not_a_tag> more&nbsp;text</p></rt>", allowed_tags);
 			check_equal("no error raised", "");
-		/* } catch (RT::SyntaxError) {  // reports compile error
-			// */
-		} catch (std::exception& e) {
-			/* Fails, names are different
-			if (typeid(e).name() != typeid(RT::EndOfText).name()) {
-				throw;  // unexpected, throw it again
-			}  // TODO(somebody): check here or above */
+		} catch (RT::SyntaxError&) {
+			// could test text in exc.what()
 		}
 	}
 	end_memory_block();

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -107,10 +107,6 @@ TESTCASE(parser_parse) {
 	{
 		std::unique_ptr<RT::Tag> tag(parser.parse("<p>some text https://example.com/xxx</p>", allowed_tags));
 		check_equal(tag->name(), "p");
-		if (tag->children().size() == 1 && tag->children()[0]->tag == nullptr) {
-			std::cerr << "TODO(somebody): autolink_protection in Tag::parse_content() stays true after above exception";
-			return;
-		}
 		check_equal(tag->children().size(), 2);
 		check_equal(tag->children()[0]->tag ? "tag instead of text" : "", "");
 		check_equal(tag->children()[0]->text, "some text ");

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -64,11 +64,10 @@ TESTCASE(parser_parse) {
 #ifdef BASE_HEAP_CHECKER_H_
 	check_equal(heap_checker.NoLeaks(), true);
 #endif
-	// triggering an other leak (trying)
-	allowed_tags.insert("rt");
+	// triggering more leaks
 	{
 		try {
-			parser.parse("<a><x>x</x></a>", allowed_tags);
+			parser.parse("<rt><p>Title <not_a_tag> more&nbsp;text</p></rt>", allowed_tags);
 		} catch (std::exception& e) {
 			std::cout << "DEBUG exception: " << typeid(e).name() << "\n";
 		}

--- a/src/graphic/text/test/test_rt_parse_memleak.cc
+++ b/src/graphic/text/test/test_rt_parse_memleak.cc
@@ -47,6 +47,16 @@ TESTCASE(parser_parse) {
 	// HeapLeakChecker became a dummy only since gperftools-2.16.90, TODO(somebody): replace with ...
 	HeapLeakChecker heap_checker("test_parse");
 #endif
+	// normal parse
+	{
+		std::unique_ptr<RT::Tag> tag(parser.parse("<rt><p>some text</p></rt>", allowed_tags));
+		check_equal(tag->name(), "rt");
+		check_equal(tag->children().size(), 1);
+		check_equal(tag->children()[0]->tag ? "" : "tag is nullptr", "");
+		check_equal(tag->children()[0]->tag->name(), "p");
+		check_equal(tag->children()[0]->tag->children().size(), 1);
+		check_equal(tag->children()[0]->tag->children()[0]->text, "some text");
+	}
 	// leak from Parser::parse()
 	{
 		try {

--- a/src/graphic/text/test/text_test_main.cc
+++ b/src/graphic/text/test/text_test_main.cc
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2007-2025 by the Widelands Development Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "base/test.h"
+TEST_EXECUTABLE(text)


### PR DESCRIPTION
### Type of Change
Bugfix

### Issue(s) Closed
Fixes #6830 fixes #6831 fixes #6832 fixes  #6833 fixes  #6834

### To Reproduce
run ./regression_test.py and see the reported memory leaks.
Or see them in the bug reports.

### New Behavior
Fewer memory leaks reported. Edited: Test result: no memory leaks reported from .../`test_text_renderer_does_not_crash.lua`.

### How it Works
unique_ptr is used inside the functions until the normal pointer is passed on.


### Possible Regressions
?

### Additional context
I wrote a test case in c++ to see quicker if I fix the right way. (It helped.)
I had to update some test code which was deactivated for that the checks on GitHub accept the code. (I do not know what arguments to pass to the executable. No idea if it runs.)
I am not experienced in c++. So fixing could be done better.
