### PR TITLE
Handle errors in add-on tribe init gracefully

### DIFF
--- a/src/logic/map_objects/tribes/tribe_basic_info.cc
+++ b/src/logic/map_objects/tribes/tribe_basic_info.cc
@@ -142,7 +142,12 @@ AllTribes get_all_tribeinfos(const AddOns::AddOnsList* addons_to_consider) {
 			for (const std::string& tribe : g_fs->list_directory(dirname)) {
 				const std::string script_path = tribe + FileSystem::file_separator() + "init.lua";
 				if (g_fs->file_exists(script_path)) {
-					tribeinfos.emplace_back(lua.run_script(script_path));
+					try {
+						tribeinfos.emplace_back(lua.run_script(script_path));
+					} catch (const std::exception& e) {
+						log_warn("Failed to load add-on tribe '%s': %s\n",
+						         script_path.c_str(), e.what());
+					}
 				}
 			}
 		}

--- a/src/logic/map_objects/tribes/tribe_basic_info.cc
+++ b/src/logic/map_objects/tribes/tribe_basic_info.cc
@@ -143,7 +143,10 @@ AllTribes get_all_tribeinfos(const AddOns::AddOnsList* addons_to_consider) {
 				const std::string script_path = tribe + FileSystem::file_separator() + "init.lua";
 				if (g_fs->file_exists(script_path)) {
 					try {
-						tribeinfos.emplace_back(lua.run_script(script_path));
+						// A script can change its Lua state before throwing, so do not reuse it for
+						// the next tribe.
+						LuaInterface addon_lua;
+						tribeinfos.emplace_back(addon_lua.run_script(script_path));
 					} catch (const std::exception& e) {
 						log_warn("Failed to load add-on tribe '%s': %s\n",
 						         script_path.c_str(), e.what());

--- a/src/logic/map_objects/tribes/tribe_basic_info.cc
+++ b/src/logic/map_objects/tribes/tribe_basic_info.cc
@@ -148,8 +148,7 @@ AllTribes get_all_tribeinfos(const AddOns::AddOnsList* addons_to_consider) {
 						LuaInterface addon_lua;
 						tribeinfos.emplace_back(addon_lua.run_script(script_path));
 					} catch (const std::exception& e) {
-						log_warn("Failed to load add-on tribe '%s': %s\n",
-						         script_path.c_str(), e.what());
+						log_warn("Failed to load add-on tribe '%s': %s\n", script_path.c_str(), e.what());
 					}
 				}
 			}

--- a/src/scripting/lua_globals.cc
+++ b/src/scripting/lua_globals.cc
@@ -215,6 +215,10 @@ static const TextdomainInfo* current_textdomain(const lua_State* L) {
 	return it == textdomains.end() || it->second.empty() ? nullptr : &it->second.back();
 }
 
+void clear_textdomain_stack(const lua_State* L) {
+	textdomains.erase(L);
+}
+
 constexpr uint16_t kCurrentPacketVersion = 1;
 void read_textdomain_stack(FileRead& fr, const lua_State* L) {
 	{

--- a/src/scripting/lua_globals.h
+++ b/src/scripting/lua_globals.h
@@ -28,6 +28,7 @@ namespace LuaGlobals {
 
 void luaopen_globals(lua_State*);
 
+void clear_textdomain_stack(const lua_State*);
 void read_textdomain_stack(FileRead&, const lua_State*);
 void write_textdomain_stack(FileWrite&, const lua_State*);
 

--- a/src/scripting/lua_interface.cc
+++ b/src/scripting/lua_interface.cc
@@ -87,6 +87,7 @@ LuaInterface::LuaInterface(const bool is_main_menu) {
 }
 
 LuaInterface::~LuaInterface() {
+	LuaGlobals::clear_textdomain_stack(lua_state_);
 	lua_close(lua_state_);
 }
 


### PR DESCRIPTION
## Summary
- Wraps individual add-on tribe loading in `get_all_tribeinfos()` with a try-catch
- A broken add-on tribe (e.g. missing dependency) now logs a warning instead of crashing the entire tribe discovery
- Other working add-on tribes still appear in the tribe selection

## Test plan
- [ ] Install two tribe add-ons, one with a deliberate error in its init.lua
- [ ] Verify the broken add-on is skipped with a log warning
- [ ] Verify the working add-on still appears in tribe selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)