### PR TITLE
Escape pinned note text before rendering as richtext

### DIFF
--- a/src/logic/map_objects/pinned_note.cc
+++ b/src/logic/map_objects/pinned_note.cc
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "graphic/rendertarget.h"
+#include "graphic/text_layout.h"
 #include "logic/game_data_error.h"
 #include "logic/player.h"
 #include "ui/wui/interactive_player.h"
@@ -110,7 +111,11 @@ void PinnedNote::draw(const EditorGameBase& egbase,
 
 	dst->blit_animation(field_on_dst, coords, scale, owner().tribe().pinned_note_animation(),
 	                    egbase.get_gametime(), &rgb_);
-	do_draw_info(info_to_draw, text_, std::string(), field_on_dst, scale, dst);
+	// The note text is free-form player input and is rendered as richtext below,
+	// so any characters that richtext treats specially (e.g. '<') must be escaped
+	// first. Without this, a note containing such a character throws an uncaught
+	// richtext parse error and crashes the game.
+	do_draw_info(info_to_draw, richtext_escape(text_), std::string(), field_on_dst, scale, dst);
 }
 
 constexpr uint8_t kCurrentPacketVersion = 1;

--- a/test/maps/plain.wmf/scripting/test_pinned_notes.lua
+++ b/test/maps/plain.wmf/scripting/test_pinned_notes.lua
@@ -11,6 +11,11 @@ run(function()
    assert_equal("Hello World", note.text)
    assert_equal(123, note.color[3])
 
+   -- Show the census overlay so the note's text actually gets rendered as
+   -- richtext on the map. Regression test for a crash when the note text
+   -- contains a character with special meaning in richtext, e.g. '<'.
+   wl.ui.MapView().census = true
+
    note.text = "<Richtext injection attempt>"
    note.color = {50, 200, 250}
    sleep(5000)
@@ -18,6 +23,8 @@ run(function()
    assert_equal("<Richtext injection attempt>", note.text)
    assert_equal(50, note.color[1])
    assert_equal(1, #f.bobs)
+
+   wl.ui.MapView().census = false
 
    sleep(1000)
    note:remove()


### PR DESCRIPTION
### Type of Change
Bugfix

### Issue(s) Closed
Fixes #7063

### To Reproduce
1. Start a game and place a pinned note.
2. Edit the note's text so it contains a character with special meaning in richtext, for example `<`.
3. Enable the census overlay (or otherwise cause the note's label to be drawn on the map).
4. Widelands throws an uncaught richtext parse error and crashes.

### New Behavior
The note's text is escaped with the existing `richtext_escape()` helper before it is handed to the richtext renderer, so characters such as `<`, `>` and `&` are displayed literally instead of being interpreted as markup. Notes with such text no longer crash the game.

### How it Works
`PinnedNote::draw()` builds the on-map label by wrapping the note's raw text in richtext font tags. The raw player-typed text was passed through unescaped, so a stray `<` broke the surrounding markup and the renderer threw. This mirrors how other free-form strings that get rendered as richtext elsewhere in the codebase (list entries, chat messages, tooltips) are already escaped before rendering.

### Possible Regressions
None expected. The note's stored text is unchanged; only the string handed to the renderer is escaped, so editing an existing note still shows and round-trips the original text.

### Additional context
Extended the existing `test/maps/plain.wmf/scripting/test_pinned_notes.lua` test to turn on the census overlay before setting a note's text to an unescaped string containing `<`, so the crash is actually exercised. Confirmed the test fails with the exact reported crash (`FATAL EXCEPTION`, exit code -6) when only the source fix is reverted, and passes with the fix applied. Also ran the full `plain.wmf` scenario test suite (20 tests, including this one and the pre-existing `test_text_renderer_does_not_crash.lua`) and the C++ unit test suite (`ctest`), all passing.
