### PR TITLE
WIP: Move Empire vineyards to mountain build spaces

### DIFF
--- a/data/tribes/buildings/productionsites/empire/vineyard/init.lua
+++ b/data/tribes/buildings/productionsites/empire/vineyard/init.lua
@@ -7,7 +7,7 @@ wl.Descriptions():new_productionsite_type {
    -- TRANSLATORS: This is a building name used in lists of buildings
    descname = pgettext("empire_building", "Vineyard"),
    icon = dirname .. "menu.png",
-   size = "medium",
+   size = "mine",
 
    buildcost = {
       planks = 2,


### PR DESCRIPTION
### Type of Change
New feature / Balancing

### Issue(s) Closed
No issue found.

This moves the Empire vineyard from medium build spaces to mine build spaces, so vineyards are placed in mountains instead of competing with regular production buildings on flat land.

The change is useful because vineyards fit mountain slopes thematically and visually better than ordinary flat production plots, especially with the updated grapevine graphics. It also gives the Empire a clearer spatial distinction between wine production and the many medium-sized economy buildings that already compete for flat land.

### New Behavior
Empire vineyards can be built on mine-capable mountain fields.

### How it Works
The Empire vineyard production site now uses `size = "mine"`, which makes the building descriptor require `BUILDCAPS_MINE` placement.

This data change depends on the AI support from #6984 ("AI: support mine-sized non-mine buildings"). Without that AI change, human players can use the new placement rule, but AI players may not reliably consider mine-sized production buildings that do not mine resources. The AI work was deliberately kept separate after review feedback on #6984: the AI fix should support the capability, while this PR discusses the actual Empire vineyard economy/balancing change on its own.

### Possible Regressions
Empire economy starts and scenarios that place vineyards may need enough nearby mine-capable terrain.

The main balancing risk is the wine chain for marble mining: Vineyard -> Grape -> Winery -> Wine -> Marblemine. Review discussion on #6984 pointed out that marble is critical for Empire and that changes to wine availability can affect economy timing. The intended effect here is spatial, not a productivity buff: the vineyard program, worker, costs, and production timings are unchanged.

### Additional context
Validation was limited to inspecting the data diff and existing engine placement logic. Per local project instructions, no build was run.
