### PR TITLE
Correctly ignore changes of data/i18n/translation_stats.conf

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,12 +64,11 @@ jobs:
             # data/ except of some subdirectories
             - 'data/!(campaigns|i18n|maps|music|sound)/**'
             # but track parts of them
-            - 'data/i18n/!(translations)/**'  # exclude translations, they are updated frequently
-            - 'data/i18n/!(translations|translation_stats.conf)'  # also from translation (above)
+            - 'data/i18n/!(translations|translation_stats.conf)/**'  # exclude translations ...
+              # ... and files created by them, because they are updated frequently
             - 'data/maps/Crater.wmf/**' # for test/template/test_alldefaults.wgt
             - 'data/maps/Lesser_Ring.wmf/**' # for test/template/*.wgt
             - 'data/maps/Wisent_Valley.wmf/**' # for test/template/test_fortified_vi*-artifacts.wgt
-            - 'data/*' # do not ignore files directly inside
             # changes of other files
             - 'regression_test.py'
             - 'test/**'


### PR DESCRIPTION
for tests in build.yaml

Tries showed that x/!(y)/** also matches file x/z (despite having a / before **).

### Type of Change
~Bugfix

### Issue(s) Closed
completes #6314 see https://github.com/widelands/widelands/pull/6314#issuecomment-3219149106

### To Reproduce
On a translation only change eab012b8a5c34b6eb56bc72c2b530a7bfbb1868e, the tests did run despite they should be ignored: https://github.com/widelands/widelands/actions/runs/17198145620/job/48783596331#step:3:117

### New Behavior
The pattern should now be correct, and the file be ignored as planned.

### Additional context
I tested the patterns on https://codesandbox.io/p/sandbox/picomatch-playground-ebjlxm and am positive it is correct now.
