### PR TITLE
WIP: fix longjump leaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,7 @@ else()
     "-Winvalid-pch"
     "-Wmissing-include-dirs"
     "-Wno-undef"
-    "-Wold-style-cast"
+#    "-Wold-style-cast"  # TODO(somebody): enable again, only ignore for third_party/eris/
     "-Woverlength-strings"
     "-Wpacked"
     "-Wpointer-arith"
@@ -608,4 +608,3 @@ if(NOT TARGET uninstall)
   add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake)
 endif()
-

--- a/src/scripting/CMakeLists.txt
+++ b/src/scripting/CMakeLists.txt
@@ -12,6 +12,7 @@ wl_library(scripting_base
     base_exceptions
     third_party_eris
 )
+set_target_properties(scripting_base PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ../third_party/eris/)
 
 wl_library(scripting_luna
   SRCS

--- a/src/scripting/CMakeLists.txt
+++ b/src/scripting/CMakeLists.txt
@@ -1,5 +1,13 @@
 add_subdirectory(test)
 
+set_source_files_properties(
+  report_error.cc
+  lua.cc
+  luna_impl
+  PROPERTIES
+    COMPILE_OPTIONS -Wno-old-style-cast  # TODO(somebody): remove this and ignore for header only
+) # because code/src/third_party/eris/lua.h and third_party/eris/luaconf.h cast integer
+
 wl_library(scripting_base
   SRCS
     lua.h

--- a/src/scripting/eris.h
+++ b/src/scripting/eris.h
@@ -19,9 +19,7 @@
 #ifndef WL_SCRIPTING_ERIS_H
 #define WL_SCRIPTING_ERIS_H
 
-// We need eris in a cpp context. Include it as such.
-extern "C" {
+// eris is compiled as c++, so include normally
 #include "third_party/eris/eris.h"
-}
 
 #endif  // end of include guard: WL_SCRIPTING_ERIS_H

--- a/src/scripting/lua.h
+++ b/src/scripting/lua.h
@@ -22,7 +22,9 @@
 #include <cstdint>
 #include <string>
 
-#include "third_party/eris/lua.hpp"
+#include "third_party/eris/lauxlib.h"
+#include "third_party/eris/lua.h"
+#include "third_party/eris/lualib.h"
 
 #define luaL_checkint32(L, n) static_cast<int32_t>(luaL_checkinteger(L, (n)))
 #define luaL_checkuint32(L, n) static_cast<uint32_t>(luaL_checkinteger(L, (n)))

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -13,7 +13,6 @@ endif()
 
 wl_library(third_party_eris
   THIRD_PARTY
-  C_LIBRARY
   SRCS
     eris/eris.c
     eris/eris.h
@@ -78,6 +77,13 @@ wl_library(third_party_eris
     eris/lvm.h
     eris/lzio.c
     eris/lzio.h
+)
+file(GLOB ERIS_SRC eris/*.c)
+file(GLOB ERIS_H eris/*.h)
+set_source_files_properties(${ERIS_SRC} PROPERTIES LANGUAGE CXX)
+set_source_files_properties(${ERIS_SRC} ${ERIS_H}
+  DIRECTORY . ..
+  PROPERTIES COMPILE_OPTIONS -Wno-old-style-cast
 )
 
 wl_library(third_party_libmd

--- a/utils/find_unused_includes.py
+++ b/utils/find_unused_includes.py
@@ -36,7 +36,7 @@ FUNCTION_REGEX = re.compile(
 
 # Header files with contents that are too hard to detect by regex
 FILE_EXCLUDES = {'graphic/gl/system_headers.h', 'scripting/lua.h',
-                 'third_party/eris/lua.hpp', 'scripting/eris.h',
+                 'third_party/eris/lua.h', 'third_party/eris/lualib.h', 'scripting/eris.h',
                  'base/format/abstract_node.h',
                  'third_party/tinygettext/include/tinygettext/tinygettext.hpp'}
 

--- a/utils/find_unused_includes.py
+++ b/utils/find_unused_includes.py
@@ -37,7 +37,6 @@ FUNCTION_REGEX = re.compile(
 # Header files with contents that are too hard to detect by regex
 FILE_EXCLUDES = {'graphic/gl/system_headers.h', 'scripting/lua.h',
                  'third_party/eris/lua.h', 'third_party/eris/lualib.h', 'scripting/eris.h',
-                 'base/format/abstract_node.h',
                  'third_party/tinygettext/include/tinygettext/tinygettext.hpp'}
 
 # Headers files with contents that need to be detected by functions


### PR DESCRIPTION
<!-- Please fill out the relevant sections below and delete the rest. -->

### Type of Change
Bugfix

### Issue(s) Closed
Fixes #6808 fixes #6809 fixes #6810 fixes #6811 fixes #6812 fixes #6812 fixes #6813 fixes #6814 fixes #6815 fixes #6816 fixes #6817 fixes #6818 fixes #6820 fixes #6821 fixes #6822 fixes #6828 fixes #6829 fixes #6838

### To Reproduce
see reported memory leak from a recent test run, like https://github.com/widelands/widelands/actions/runs/17108726999/job/48524654051#step:9:1417

### New Behavior
Now there are much fewer memory leaks because lua does not use longjump. 
(see summary of leaks below in comment)

### How it Works
The code for eris+lua is compiled with c++. Now lua throws an exception on error instead of doing longjump (and catches the exception). So stack is unwound and variables get deleted properly (including calling the destructor).

### Possible Regressions
- see below in TODO
- save/load _should_ work as before and be compatible
- ??

### Additional context
As expected GitHub complained about the headers. I ignored it on my machine. So no proof that many leaks are fixed.

How shall the two following points be fixed? As the label says: HELP WANTED

#### TODO
- [x] handle unused headers reported for src/scripting/lua.h (but files importing lua.h use them)
- [ ] properly exclude compiler warnings about header files from src/third_party/eris/