### PR TITLE
Add macOS15 intel builds

### DIFF
--- a/.github/workflows/build_macos.yaml
+++ b/.github/workflows/build_macos.yaml
@@ -9,13 +9,13 @@ jobs:
       matrix:
         config: [debug, release]
         compiler: [clang]
-        os: [13, 14, 15]
+        os: [13, 14, 15, 15-intel]
         # Check https://github.com/actions/runner-images#available-images
         include:
           - os: 13
             osname: macOS13_x86
-          # - os: 14-large
-            # osname: macOS14_x86
+          - os: 15-intel
+            osname: macOS15_x86
           - os: 14
             osname: macOS14_arm64
           - os: 15


### PR DESCRIPTION
### Type of Change
Refactoring

### Issue(s) Closed
first part to keep an intel build after deprecation of macOS13


### New Behavior
adds an intel based macOS15 build

